### PR TITLE
Fix: Auditor information is not read from global git config

### DIFF
--- a/book/src/audit-entries.md
+++ b/book/src/audit-entries.md
@@ -53,7 +53,7 @@ dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.
 ## `who`
 
 A string identifying the auditor. When invoking `cargo vet certify`, the
-value is auto-populated from the global git config.
+value is auto-populated from the git config.
 
 This field is optional, but encouraged for two reasons:
 * It makes it easier to attribute audits at a glance, particularly for


### PR DESCRIPTION
The git configuration is used (in `get_user_info()` in src/main.rs) by
calling `git config --get`, which is not the same as reading the global
git configuration, as `git config` considers the repository-local
configuration file as well as the $HOME git configuration file.

Hence, adapt the wording here.
