### PR TITLE
Make read_line_initial_text omit prompt from the returned input.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -684,7 +684,8 @@ fn do_cmd_certify(
                     .collect::<Vec<_>>()
             )?;
             writeln!(out, "(press ENTER to accept the current criteria)")?;
-            let input = out.read_line_initial_text("> ")?;
+            let input = out.read_line_with_prompt("> ")?;
+            dbg!(&input);
             let input = input.trim();
             if input.is_empty() {
                 if chosen_criteria.is_empty() {

--- a/src/out.rs
+++ b/src/out.rs
@@ -25,7 +25,7 @@ pub trait Out: io::Write {
 
     /// Ask the user a question, and read in a line with the user's response. If
     /// there's no user able to respond, `None` will be returned instead.
-    fn read_line_initial_text(&mut self, _initial: &str) -> io::Result<String> {
+    fn read_line_with_prompt(&mut self, _prompt: &str) -> io::Result<String> {
         Err(io::ErrorKind::Unsupported.into())
     }
 
@@ -53,8 +53,10 @@ impl Out for Term {
         (&*self).clear_screen()
     }
 
-    fn read_line_initial_text(&mut self, initial: &str) -> io::Result<String> {
-        (&*self).read_line_initial_text(initial)
+    fn read_line_with_prompt(&mut self, prompt: &str) -> io::Result<String> {
+        self.write_str(prompt)?;
+        self.flush()?;
+        (&*self).read_line()
     }
 
     fn style(&self) -> Style {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1067,7 +1067,7 @@ impl<'a> Out for BasicTestOutput<'a> {
         Ok(())
     }
 
-    fn read_line_initial_text(&mut self, initial: &str) -> io::Result<String> {
+    fn read_line_with_prompt(&mut self, initial: &str) -> io::Result<String> {
         write!(self, "{}", initial)?;
         if let Some(on_read_line) = &mut self.on_read_line {
             let response = on_read_line(initial)?;


### PR DESCRIPTION
Don't pass the prompt string to `console::read_line_initial_text`, as that causes it to include the prompt in the input: entering "2" and hitting ENTER returns the string "> 2". Just write the prompt to the console, and then call read_line_initial_text with a null string.