### PR TITLE
Create separate concepts for --locked and --frozen.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,9 +32,15 @@ pub struct Cli {
     pub features: Features,
 
     // Top-level flags
-    /// Do not pull in new "audits" and try to avoid the network
+    /// Do not fetch new imported audits.
     #[clap(long)]
     pub locked: bool,
+
+    /// Avoid the network entirely, requiring either that the cargo cache is
+    /// populated or the dependencies are vendored. Requires --locked.
+    #[clap(long)]
+    #[clap(requires = "locked")]
+    pub frozen: bool,
 
     /// Do not modify or lock the store (supply-chain) directory
     ///
@@ -412,6 +418,7 @@ impl Cli {
             workspace: clap_cargo::Workspace::default(),
             features: Features::default(),
             locked: false,
+            frozen: false,
             readonly_lockless: true,
             verbose: LevelFilter::OFF,
             output_file: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,9 +232,8 @@ fn real_main() -> Result<(), VetError> {
         other_options.push(package.to_string());
     }
     // We never want cargo-vet to update the Cargo.lock.
-    // For locked runs we don't want to touch the network so use --frozen
-    // For unlocked runs we want to error out if the lock is out of date, so use --locked
-    if cli.locked {
+    // For frozen runs we also don't want to touch the network.
+    if cli.frozen {
         other_options.push("--frozen".to_string());
     } else {
         other_options.push("--locked".to_string());

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2267,9 +2267,8 @@ impl<'a> ResolveReport<'a> {
                 }).collect::<SortedMap<_,_>>(),
             }),
             Conclusion::FailForVet(fail) => {
-                // Don't print suggest output if we're --locked because we don't want to
-                // touch the network in that configuration and we're probably in CI.
-                let suggest = if cfg.cli.locked {
+                // Suggest output generally requires hitting the network.
+                let suggest = if cfg.cli.frozen {
                     None
                 } else {
                     self.compute_suggest(cfg, true)?
@@ -2460,9 +2459,8 @@ impl FailForVet {
             )?;
         }
 
-        // Don't print suggest output if we're --locked because we don't want to
-        // touch the network in that configuration and we're probably in CI.
-        if !cfg.cli.locked {
+        // Suggest output generally requires hitting the network.
+        if !cfg.cli.frozen {
             if let Some(suggest) = report.compute_suggest(cfg, true)? {
                 writeln!(out)?;
                 suggest.print_human(out, report)?;

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -70,11 +70,15 @@ OPTIONS:
             * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
             graph
 
+        --frozen
+            Avoid the network entirely, requiring either that the cargo cache is populated or the
+            dependencies are vendored. Requires --locked
+
     -h, --help
             Print help information
 
         --locked
-            Do not pull in new "audits" and try to avoid the network
+            Do not fetch new imported audits
 
         --log-file <LOG_FILE>
             Instead of stderr, write logs to this file (only used after successful CLI parsing)

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -77,11 +77,15 @@ tested)
 * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
 graph
 
+#### `--frozen`
+Avoid the network entirely, requiring either that the cargo cache is populated or the
+dependencies are vendored. Requires --locked
+
 #### `-h, --help`
 Print help information
 
 #### `--locked`
-Do not pull in new "audits" and try to avoid the network
+Do not fetch new imported audits
 
 #### `--log-file <LOG_FILE>`
 Instead of stderr, write logs to this file (only used after successful CLI parsing)

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -22,11 +22,15 @@ OPTIONS:
         --filter-graph <FILTER_GRAPH>
             Filter out different parts of the build graph and pretend that's the true graph
 
+        --frozen
+            Avoid the network entirely, requiring either that the cargo cache is populated or the
+            dependencies are vendored. Requires --locked
+
     -h, --help
             Print help information
 
         --locked
-            Do not pull in new "audits" and try to avoid the network
+            Do not fetch new imported audits
 
         --log-file <LOG_FILE>
             Instead of stderr, write logs to this file (only used after successful CLI parsing)


### PR DESCRIPTION
Fixes #156.

There are roughly three use-cases:
(1) Running locally (no flags)
(2) Running in network-connected CI (--locked).
(3) Running in network-isolated CI with vendored dependencies (--frozen).