### PR TITLE
Wrap long inline arrays and tables over multiple lines

### DIFF
--- a/src/snapshots/cargo_vet__serialization__test__formatted_toml_long_inline.snap
+++ b/src/snapshots/cargo_vet__serialization__test__formatted_toml_long_inline.snap
@@ -1,0 +1,25 @@
+---
+source: src/serialization.rs
+expression: formatted
+---
+
+[[audits.test]]
+criteria = "long-criteria"
+version = "1.0.0"
+notes = "notes go here!"
+
+[audits.test.dependency-criteria]
+example-crate-1 = ["criteria-one-very-long", "criteria-two-very-long"]
+example-crate-2 = ["criteria-one-✨✨✨✨✨✨✨✨✨✨", "criteria-two-✨✨✨✨✨✨✨✨✨✨"]
+example-crate-3 = [
+    "criteria-one-very-long",
+    "criteria-two-very-long",
+    "criteria-three-extremely-long-this-array-should-wrap",
+]
+
+[[audits.test]]
+criteria = "short-criteria"
+version = "1.0.0"
+dependency-criteria = { example-crate-1 = "criteria-one" }
+notes = "notes go here!"
+


### PR DESCRIPTION
This should help improve the readability of very complex toml files by wrapping complex fields over multiple lines (either as a non-inline table or as a multi-line array literal) when they get too long.

The current thresholds selected are completely arbitrary and can be changed in the future.

Fixes #176