### PR TITLE
Limit the maximum number of concurrent diffs

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2443,7 +2443,7 @@ impl<'a> ResolveReport<'a> {
                                 // We don't want to actually error out completely here,
                                 // as other packages might still successfully diff!
                                 error!(
-                                    "error diffing {}:{} {}",
+                                    "error diffing {}:{}: {:?}",
                                     package.name, package.version, err
                                 );
                                 None


### PR DESCRIPTION
This patch also adds extra diagnostics to improve other errors like this
in the future, and limits the number of blocking threads available to
tokio to reduce the risk of unbounded concurrency in the future.

Fixes #204