### PR TITLE
Improve criteria selection in certify

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -509,16 +509,8 @@ impl FetchCommand {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SuggestedAudit {
-    #[serde(flatten)]
-    pub command: FetchCommand,
-    pub criteria: Vec<CriteriaName>,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CommandHistory {
     #[serde(flatten)]
     pub last_fetch: Option<FetchCommand>,
-    pub last_suggest: Vec<SuggestedAudit>,
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,7 +126,7 @@ impl MetaConfig {
 pub type AuditedDependencies = SortedMap<PackageName, Vec<AuditEntry>>;
 
 /// audits.toml
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct AuditsFile {
     /// A map of criteria_name to details on that criteria.
     #[serde(skip_serializing_if = "SortedMap::is_empty")]
@@ -271,7 +271,7 @@ impl Serialize for Delta {
 ////////////////////////////////////////////////////////////////////////////////////
 
 /// config.toml
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct ConfigFile {
     /// This top-level key specifies the default criteria that cargo vet certify will use
     /// when recording audits. If unspecified, this defaults to "safe-to-deploy".
@@ -323,7 +323,7 @@ fn is_default_criteria(val: &CriteriaName) -> bool {
 /// If this sounds overwhelming, don't worry, everything defaults to "nothing special"
 /// and an empty PolicyTable basically just means "everything should satisfy the
 /// default criteria in audits.toml".
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct PolicyEntry {
     /// Whether this nominally-first-party crate should actually be subject to audits
     /// as-if it was third-party, based on matches to crates.io packages with the same
@@ -388,7 +388,7 @@ pub static DEFAULT_POLICY_CRITERIA: CriteriaStr = SAFE_TO_DEPLOY;
 pub static DEFAULT_POLICY_DEV_CRITERIA: CriteriaStr = SAFE_TO_RUN;
 
 /// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct RemoteImport {
     /// URL of the foreign audits.toml
     pub url: String,
@@ -398,7 +398,7 @@ pub struct RemoteImport {
 }
 
 /// Translations of foreign criteria to local criteria.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct CriteriaMapping {
     /// This local criteria is implied...
     pub ours: CriteriaName,
@@ -454,7 +454,7 @@ fn is_default_unaudited_suggest(val: &bool) -> bool {
 ////////////////////////////////////////////////////////////////////////////////////
 
 /// imports.lock, not sure what I want to put in here yet.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct ImportsFile {
     pub audits: SortedMap<ImportName, AuditsFile>,
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -68,8 +68,8 @@ use std::io::Write;
 use tracing::{error, trace, trace_span, warn};
 
 use crate::format::{
-    self, AuditKind, CriteriaName, CriteriaStr, Delta, DiffStat, FetchCommand, ImportName,
-    PackageName, PackageStr, PolicyEntry, SuggestedAudit, UnauditedDependency,
+    self, AuditKind, CriteriaName, CriteriaStr, Delta, DiffStat, ImportName, PackageName,
+    PackageStr, PolicyEntry, UnauditedDependency,
 };
 use crate::format::{FastMap, FastSet, SortedMap, SortedSet};
 use crate::network::Network;
@@ -2505,30 +2505,6 @@ impl<'a> ResolveReport<'a> {
                 .or_default()
                 .push(s);
         }
-
-        let mut last_suggest = vec![];
-        for suggestion in &suggestions {
-            let package = self.graph.nodes[suggestion.package].name.to_string();
-            let command = if suggestion.suggested_diff.from == ROOT_VERSION {
-                FetchCommand::Inspect {
-                    package,
-                    version: suggestion.suggested_diff.to.clone(),
-                }
-            } else {
-                FetchCommand::Diff {
-                    package,
-                    version1: suggestion.suggested_diff.from.clone(),
-                    version2: suggestion.suggested_diff.to.clone(),
-                }
-            };
-            let criteria = self
-                .criteria_mapper
-                .all_criteria_names(&suggestion.suggested_criteria)
-                .map(CriteriaName::from)
-                .collect::<Vec<_>>();
-            last_suggest.push(SuggestedAudit { command, criteria });
-        }
-        cache.set_last_suggest(last_suggest);
 
         Ok(Some(Suggest {
             suggestions,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -22,7 +22,7 @@ use crate::{
     flock::{FileLock, Filesystem},
     format::{
         AuditsFile, CommandHistory, ConfigFile, Delta, DiffCache, DiffStat, FastMap, FetchCommand,
-        ImportsFile, MetaConfig, PackageStr, SortedMap, SuggestedAudit,
+        ImportsFile, MetaConfig, PackageStr, SortedMap,
     },
     network::Network,
     resolver,
@@ -865,19 +865,14 @@ impl Cache {
         tokio::runtime::Handle::current().block_on(self.clean())
     }
 
-    pub fn get_command_history(&self) -> CommandHistory {
+    pub fn get_last_fetch(&self) -> Option<FetchCommand> {
         let guard = self.state.lock().unwrap();
-        guard.command_history.clone()
+        guard.command_history.last_fetch.clone()
     }
 
     pub fn set_last_fetch(&self, last_fetch: FetchCommand) {
         let mut guard = self.state.lock().unwrap();
         guard.command_history.last_fetch = Some(last_fetch);
-    }
-
-    pub fn set_last_suggest(&self, last_suggest: Vec<SuggestedAudit>) {
-        let mut guard = self.state.lock().unwrap();
-        guard.command_history.last_suggest = last_suggest;
     }
 }
 

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -1,0 +1,85 @@
+use super::*;
+use std::fmt::Write;
+
+#[test]
+fn mock_simple_suggested_criteria() {
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+
+    let (mut config, mut audits, imports) = files_no_unaudited(&metadata);
+
+    config.policy.insert(
+        "first-party".to_string(),
+        dep_policy([("third-party1", ["strong-reviewed"])]),
+    );
+
+    audits.audits.insert(
+        "third-party1".to_owned(),
+        vec![
+            full_audit(ver(2), "weak-reviewed"),
+            full_audit(ver(3), "reviewed"),
+            full_audit(ver(4), "strong-reviewed"),
+            delta_audit(ver(6), ver(DEFAULT_VER), "strong-reviewed"),
+            delta_audit(ver(7), ver(DEFAULT_VER), "reviewed"),
+            delta_audit(ver(8), ver(DEFAULT_VER), "weak-reviewed"),
+        ],
+    );
+    audits.audits.insert(
+        "third-party2".to_owned(),
+        vec![
+            full_audit(ver(2), "weak-reviewed"),
+            full_audit(ver(3), "reviewed"),
+            full_audit(ver(4), "strong-reviewed"),
+            delta_audit(ver(6), ver(DEFAULT_VER), "strong-reviewed"),
+            delta_audit(ver(7), ver(DEFAULT_VER), "reviewed"),
+            delta_audit(ver(8), ver(DEFAULT_VER), "weak-reviewed"),
+        ],
+    );
+
+    let store = Store::mock(config, audits, imports);
+    let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Deep);
+
+    let mut output = String::new();
+    for (from, to, descr) in [
+        (0, DEFAULT_VER, "full audit"),
+        // from existing audit
+        (2, DEFAULT_VER, "from weak-reviewed"),
+        (3, DEFAULT_VER, "from reviewed"),
+        (4, DEFAULT_VER, "from strong-reviewed"),
+        // to existing audit
+        (0, 6, "to strong-reviewed"),
+        (0, 7, "to reviewed"),
+        (0, 8, "to weak-reviewed"),
+        // bridge existing audits
+        (2, 6, "from weak-reviewed to strong-reviewed"),
+        (2, 7, "from weak-reviewed to reviewed"),
+        (2, 8, "from weak-reviewed to weak-reviewed"),
+        (3, 6, "from reviewed to strong-reviewed"),
+        (3, 7, "from reviewed to reviewed"),
+        (3, 8, "from reviewed to weak-reviewed"),
+        (4, 6, "from strong-reviewed to strong-reviewed"),
+        (4, 7, "from strong-reviewed to reviewed"),
+        (4, 8, "from strong-reviewed to weak-reviewed"),
+    ] {
+        let delta = Delta {
+            from: ver(from),
+            to: ver(to),
+        };
+        writeln!(output, "{} ({} -> {})", descr, delta.from, delta.to).unwrap();
+        writeln!(
+            output,
+            "  third-party1: {:?}",
+            report.compute_suggested_criteria("third-party1", &delta)
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "  third-party2: {:?}",
+            report.compute_suggested_criteria("third-party2", &delta)
+        )
+        .unwrap();
+    }
+
+    insta::assert_snapshot!("mock-simple-suggested-criteria", output);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 mod audit_as_crates_io;
+mod certify;
 mod regenerate_unaudited;
 mod vet;
 mod violations;

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-suggested-criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-suggested-criteria.snap
@@ -1,0 +1,53 @@
+---
+source: src/tests/certify.rs
+expression: output
+---
+full audit (0.0.0 -> 10.0.0)
+  third-party1: ["strong-reviewed"]
+  third-party2: ["reviewed"]
+from weak-reviewed (2.0.0 -> 10.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from reviewed (3.0.0 -> 10.0.0)
+  third-party1: ["reviewed"]
+  third-party2: ["reviewed"]
+from strong-reviewed (4.0.0 -> 10.0.0)
+  third-party1: ["strong-reviewed"]
+  third-party2: ["reviewed"]
+to strong-reviewed (0.0.0 -> 6.0.0)
+  third-party1: ["strong-reviewed"]
+  third-party2: ["reviewed"]
+to reviewed (0.0.0 -> 7.0.0)
+  third-party1: ["reviewed"]
+  third-party2: ["reviewed"]
+to weak-reviewed (0.0.0 -> 8.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from weak-reviewed to strong-reviewed (2.0.0 -> 6.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from weak-reviewed to reviewed (2.0.0 -> 7.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from weak-reviewed to weak-reviewed (2.0.0 -> 8.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from reviewed to strong-reviewed (3.0.0 -> 6.0.0)
+  third-party1: ["reviewed"]
+  third-party2: ["reviewed"]
+from reviewed to reviewed (3.0.0 -> 7.0.0)
+  third-party1: ["reviewed"]
+  third-party2: ["reviewed"]
+from reviewed to weak-reviewed (3.0.0 -> 8.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+from strong-reviewed to strong-reviewed (4.0.0 -> 6.0.0)
+  third-party1: ["strong-reviewed"]
+  third-party2: ["reviewed"]
+from strong-reviewed to reviewed (4.0.0 -> 7.0.0)
+  third-party1: ["reviewed"]
+  third-party2: ["reviewed"]
+from strong-reviewed to weak-reviewed (4.0.0 -> 8.0.0)
+  third-party1: ["weak-reviewed"]
+  third-party2: ["weak-reviewed"]
+


### PR DESCRIPTION
This patch makes 2 major changes to certify:

First, certify will no longer attempt to guess the version you are trying to certify unless there is a previous diff or inspect command in history for the crate being certified. This is to avoid potential mistakes, as it would be easy to miss the fact that the wrong version
was selected.

Second, when suggesting criteria to certify, the command will try harder to find the relevant set of criteria. If the diff or version
being certified isn't found in the `suggest` output history, it will now also check the unaudited table, and fall back to running the resolver to determine what criteria would heal the graph when specified for this revision.

This pass with the resolver is intended to be more relaxed that `suggest`, as the precise delta being checked is already known, so it
should be able to give suggested criteria even for audits which would not be suggested by the `suggest` algorithm.

Fixes #192 