### PR TITLE
Interactively display criteria and instructions for inspect and diff

### DIFF
--- a/src/out.rs
+++ b/src/out.rs
@@ -6,7 +6,7 @@
 
 use crate::editor::Editor;
 use console::{Style, Term};
-use std::{fs::File, io};
+use std::{fs::File, future::Future, io, pin::Pin};
 
 /// Object-safe extension of `std::io::Write` with extra features for
 /// interacting with the terminal. Can be mocked in tests to allow them to test
@@ -24,9 +24,20 @@ pub trait Out: io::Write {
     }
 
     /// Ask the user a question, and read in a line with the user's response. If
-    /// there's no user able to respond, `None` will be returned instead.
+    /// there's no user able to respond, an error will be returned instead.
     fn read_line_with_prompt(&mut self, _prompt: &str) -> io::Result<String> {
         Err(io::ErrorKind::Unsupported.into())
+    }
+
+    /// Like `read_line_with_prompt`, except will be run asynchronously when
+    /// possible in order to avoid blocking other futures running on the current
+    /// thread. This can be used to allow running background tasks, such as
+    /// fetching resources, while waiting for the user to respond.
+    fn read_line_with_prompt_async<'a>(
+        &'a mut self,
+        initial: &'a str,
+    ) -> Pin<Box<dyn Future<Output = io::Result<String>> + 'a>> {
+        Box::pin(async { self.read_line_with_prompt(initial) })
     }
 
     /// Get a `Style` object which can be used to style text written to this
@@ -56,7 +67,20 @@ impl Out for Term {
     fn read_line_with_prompt(&mut self, prompt: &str) -> io::Result<String> {
         self.write_str(prompt)?;
         self.flush()?;
-        (&*self).read_line()
+        self.read_line()
+    }
+
+    fn read_line_with_prompt_async<'a>(
+        &'a mut self,
+        prompt: &'a str,
+    ) -> Pin<Box<dyn Future<Output = io::Result<String>> + 'a>> {
+        let mut this = self.clone();
+        let prompt = prompt.to_owned();
+        Box::pin(async {
+            tokio::task::spawn_blocking(move || this.read_line_with_prompt(&prompt))
+                .await
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "background task failed"))?
+        })
     }
 
     fn style(&self) -> Style {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2543,7 +2543,8 @@ impl<'a> ResolveReport<'a> {
     pub fn compute_suggested_criteria(
         &self,
         package_name: PackageStr<'_>,
-        delta: &Delta,
+        from: Option<&Version>,
+        to: &Version,
     ) -> Vec<CriteriaName> {
         let fail = if let Conclusion::FailForVet(fail) = &self.conclusion {
             fail
@@ -2569,8 +2570,8 @@ impl<'a> ResolveReport<'a> {
                     reachable_from_target,
                 } = search_result
                 {
-                    if reachable_from_target.contains(&delta.to)
-                        && reachable_from_root.contains(&delta.from)
+                    if reachable_from_target.contains(to)
+                        && from.map_or(true, |v| reachable_from_root.contains(v))
                     {
                         criteria.set_criteria(criteria_idx);
                     }

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -42,41 +42,46 @@ fn mock_simple_suggested_criteria() {
 
     let mut output = String::new();
     for (from, to, descr) in [
-        (0, DEFAULT_VER, "full audit"),
+        (None, DEFAULT_VER, "full audit"),
         // from existing audit
-        (2, DEFAULT_VER, "from weak-reviewed"),
-        (3, DEFAULT_VER, "from reviewed"),
-        (4, DEFAULT_VER, "from strong-reviewed"),
+        (Some(2), DEFAULT_VER, "from weak-reviewed"),
+        (Some(3), DEFAULT_VER, "from reviewed"),
+        (Some(4), DEFAULT_VER, "from strong-reviewed"),
         // to existing audit
-        (0, 6, "to strong-reviewed"),
-        (0, 7, "to reviewed"),
-        (0, 8, "to weak-reviewed"),
+        (None, 6, "to strong-reviewed"),
+        (None, 7, "to reviewed"),
+        (None, 8, "to weak-reviewed"),
         // bridge existing audits
-        (2, 6, "from weak-reviewed to strong-reviewed"),
-        (2, 7, "from weak-reviewed to reviewed"),
-        (2, 8, "from weak-reviewed to weak-reviewed"),
-        (3, 6, "from reviewed to strong-reviewed"),
-        (3, 7, "from reviewed to reviewed"),
-        (3, 8, "from reviewed to weak-reviewed"),
-        (4, 6, "from strong-reviewed to strong-reviewed"),
-        (4, 7, "from strong-reviewed to reviewed"),
-        (4, 8, "from strong-reviewed to weak-reviewed"),
+        (Some(2), 6, "from weak-reviewed to strong-reviewed"),
+        (Some(2), 7, "from weak-reviewed to reviewed"),
+        (Some(2), 8, "from weak-reviewed to weak-reviewed"),
+        (Some(3), 6, "from reviewed to strong-reviewed"),
+        (Some(3), 7, "from reviewed to reviewed"),
+        (Some(3), 8, "from reviewed to weak-reviewed"),
+        (Some(4), 6, "from strong-reviewed to strong-reviewed"),
+        (Some(4), 7, "from strong-reviewed to reviewed"),
+        (Some(4), 8, "from strong-reviewed to weak-reviewed"),
     ] {
-        let delta = Delta {
-            from: ver(from),
-            to: ver(to),
-        };
-        writeln!(output, "{} ({} -> {})", descr, delta.from, delta.to).unwrap();
+        let from = from.map(ver);
+        let to = ver(to);
+        writeln!(
+            output,
+            "{} ({} -> {})",
+            descr,
+            from.as_ref().map_or("root".to_owned(), |v| v.to_string()),
+            to
+        )
+        .unwrap();
         writeln!(
             output,
             "  third-party1: {:?}",
-            report.compute_suggested_criteria("third-party1", &delta)
+            report.compute_suggested_criteria("third-party1", from.as_ref(), &to)
         )
         .unwrap();
         writeln!(
             output,
             "  third-party2: {:?}",
-            report.compute_suggested_criteria("third-party2", &delta)
+            report.compute_suggested_criteria("third-party2", from.as_ref(), &to)
         )
         .unwrap();
     }

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-suggested-criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-suggested-criteria.snap
@@ -2,7 +2,7 @@
 source: src/tests/certify.rs
 expression: output
 ---
-full audit (0.0.0 -> 10.0.0)
+full audit (root -> 10.0.0)
   third-party1: ["strong-reviewed"]
   third-party2: ["reviewed"]
 from weak-reviewed (2.0.0 -> 10.0.0)
@@ -14,13 +14,13 @@ from reviewed (3.0.0 -> 10.0.0)
 from strong-reviewed (4.0.0 -> 10.0.0)
   third-party1: ["strong-reviewed"]
   third-party2: ["reviewed"]
-to strong-reviewed (0.0.0 -> 6.0.0)
+to strong-reviewed (root -> 6.0.0)
   third-party1: ["strong-reviewed"]
   third-party2: ["reviewed"]
-to reviewed (0.0.0 -> 7.0.0)
+to reviewed (root -> 7.0.0)
   third-party1: ["reviewed"]
   third-party2: ["reviewed"]
-to weak-reviewed (0.0.0 -> 8.0.0)
+to weak-reviewed (root -> 8.0.0)
   third-party1: ["weak-reviewed"]
   third-party2: ["weak-reviewed"]
 from weak-reviewed to strong-reviewed (2.0.0 -> 6.0.0)

--- a/tests/diff-cache.toml
+++ b/tests/diff-cache.toml
@@ -1397,6 +1397,12 @@ raw = """
 """
 count = 57175
 
+[syn."1.0.0 -> 1.0.91"]
+raw = """
+ 93 files changed, 21776 insertions(+), 6701 deletions(-)
+"""
+count = 28477
+
 [synstructure."0.0.0 -> 0.12.6"]
 raw = """
  8 files changed, 2991 insertions(+)

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -2047,6 +2047,21 @@ stdout:
           }
         },
         {
+          "name": "syn",
+          "notable_parents": "tracing-attributes, and 2 others",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 28477,
+              "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n"
+            },
+            "from": "1.0.0",
+            "to": "1.0.91"
+          }
+        },
+        {
           "name": "unicode-normalization",
           "notable_parents": "idna",
           "suggested_criteria": [
@@ -2104,21 +2119,6 @@ stdout:
             },
             "from": "0.0.0",
             "to": "0.2.15"
-          }
-        },
-        {
-          "name": "syn",
-          "notable_parents": "tracing-attributes, and 2 others",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "diffstat": {
-              "count": 57175,
-              "raw": " 98 files changed, 57175 insertions(+)\n"
-            },
-            "from": "0.0.0",
-            "to": "1.0.91"
           }
         },
         {
@@ -3537,6 +3537,21 @@ stdout:
         }
       },
       {
+        "name": "syn",
+        "notable_parents": "tracing-attributes, and 2 others",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 28477,
+            "raw": " 93 files changed, 21776 insertions(+), 6701 deletions(-)\n"
+          },
+          "from": "1.0.0",
+          "to": "1.0.91"
+        }
+      },
+      {
         "name": "unicode-normalization",
         "notable_parents": "idna",
         "suggested_criteria": [
@@ -3597,21 +3612,6 @@ stdout:
         }
       },
       {
-        "name": "syn",
-        "notable_parents": "tracing-attributes, and 2 others",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "diffstat": {
-            "count": 57175,
-            "raw": " 98 files changed, 57175 insertions(+)\n"
-          },
-          "from": "0.0.0",
-          "to": "1.0.91"
-        }
-      },
-      {
         "name": "web-sys",
         "notable_parents": "reqwest, wasm-bindgen-futures",
         "suggested_criteria": [
@@ -3642,7 +3642,7 @@ stdout:
         }
       }
     ],
-    "total_lines": 1771316
+    "total_lines": 1742618
   }
 }
 stderr:

--- a/tests/snapshots/test_cli__test-project-suggest.snap
+++ b/tests/snapshots/test_cli__test-project-suggest.snap
@@ -94,18 +94,18 @@ recommended audits for safe-to-deploy:
     cargo vet inspect futures-util 0.3.21                 (used by h2, hyper, reqwest)                                (25074 lines)
     cargo vet inspect hyper 0.14.18                       (used by reqwest, hyper-tls)                                (25617 lines)
     cargo vet inspect h2 0.3.13                           (used by hyper, reqwest)                                    (26066 lines)
+    cargo vet diff syn 1.0.0 1.0.91                       (used by tracing-attributes, and 2 others)                  (93 files changed, 21776 insertions(+), 6701 deletions(-))
     cargo vet inspect unicode-normalization 0.1.19        (used by idna)                                              (28628 lines)
     cargo vet inspect openssl 0.10.38                     (used by native-tls)                                        (28634 lines)
     cargo vet inspect idna 0.2.3                          (used by url)                                               (32538 lines)
     cargo vet inspect vcpkg 0.2.15                        (used by openssl-sys)                                       (42648 lines)
-    cargo vet inspect syn 1.0.91                          (used by tracing-attributes, and 2 others)                  (57175 lines)
     cargo vet inspect web-sys 0.3.57                      (used by reqwest, wasm-bindgen-futures)                     (197014 lines)
     cargo vet inspect encoding_rs 0.8.31                  (used by reqwest)                                           (507252 lines)
 
 recommended audits for safe-to-run:
     cargo vet inspect hermit-abi 0.1.19  (used by atty)  (938 lines)
 
-estimated audit backlog: 1771316 lines
+estimated audit backlog: 1742618 lines
 
 Use |cargo vet certify| to record the audits.
 

--- a/tests/test-project/supply-chain/audits.toml
+++ b/tests/test-project/supply-chain/audits.toml
@@ -70,6 +70,11 @@ version = "3.1.8"
 dependency-criteria = { atty = "safe-to-run", bitflags = ["audited", "fuzzed"] }
 notes = "test for custom criteria (low-grade and high-grade)"
 
+[[audits.syn]]
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "test for partial delta criteria"
+
 [[audits.unicode-bidi]]
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.3.7"


### PR DESCRIPTION
This changes the behaviour of the inspect and diff instructions to now
predict the required criteria for the audit, and display the relevant
information up-front. A warning is shown if no criteria could be
determined, to help avoid accidentally unnecessary audits.

In addition, a partial audit for `syn` was added to the test project to
make it easier to test delta audit suggestions.

Fixes #200