### PR TITLE
Fix a typo in the safe-to-run criteria text

### DIFF
--- a/src/criteria/safe-to-run.txt
+++ b/src/criteria/safe-to-run.txt
@@ -3,4 +3,4 @@ controlled automation without surprising consequences, such as:
 * Reading or writing data from sensitive or unrelated parts of the filesystem.
 * Installing software or reconfiguring the device.
 * Connecting to untrusted network endpoints.
-* Misuse of system resources (e.g. crytocurrency mining).
+* Misuse of system resources (e.g. cryptocurrency mining).


### PR DESCRIPTION
Noticed by @chutten 