### PR TITLE
Sort the unaudited table

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,7 @@
 //! Details of the file formats used by cargo vet
 
 use core::fmt;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use cargo_metadata::{Version, VersionReq};
@@ -9,7 +10,12 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
+// Collections based on how we're using, so it's easier to swap them out.
 pub type StableMap<K, V> = linked_hash_map::LinkedHashMap<K, V>;
+pub type FastMap<K, V> = HashMap<K, V>;
+pub type FastSet<T> = HashSet<T>;
+pub type SortedMap<K, V> = BTreeMap<K, V>;
+pub type SortedSet<T> = BTreeSet<T>;
 
 ////////////////////////////////////////////////////////////////////////////////////
 //                                                                                //
@@ -230,9 +236,9 @@ pub struct ConfigFile {
     /// All of the "foreign" dependencies that we rely on but haven't audited yet.
     /// Foreign dependencies are just "things on crates.io", everything else
     /// (paths, git, etc) is assumed to be "under your control" and therefore implicitly trusted.
-    #[serde(skip_serializing_if = "StableMap::is_empty")]
+    #[serde(skip_serializing_if = "SortedMap::is_empty")]
     #[serde(default)]
-    pub unaudited: StableMap<String, Vec<UnauditedDependency>>,
+    pub unaudited: SortedMap<String, Vec<UnauditedDependency>>,
 }
 
 pub static SAFE_TO_DEPLOY: &str = "safe-to-deploy";

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,20 +3,14 @@ use core::fmt;
 use log::{error, trace, warn};
 use serde::Serialize;
 use serde_json::json;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Write;
 
 use crate::format::{self, AuditKind, Delta, DiffStat};
+use crate::format::{FastMap, FastSet, SortedMap, SortedSet};
 use crate::{
     AuditEntry, Cache, Config, CriteriaEntry, DumpGraphArgs, GraphFilter, GraphFilterProperty,
     GraphFilterQuery, PackageExt, StableMap, Store, VetError,
 };
-
-// Collections based on how we're using, so it's easier to swap them out.
-pub type FastMap<K, V> = HashMap<K, V>;
-pub type FastSet<T> = HashSet<T>;
-pub type SortedMap<K, V> = BTreeMap<K, V>;
-pub type SortedSet<T> = BTreeSet<T>;
 
 /// A report of the results of running `resolve`.
 #[derive(Debug, Clone)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,8 @@ use serde_json::{json, Value};
 
 use crate::{
     format::{
-        AuditKind, Delta, DependencyCriteria, MetaConfig, PolicyEntry, SAFE_TO_DEPLOY, SAFE_TO_RUN,
+        AuditKind, Delta, DependencyCriteria, MetaConfig, PolicyEntry, SortedMap, SAFE_TO_DEPLOY,
+        SAFE_TO_RUN,
     },
     init_files,
     resolver::ResolveReport,
@@ -814,7 +815,7 @@ fn builtin_files_minimal_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile
     let (mut config, mut audits, imports) = builtin_files_inited(metadata);
 
     let mut audited = StableMap::<String, Vec<AuditEntry>>::new();
-    for (name, entries) in std::mem::replace(&mut config.unaudited, StableMap::new()) {
+    for (name, entries) in std::mem::replace(&mut config.unaudited, SortedMap::new()) {
         for entry in entries {
             audited
                 .entry(name.clone())


### PR DESCRIPTION
At present, regenerate-unaudited will append new things to the end of the file. I think we should just always sort it.

I'm tempted to sort the other tables as well, but less certain about it.