### PR TITLE
Use the 'dirs' crate to store our cache in a platform-appropriate cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "clap-cargo",
  "console",
  "crates-index",
+ "dirs",
  "eyre",
  "flate2",
  "home",
@@ -235,6 +236,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +377,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -793,6 +825,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1146,26 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "3.2.0", features = ["derive"] }
 clap-cargo = "0.8.0"
 console = "0.15.0"
 crates-index = { version = "0.18.8", default-features = false }
+dirs = "4.0.0"
 eyre = "0.6.8"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 home = "0.5.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ pub struct Config {
 pub struct PartialConfig {
     /// Details of the CLI invocation (args)
     pub cli: Cli,
-    /// Path to the global tmp we're using
-    pub tmp: PathBuf,
+    /// Path to the cache directory we're using
+    pub cache_dir: PathBuf,
     /// Whether we should mock the global cache (for unit testing)
     pub mock_cache: bool,
 }
@@ -207,10 +207,12 @@ fn real_main() -> Result<(), VetError> {
     ////////////////////////////////////////////////////
 
     // TODO: make this configurable
-    let tmp = std::env::temp_dir().join(TEMP_DIR_SUFFIX);
+    let cache_dir = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(TEMP_DIR_SUFFIX);
     let partial_cfg = PartialConfig {
         cli,
-        tmp,
+        cache_dir,
         mock_cache: false,
     };
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -344,7 +344,7 @@ impl Cache {
         }
 
         // Make sure the cache directory exists, and acquire an exclusive lock on it.
-        let root = cfg.tmp.clone();
+        let root = cfg.cache_dir.clone();
         fs::create_dir_all(&root)
             .wrap_err_with(|| format!("failed to create cache directory `{}`", root.display()))?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -834,7 +834,7 @@ fn mock_cfg(metadata: &Metadata) -> Config {
         metadata: metadata.clone(),
         _rest: PartialConfig {
             cli: Cli::mock(),
-            tmp: PathBuf::new(),
+            cache_dir: PathBuf::new(),
             mock_cache: true,
         },
     }


### PR DESCRIPTION
This seemed straightforward enough to do, so I figured I'd post a patch for it based on @glandium's suggestion, so it's ready if we decide to go with it.

Fixes #184