### PR TITLE
Remove spelling/usage error in index.md

### DIFF
--- a/book/src/index.md
+++ b/book/src/index.md
@@ -21,8 +21,7 @@ to each other. Developers can inspect the difference between two versions, and r
 that if the first version was vetted, the second can be considered vetted as well.
 
 * **Deferred Audits**: It is not always practical to achieve full coverage.
-Dependencies can be added to a list of exceptions which can be ratched down
-down over time. This makes it trivial to introduce `cargo vet` to a new project
+Dependencies can be added to a list of exceptions which can be ratcheted down over time. This makes it trivial to introduce `cargo vet` to a new project
 and guard against future vulnerabilities while vetting the pre-existing code
 gradually as time permits.
 


### PR DESCRIPTION
Hi there! 👋 😄 This is a _very_ small change. I replaced "ratched down down" with "ratcheted down" to make it clearer that the size of the list of exceptions will be slowly decreased over time.