### PR TITLE
Cli blitz

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,15 +355,28 @@ pub enum Commands {
 
 #[derive(Subcommand)]
 pub enum RegenerateSubcommands {
+    /// Regenerate your exemptions to make `check` pass minimally
     ///
+    /// This command can be used for two purposes: to force your supply-chain to pass `check`
+    /// when it's currently failing, or to minimize/garbage-collect your exemptions when it's
+    /// already passing. These are ultimately the same operation.
+    ///
+    /// We will try our best to preserve existing exemptions, removing only those that
+    /// aren't needed, and adding only those that are needed. Exemptions that are overbroad
+    /// may also be weakened (i.e. safe-to-deploy may be reduced to safe-to-run).
     #[clap(disable_version_flag = true)]
     Exemptions(RegenerateExemptionsArgs),
 
-    /// Suggest some low-hanging fruit to review
+    /// Regenerate your imports and accept changes to criteria
+    ///
+    /// This is equivalent to `cargo vet fetch-imports` but it won't produce an error if
+    /// the descriptions of foreign criteria change.
     #[clap(disable_version_flag = true)]
     Imports(RegenerateImportsArgs),
 
-    /// Initialize cargo-vet for your project
+    /// Regenerate you audit-as-crates-io entries to make `check` pass
+    ///
+    /// This will just set any problematic entries to `audit-as-crates-io = false`.
     #[clap(disable_version_flag = true)]
     AuditAsCratesIo(RegenerateAuditAsCratesIoArgs),
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,7 +198,7 @@ pub enum Commands {
     /// If you don't consider an exemption to be "backlog", add `suggest = false` to its
     /// entry and we won't remove it while suggesting.
     ///
-    /// See also `regenerate unaudited`, which can be used to "garbage collect"
+    /// See also `regenerate exemptions`, which can be used to "garbage collect"
     /// your backlog (if you run it while `check` is passing).
     #[clap(disable_version_flag = true)]
     Suggest(SuggestArgs),
@@ -474,10 +474,10 @@ pub struct RecordViolationArgs {
 /// Certifies the given version
 #[derive(clap::Args)]
 pub struct AddExemptionArgs {
-    /// The package to mark as unaudited (trusted)
+    /// The package to mark as exempted
     #[clap(action)]
     pub package: PackageName,
-    /// The version to mark as unaudited
+    /// The version to mark as exempted
     #[clap(action)]
     pub version: Version,
     /// The criteria to assume (trust)
@@ -485,7 +485,7 @@ pub struct AddExemptionArgs {
     /// If not provided, we will prompt you for this information.
     #[clap(long, action)]
     pub criteria: Vec<CriteriaName>,
-    /// The dependency-criteria to require for this unaudited entry to be valid
+    /// The dependency-criteria to require for this exemption to be valid
     ///
     /// If not provided, we will still implicitly require dependencies to satisfy `criteria`.
     #[clap(long, action)]
@@ -495,7 +495,7 @@ pub struct AddExemptionArgs {
     /// If not provided, there will be no notes.
     #[clap(long, action)]
     pub notes: Option<String>,
-    /// Suppress suggesting this unaudited entry
+    /// Suppress suggesting this exemption for review
     #[clap(long, action)]
     pub no_suggest: bool,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -143,7 +143,7 @@ pub enum MinimizeUnauditedError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Suggest(#[from] SuggestError),
-    #[error("An unknown error occured while trying to minimize unaudited entries")]
+    #[error("An unknown error occured while trying to minimize exemptions entries")]
     Unknown,
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -286,7 +286,8 @@ pub struct ConfigFile {
     /// (paths, git, etc) is assumed to be "under your control" and therefore implicitly trusted.
     #[serde(skip_serializing_if = "SortedMap::is_empty")]
     #[serde(default)]
-    pub unaudited: SortedMap<PackageName, Vec<UnauditedDependency>>,
+    #[serde(alias = "unaudited")]
+    pub exemptions: SortedMap<PackageName, Vec<ExemptedDependency>>,
 }
 
 pub static SAFE_TO_DEPLOY: CriteriaStr = "safe-to-deploy";
@@ -401,7 +402,7 @@ pub struct CriteriaMapping {
 /// Semantically identical to a 'full audit' entry, but private to our project
 /// and tracked as less-good than a proper audit, so that you try to get rid of it.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct UnauditedDependency {
+pub struct ExemptedDependency {
     /// The version of the crate that we are currently "fine" with leaving unaudited.
     pub version: Version,
     /// Criteria that we're willing to handwave for this version (assuming our dependencies
@@ -411,10 +412,10 @@ pub struct UnauditedDependency {
     #[serde(with = "serialization::string_or_vec")]
     pub criteria: Vec<Spanned<CriteriaName>>,
     /// Whether 'suggest' should bother mentioning this (defaults true).
-    #[serde(default = "get_default_unaudited_suggest")]
-    #[serde(skip_serializing_if = "is_default_unaudited_suggest")]
+    #[serde(default = "get_default_exemptions_suggest")]
+    #[serde(skip_serializing_if = "is_default_exemptions_suggest")]
     pub suggest: bool,
-    /// Custom criteria for an unaudited crate's dependencies.
+    /// Custom criteria for an exempted crate's dependencies.
     ///
     /// Any dependency edge that isn't explicitly specified defaults to `criteria`.
     #[serde(rename = "dependency-criteria")]
@@ -426,12 +427,12 @@ pub struct UnauditedDependency {
     pub notes: Option<String>,
 }
 
-static DEFAULT_UNAUDITED_SUGGEST: bool = true;
-pub fn get_default_unaudited_suggest() -> bool {
-    DEFAULT_UNAUDITED_SUGGEST
+static DEFAULT_EXEMPTIONS_SUGGEST: bool = true;
+pub fn get_default_exemptions_suggest() -> bool {
+    DEFAULT_EXEMPTIONS_SUGGEST
 }
-fn is_default_unaudited_suggest(val: &bool) -> bool {
-    val == &DEFAULT_UNAUDITED_SUGGEST
+fn is_default_exemptions_suggest(val: &bool) -> bool {
+    val == &DEFAULT_EXEMPTIONS_SUGGEST
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/format.rs
+++ b/src/format.rs
@@ -314,7 +314,7 @@ fn is_default_criteria(val: &CriteriaName) -> bool {
 /// If this sounds overwhelming, don't worry, everything defaults to "nothing special"
 /// and an empty PolicyTable basically just means "everything should satisfy the
 /// default criteria in audits.toml".
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct PolicyEntry {
     /// Whether this nominally-first-party crate should actually be subject to audits
     /// as-if it was third-party, based on matches to crates.io packages with the same

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,10 +407,10 @@ fn real_main() -> Result<(), miette::Report> {
         Some(DumpGraph(sub_args)) => cmd_dump_graph(out, &cfg, sub_args),
         Some(Inspect(sub_args)) => cmd_inspect(out, &cfg, sub_args),
         Some(Diff(sub_args)) => cmd_diff(out, &cfg, sub_args),
-        Some(HelpMarkdown(_)) | Some(Gc(_)) => unreachable!("handled earlier"),
         Some(Regenerate(Imports(sub_args))) => cmd_regenerate_imports(out, &cfg, sub_args),
         Some(Regenerate(Exemptions(sub_args))) => cmd_regenerate_exemptions(out, &cfg, sub_args),
         Some(Regenerate(AuditAsCratesIo(sub_args))) => cmd_regenerate_audit_as(out, &cfg, sub_args),
+        Some(HelpMarkdown(_)) | Some(Gc(_)) => unreachable!("handled earlier"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,22 +392,24 @@ fn real_main() -> Result<(), miette::Report> {
         _rest: partial_cfg,
     };
 
+    use RegenerateSubcommands::*;
     match &cfg.cli.command {
         None => cmd_check(out, &cfg, &cfg.cli.check_args),
         Some(Check(sub_args)) => cmd_check(out, &cfg, sub_args),
         Some(Init(sub_args)) => cmd_init(out, &cfg, sub_args),
-        Some(AcceptCriteriaChange(sub_args)) => cmd_accept_criteria_change(out, &cfg, sub_args),
         Some(Certify(sub_args)) => cmd_certify(out, &cfg, sub_args),
-        Some(AddUnaudited(sub_args)) => cmd_add_unaudited(out, &cfg, sub_args),
+        Some(AddExemption(sub_args)) => cmd_add_unaudited(out, &cfg, sub_args),
         Some(RecordViolation(sub_args)) => cmd_record_violation(out, &cfg, sub_args),
         Some(Suggest(sub_args)) => cmd_suggest(out, &cfg, sub_args),
         Some(Fmt(sub_args)) => cmd_fmt(out, &cfg, sub_args),
         Some(FetchImports(sub_args)) => cmd_fetch_imports(out, &cfg, sub_args),
-        Some(RegenerateUnaudited(sub_args)) => cmd_regenerate_unaudited(out, &cfg, sub_args),
         Some(DumpGraph(sub_args)) => cmd_dump_graph(out, &cfg, sub_args),
         Some(Inspect(sub_args)) => cmd_inspect(out, &cfg, sub_args),
         Some(Diff(sub_args)) => cmd_diff(out, &cfg, sub_args),
         Some(HelpMarkdown(_)) | Some(Gc(_)) => unreachable!("handled earlier"),
+        Some(Regenerate(Imports(sub_args))) => cmd_regenerate_imports(out, &cfg, sub_args),
+        Some(Regenerate(Exemptions(sub_args))) => cmd_regenerate_exemptions(out, &cfg, sub_args),
+        Some(Regenerate(AuditAsCratesIo(sub_args))) => cmd_regenerate_audit_as(out, &cfg, sub_args),
     }
 }
 
@@ -1041,7 +1043,7 @@ fn cmd_record_violation(
 fn cmd_add_unaudited(
     _out: &mut dyn Out,
     cfg: &Config,
-    sub_args: &AddUnauditedArgs,
+    sub_args: &AddExemptionArgs,
 ) -> Result<(), miette::Report> {
     // Add an unaudited entry
     let mut store = Store::acquire(cfg)?;
@@ -1140,13 +1142,32 @@ fn cmd_suggest(
     Ok(())
 }
 
-fn cmd_regenerate_unaudited(
+fn cmd_regenerate_imports(
     _out: &mut dyn Out,
-    cfg: &Config,
-    _sub_args: &RegenerateUnauditedArgs,
+    _cfg: &Config,
+    _sub_args: &RegenerateImportsArgs,
+) -> Result<(), miette::Report> {
+    // Run the checker to validate that the current set of deps is covered by the current cargo vet store
+    trace!("regenerating imports...");
+    todo!();
+}
+
+fn cmd_regenerate_audit_as(
+    _out: &mut dyn Out,
+    _cfg: &Config,
+    _sub_args: &RegenerateAuditAsCratesIoArgs,
 ) -> Result<(), miette::Report> {
     // Run the checker to validate that the current set of deps is covered by the current cargo vet store
     trace!("regenerating unaudited...");
+    todo!();
+}
+
+fn cmd_regenerate_exemptions(
+    _out: &mut dyn Out,
+    cfg: &Config,
+    _sub_args: &RegenerateExemptionsArgs,
+) -> Result<(), miette::Report> {
+    trace!("regenerating exemptions...");
     let mut store = Store::acquire(cfg)?;
     let network = Network::acquire(cfg);
 
@@ -1425,17 +1446,6 @@ fn cmd_fmt(_out: &mut dyn Out, cfg: &Config, _sub_args: &FmtArgs) -> Result<(), 
     let store = Store::acquire(cfg)?;
     store.commit()?;
     Ok(())
-}
-
-fn cmd_accept_criteria_change(
-    _out: &mut dyn Out,
-    _cfg: &Config,
-    _sub_args: &AcceptCriteriaChangeArgs,
-) -> Result<(), miette::Report> {
-    // Accept changes that a foreign audits.toml made to their criteria.
-    trace!("accepting...");
-
-    unimplemented!("TODO(#68): unimplemented feature!");
 }
 
 /// Perform crimes on clap long_help to generate markdown docs

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -142,7 +142,7 @@ impl Store {
                 default_criteria: String::new(),
                 imports: SortedMap::new(),
                 policy: SortedMap::new(),
-                unaudited: SortedMap::new(),
+                exemptions: SortedMap::new(),
             },
             imports: ImportsFile {
                 audits: SortedMap::new(),
@@ -234,7 +234,7 @@ impl Store {
 
     /// Create a clone of the store for use to resolve `suggest`.
     ///
-    /// This cloned store will not contain `unaudited` entries from the config,
+    /// This cloned store will not contain `exemptions` entries from the config,
     /// unless they're marked as `suggest = false`, such that the resolver will
     /// identify these missing audits when generating a report.
     ///
@@ -251,8 +251,8 @@ impl Store {
             audits_src: self.audits_src.clone(),
             imports_src: self.imports_src.clone(),
         };
-        // Delete all unaudited entries except those that are suggest=false
-        for versions in &mut clone.config.unaudited.values_mut() {
+        // Delete all exemptions entries except those that are suggest=false
+        for versions in &mut clone.config.exemptions.values_mut() {
             versions.retain(|e| !e.suggest);
         }
         clone
@@ -283,7 +283,7 @@ impl Store {
         //
         // * check that policy entries are only first-party?
         //   * (we currently allow policy.criteria on third-parties for audit-as-crates-io)
-        // * check that unaudited entries are for things that exist?
+        // * check that exemptions entries are for things that exist?
         // * check that lockfile and imports aren't desync'd (catch new/removed import urls)
         //
         // * check that each CriteriaEntry has 'description' or 'description_url'
@@ -325,7 +325,7 @@ impl Store {
         let no_criteria = vec![];
         let mut invalid_criteria_errors = vec![];
 
-        for (_package, entries) in &self.config.unaudited {
+        for (_package, entries) in &self.config.exemptions {
             for entry in entries {
                 check_criteria(
                     &self.config_src,
@@ -1335,7 +1335,7 @@ fn store_audits(writer: impl Write, mut audits: AuditsFile) -> Result<(), StoreT
 }
 fn store_config(writer: impl Write, mut config: ConfigFile) -> Result<(), StoreTomlError> {
     config
-        .unaudited
+        .exemptions
         .values_mut()
         .for_each(|entries| entries.sort());
 

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -7,7 +7,7 @@ fn mock_simple_suggested_criteria() {
 
     let metadata = mock.metadata();
 
-    let (mut config, mut audits, imports) = files_no_unaudited(&metadata);
+    let (mut config, mut audits, imports) = files_no_exemptions(&metadata);
 
     config.policy.insert(
         "first-party".to_string(),

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -1,13 +1,13 @@
 use super::*;
 
-fn get_unaudited(store: &Store) -> String {
-    toml_edit::ser::to_string_pretty(&store.config.unaudited).unwrap()
+fn get_exemptions(store: &Store) -> String {
+    toml_edit::ser::to_string_pretty(&store.config.exemptions).unwrap()
 }
 
 #[test]
-fn builtin_simple_unaudited_not_a_real_dep_regenerate() {
-    // (Pass) there's an unaudited entry for a package that isn't in our tree at all.
-    // Should strip the result and produce an empty unaudited file.
+fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
+    // (Pass) there's an exemptions entry for a package that isn't in our tree at all.
+    // Should strip the result and produce an empty exemptions file.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -15,22 +15,22 @@ fn builtin_simple_unaudited_not_a_real_dep_regenerate() {
     let metadata = mock.metadata();
     let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "fake-dep".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_simple_deps_unaudited_overbroad_regenerate() {
-    // (Pass) the unaudited entry is needed but it's overbroad
+fn builtin_simple_deps_exemptions_overbroad_regenerate() {
+    // (Pass) the exemptions entry is needed but it's overbroad
     // Should downgrade from safe-to-deploy to safe-to-run
 
     let _enter = TEST_RUNTIME.enter();
@@ -41,22 +41,22 @@ fn builtin_simple_deps_unaudited_overbroad_regenerate() {
 
     audits.audits.insert("dev".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "dev".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_complex_unaudited_twins_regenerate() {
-    // (Pass) two versions of a crate exist and both are unaudited and they're needed
+fn builtin_complex_exemptions_twins_regenerate() {
+    // (Pass) two versions of a crate exist and both are exemptions and they're needed
     // Should be a no-op and both entries should remain
 
     let _enter = TEST_RUNTIME.enter();
@@ -67,25 +67,25 @@ fn builtin_complex_unaudited_twins_regenerate() {
 
     audits.audits.insert("third-core".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-core".to_string(),
         vec![
-            unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
-            unaudited(ver(5), SAFE_TO_DEPLOY),
+            exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+            exemptions(ver(5), SAFE_TO_DEPLOY),
         ],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_complex_unaudited_partial_twins_regenerate() {
-    // (Pass) two versions of a crate exist and one is unaudited and one is audited
+fn builtin_complex_exemptions_partial_twins_regenerate() {
+    // (Pass) two versions of a crate exist and one is exemptions and one is audited
     // Should be a no-op and both entries should remain
 
     let _enter = TEST_RUNTIME.enter();
@@ -99,26 +99,26 @@ fn builtin_complex_unaudited_partial_twins_regenerate() {
         vec![full_audit(ver(5), SAFE_TO_DEPLOY)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-core".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-unaudited-partial-twins-regenerate",
-        unaudited
+        exemptions
     );
 }
 
 #[test]
-fn builtin_simple_unaudited_in_delta_regenerate() {
+fn builtin_simple_exemptions_in_delta_regenerate() {
     // (Pass) An audited entry overlaps a delta and isn't needed
-    // Should emit an empty unaudited file
+    // Should emit an empty exemptions file
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -135,23 +135,23 @@ fn builtin_simple_unaudited_in_delta_regenerate() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(5), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(5), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_simple_unaudited_in_full_regenerate() {
+fn builtin_simple_exemptions_in_full_regenerate() {
     // (Pass) An audited entry overlaps a full audit and isn't needed
-    // Should emit an empty unaudited file
+    // Should emit an empty exemptions file
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -168,23 +168,23 @@ fn builtin_simple_unaudited_in_full_regenerate() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(3), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(3), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_simple_deps_unaudited_adds_uneeded_criteria_regenerate() {
+fn builtin_simple_deps_exemptions_adds_uneeded_criteria_regenerate() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // Should produce an empty unaudited
+    // Should produce an empty exemptions
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple_deps();
@@ -201,24 +201,24 @@ fn builtin_simple_deps_unaudited_adds_uneeded_criteria_regenerate() {
     );
 
     config
-        .unaudited
-        .insert("dev".to_string(), vec![unaudited(ver(5), SAFE_TO_DEPLOY)]);
+        .exemptions
+        .insert("dev".to_string(), vec![exemptions(ver(5), SAFE_TO_DEPLOY)]);
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-deps-unaudited-adds-uneeded-criteria-regenerate",
-        unaudited
+        exemptions
     );
 }
 
 #[test]
-fn builtin_dev_detection_unaudited_adds_uneeded_criteria_indirect_regenerate() {
+fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect_regenerate() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // Should result in an empty unaudited file
+    // Should result in an empty exemptions file
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::dev_detection();
@@ -235,26 +235,26 @@ fn builtin_dev_detection_unaudited_adds_uneeded_criteria_indirect_regenerate() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "simple-dev-indirect".to_string(),
-        vec![unaudited(ver(5), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(5), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect-regenerate",
-        unaudited
+        exemptions
     );
 }
 
 #[test]
-fn builtin_simple_unaudited_extra_regenerate() {
-    // (Pass) there's an extra unused unaudited entry, but the other is needed.
-    // Should result in only the v10 unaudited entry remaining.
+fn builtin_simple_exemptions_extra_regenerate() {
+    // (Pass) there's an extra unused exemptions entry, but the other is needed.
+    // Should result in only the v10 exemptions entry remaining.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -264,26 +264,26 @@ fn builtin_simple_unaudited_extra_regenerate() {
 
     audits.audits.insert("third-party1".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
         vec![
-            unaudited(ver(5), SAFE_TO_DEPLOY),
-            unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+            exemptions(ver(5), SAFE_TO_DEPLOY),
+            exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
         ],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", exemptions);
 }
 
 #[test]
-fn builtin_simple_unaudited_in_direct_full_regenerate() {
+fn builtin_simple_exemptions_in_direct_full_regenerate() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // Should produce an empty unaudited
+    // Should produce an empty exemptions
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -296,26 +296,26 @@ fn builtin_simple_unaudited_in_direct_full_regenerate() {
         vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-unaudited-in-direct-full-regenerate",
-        unaudited
+        exemptions
     );
 }
 
 #[test]
-fn builtin_simple_unaudited_nested_weaker_req_regenerate() {
+fn builtin_simple_exemptions_nested_weaker_req_regenerate() {
     // (Pass) A dep that has weaker requirements on its dep
-    // BUSTED: doesn't emit dependency-criteria for third-party1's 'unaudited'
+    // BUSTED: doesn't emit dependency-criteria for third-party1's 'exemptions'
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -348,33 +348,33 @@ fn builtin_simple_unaudited_nested_weaker_req_regenerate() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited_dep(
+        vec![exemptions_dep(
             ver(3),
             SAFE_TO_DEPLOY,
             [("transitive-third-party1", [SAFE_TO_RUN])],
         )],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "transitive-third-party1".to_string(),
-        vec![unaudited(ver(4), SAFE_TO_RUN)],
+        vec![exemptions(ver(4), SAFE_TO_RUN)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-unaudited-nested-weaker-req-regenerate",
-        unaudited
+        exemptions
     );
 }
 
 #[test]
-fn builtin_simple_unaudited_nested_stronger_req_regenerate() {
+fn builtin_simple_exemptions_nested_stronger_req_regenerate() {
     // (Pass) A dep that has stronger requirements on its dep
     // BUSTED: should emit safe-to-deploy for transitive-third-party1
 
@@ -414,24 +414,24 @@ fn builtin_simple_unaudited_nested_stronger_req_regenerate() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(3), SAFE_TO_RUN)],
+        vec![exemptions(ver(3), SAFE_TO_RUN)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "transitive-third-party1".to_string(),
-        vec![unaudited(ver(4), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(4), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
+    let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-unaudited-nested-stronger-req-regenerate",
-        unaudited
+        exemptions
     );
 }
 
@@ -448,17 +448,20 @@ fn builtin_simple_audit_as_default_root_regenerate() {
     config
         .policy
         .insert("root-package".to_string(), audit_as_policy(Some(true)));
-    config.unaudited.insert(
+    config.exemptions.insert(
         "root-package".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-audit-as-default-root-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!(
+        "builtin-simple-audit-as-default-root-regenerate",
+        exemptions
+    );
 }
 
 #[test]
@@ -478,15 +481,15 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
             ..audit_as_policy(Some(true))
         },
     );
-    config.unaudited.insert(
+    config.exemptions.insert(
         "root-package".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::minimize_unaudited(&cfg, &mut store, None).unwrap();
+    crate::minimize_exemptions(&cfg, &mut store, None).unwrap();
 
-    let unaudited = get_unaudited(&store);
-    insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", unaudited);
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", exemptions);
 }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (4 unaudited)
+Vetting Succeeded (4 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (2 unaudited)
+Vetting Succeeded (2 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (2 unaudited)
+Vetting Succeeded (2 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (1 fully audited, 3 unaudited)
+Vetting Succeeded (1 fully audited, 3 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (1 fully audited, 3 unaudited)
+Vetting Succeeded (1 fully audited, 3 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (6 unaudited)
+Vetting Succeeded (6 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (3 unaudited)
+Vetting Succeeded (3 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (2 fully audited, 1 unaudited)
+Vetting Succeeded (2 fully audited, 1 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (5 fully audited, 1 unaudited)
+Vetting Succeeded (5 fully audited, 1 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (3 fully audited, 1 unaudited)
+Vetting Succeeded (3 fully audited, 1 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (2 fully audited, 2 unaudited)
+Vetting Succeeded (2 fully audited, 2 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (4 unaudited)
+Vetting Succeeded (4 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (3 unaudited)
+Vetting Succeeded (3 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Violations Found!
   third-party1:10.0.0
-    the unaudited 10.0.0
+    the exemption 10.0.0
       criteria: ["reviewed"]
     conflicts with own violation against =10
       criteria: ["weak-reviewed"]

--- a/src/tests/store_parsing.rs
+++ b/src/tests/store_parsing.rs
@@ -86,12 +86,12 @@ dependency-criteria = { clap_derive = "good" }
 [policy.boring]
 audit-as-crates-io = true
 
-[[unaudited.clap]]
+[[exemptions.clap]]
 version = "1.0.0"
 criteria = "oops"
 dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
 
-[[unaudited.clap_derive]]
+[[exemptions.clap_derive]]
 version = "1.0.0"
 criteria = "safe-to-run"
 

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -17,14 +17,14 @@ fn mock_simple_init() {
 }
 
 #[test]
-fn mock_simple_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn mock_simple_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = files_no_unaudited(&metadata);
+    let (config, audits, imports) = files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -67,14 +67,14 @@ fn builtin_simple_init() {
 }
 
 #[test]
-fn builtin_simple_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_simple_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -332,8 +332,8 @@ fn mock_simple_reviewed_too_weakly() {
 }
 
 #[test]
-fn mock_simple_delta_to_unaudited() {
-    // (Pass) A dep has a delta to an unaudited entry
+fn mock_simple_delta_to_exemptions() {
+    // (Pass) A dep has a delta to an exemptions entry
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -349,10 +349,10 @@ fn mock_simple_delta_to_unaudited() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -363,8 +363,8 @@ fn mock_simple_delta_to_unaudited() {
 }
 
 #[test]
-fn mock_simple_delta_to_unaudited_overshoot() {
-    // (Fail) A dep has a delta but it overshoots the unaudited entry.
+fn mock_simple_delta_to_exemptions_overshoot() {
+    // (Fail) A dep has a delta but it overshoots the exemptions entry.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -380,10 +380,10 @@ fn mock_simple_delta_to_unaudited_overshoot() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -394,8 +394,8 @@ fn mock_simple_delta_to_unaudited_overshoot() {
 }
 
 #[test]
-fn mock_simple_delta_to_unaudited_undershoot() {
-    // (Fail) A dep has a delta but it undershoots the unaudited entry.
+fn mock_simple_delta_to_exemptions_undershoot() {
+    // (Fail) A dep has a delta but it undershoots the exemptions entry.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -411,10 +411,10 @@ fn mock_simple_delta_to_unaudited_undershoot() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -529,8 +529,8 @@ fn mock_simple_reverse_delta_to_full_audit() {
 }
 
 #[test]
-fn mock_simple_reverse_delta_to_unaudited() {
-    // (Pass) A dep has a *reverse* delta to an unaudited entry
+fn mock_simple_reverse_delta_to_exemptions() {
+    // (Pass) A dep has a *reverse* delta to an exemptions entry
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -546,10 +546,10 @@ fn mock_simple_reverse_delta_to_unaudited() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER + 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER + 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -560,8 +560,8 @@ fn mock_simple_reverse_delta_to_unaudited() {
 }
 
 #[test]
-fn mock_simple_wrongly_reversed_delta_to_unaudited() {
-    // (Fail) A dep has a *reverse* delta to an unaudited entry but they needed a normal one
+fn mock_simple_wrongly_reversed_delta_to_exemptions() {
+    // (Fail) A dep has a *reverse* delta to an exemptions entry but they needed a normal one
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -577,10 +577,10 @@ fn mock_simple_wrongly_reversed_delta_to_unaudited() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -617,8 +617,8 @@ fn mock_simple_wrongly_reversed_delta_to_full_audit() {
 }
 
 #[test]
-fn mock_simple_needed_reversed_delta_to_unaudited() {
-    // (Fail) A dep has a delta to an unaudited entry but they needed a reversed one
+fn mock_simple_needed_reversed_delta_to_exemptions() {
+    // (Fail) A dep has a delta to an exemptions entry but they needed a reversed one
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -634,10 +634,10 @@ fn mock_simple_needed_reversed_delta_to_unaudited() {
         DEFAULT_CRIT,
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER + 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER + 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -648,8 +648,8 @@ fn mock_simple_needed_reversed_delta_to_unaudited() {
 }
 
 #[test]
-fn mock_simple_delta_to_unaudited_too_weak() {
-    // (Fail) A dep has a delta to an unaudited entry but it's too weak
+fn mock_simple_delta_to_exemptions_too_weak() {
+    // (Fail) A dep has a delta to an exemptions entry but it's too weak
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -665,10 +665,10 @@ fn mock_simple_delta_to_unaudited_too_weak() {
         "weak-reviewed",
     ));
 
-    let direct_unaudited = &mut config.unaudited;
-    direct_unaudited.insert(
+    let direct_exemptions = &mut config.exemptions;
+    direct_exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
+        vec![exemptions(ver(DEFAULT_VER - 5), DEFAULT_CRIT)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -732,7 +732,7 @@ fn mock_simple_delta_to_too_weak_full_audit() {
 
 #[test]
 fn mock_complex_inited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
@@ -746,13 +746,13 @@ fn mock_complex_inited() {
 }
 
 #[test]
-fn mock_complex_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn mock_complex_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
     let metadata = mock.metadata();
-    let (config, audits, imports) = files_no_unaudited(&metadata);
+    let (config, audits, imports) = files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -777,7 +777,7 @@ fn mock_complex_full_audited() {
 
 #[test]
 fn builtin_complex_inited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
@@ -791,13 +791,13 @@ fn builtin_complex_inited() {
 }
 
 #[test]
-fn builtin_complex_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_complex_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -1338,14 +1338,14 @@ fn builtin_simple_deps_inited() {
 }
 
 #[test]
-fn builtin_simple_deps_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_simple_deps_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple_deps();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -1456,14 +1456,14 @@ fn builtin_cycle_inited() {
 }
 
 #[test]
-fn builtin_cycle_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_cycle_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::cycle();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -1515,7 +1515,7 @@ fn builtin_dev_detection() {
     let mock = MockMetadata::dev_detection();
 
     let metadata = mock.metadata();
-    let (config, mut audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, mut audits, imports) = builtin_files_no_exemptions(&metadata);
     audits.audits.insert(
         "normal".to_string(),
         vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
@@ -1556,7 +1556,7 @@ fn builtin_dev_detection_empty() {
     let mock = MockMetadata::dev_detection();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -1573,7 +1573,7 @@ fn builtin_dev_detection_empty_deeper() {
     let mock = MockMetadata::dev_detection();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Deep);
@@ -1583,9 +1583,9 @@ fn builtin_dev_detection_empty_deeper() {
 }
 
 #[test]
-fn builtin_simple_unaudited_extra() {
-    // (Pass) there's an extra unused unaudited entry, but the other is needed
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+fn builtin_simple_exemptions_extra() {
+    // (Pass) there's an extra unused exemptions entry, but the other is needed
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1595,11 +1595,11 @@ fn builtin_simple_unaudited_extra() {
 
     audits.audits.insert("third-party1".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
         vec![
-            unaudited(ver(5), SAFE_TO_DEPLOY),
-            unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+            exemptions(ver(5), SAFE_TO_DEPLOY),
+            exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
         ],
     );
 
@@ -1611,9 +1611,9 @@ fn builtin_simple_unaudited_extra() {
 }
 
 #[test]
-fn builtin_simple_unaudited_not_a_real_dep() {
-    // (Pass) there's an unaudited entry for a package that isn't in our tree at all.
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+fn builtin_simple_exemptions_not_a_real_dep() {
+    // (Pass) there's an exemptions entry for a package that isn't in our tree at all.
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1621,9 +1621,9 @@ fn builtin_simple_unaudited_not_a_real_dep() {
     let metadata = mock.metadata();
     let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "fake-dep".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1634,9 +1634,9 @@ fn builtin_simple_unaudited_not_a_real_dep() {
 }
 
 #[test]
-fn builtin_simple_deps_unaudited_overbroad() {
-    // (Pass) the unaudited entry is needed but it's overbroad
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+fn builtin_simple_deps_exemptions_overbroad() {
+    // (Pass) the exemptions entry is needed but it's overbroad
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple_deps();
@@ -1646,9 +1646,9 @@ fn builtin_simple_deps_unaudited_overbroad() {
 
     audits.audits.insert("dev".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "dev".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1659,8 +1659,8 @@ fn builtin_simple_deps_unaudited_overbroad() {
 }
 
 #[test]
-fn builtin_complex_unaudited_twins() {
-    // (Pass) two versions of a crate exist and both are unaudited and they're needed
+fn builtin_complex_exemptions_twins() {
+    // (Pass) two versions of a crate exist and both are exemptions and they're needed
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
@@ -1670,11 +1670,11 @@ fn builtin_complex_unaudited_twins() {
 
     audits.audits.insert("third-core".to_string(), vec![]);
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-core".to_string(),
         vec![
-            unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
-            unaudited(ver(5), SAFE_TO_DEPLOY),
+            exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+            exemptions(ver(5), SAFE_TO_DEPLOY),
         ],
     );
 
@@ -1686,8 +1686,8 @@ fn builtin_complex_unaudited_twins() {
 }
 
 #[test]
-fn builtin_complex_unaudited_partial_twins() {
-    // (Pass) two versions of a crate exist and one is unaudited and one is audited
+fn builtin_complex_exemptions_partial_twins() {
+    // (Pass) two versions of a crate exist and one is exemptions and one is audited
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::complex();
@@ -1700,9 +1700,9 @@ fn builtin_complex_unaudited_partial_twins() {
         vec![full_audit(ver(5), SAFE_TO_DEPLOY)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-core".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1713,9 +1713,9 @@ fn builtin_complex_unaudited_partial_twins() {
 }
 
 #[test]
-fn builtin_simple_unaudited_in_delta() {
+fn builtin_simple_exemptions_in_delta() {
     // (Pass) An audited entry overlaps a delta and isn't needed
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1732,9 +1732,9 @@ fn builtin_simple_unaudited_in_delta() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(5), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(5), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1745,9 +1745,9 @@ fn builtin_simple_unaudited_in_delta() {
 }
 
 #[test]
-fn builtin_simple_unaudited_in_full() {
+fn builtin_simple_exemptions_in_full() {
     // (Pass) An audited entry overlaps a full audit and isn't needed
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1764,9 +1764,9 @@ fn builtin_simple_unaudited_in_full() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(3), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(3), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1777,9 +1777,9 @@ fn builtin_simple_unaudited_in_full() {
 }
 
 #[test]
-fn builtin_simple_unaudited_in_direct_full() {
+fn builtin_simple_exemptions_in_direct_full() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // (This test used to warn when we tried to detect "useless unaudited" eagerly)
+    // (This test used to warn when we tried to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1792,9 +1792,9 @@ fn builtin_simple_unaudited_in_direct_full() {
         vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1805,9 +1805,9 @@ fn builtin_simple_unaudited_in_direct_full() {
 }
 
 #[test]
-fn builtin_simple_unaudited_nested_weaker_req() {
+fn builtin_simple_exemptions_nested_weaker_req() {
     // (Pass) A dep that has weaker requirements on its dep
-    // including dependency_criteria on an unaudited entry
+    // including dependency_criteria on an exemptions entry
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1840,18 +1840,18 @@ fn builtin_simple_unaudited_nested_weaker_req() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited_dep(
+        vec![exemptions_dep(
             ver(3),
             SAFE_TO_DEPLOY,
             [("transitive-third-party1", [SAFE_TO_RUN])],
         )],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "transitive-third-party1".to_string(),
-        vec![unaudited(ver(4), SAFE_TO_RUN)],
+        vec![exemptions(ver(4), SAFE_TO_RUN)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1862,9 +1862,9 @@ fn builtin_simple_unaudited_nested_weaker_req() {
 }
 
 #[test]
-fn builtin_simple_unaudited_nested_weaker_req_needs_dep_criteria() {
+fn builtin_simple_exemptions_nested_weaker_req_needs_dep_criteria() {
     // (Fail) A dep that has weaker requirements on its dep
-    // but the unaudited entry is missing that so the whole thing fails
+    // but the exemptions entry is missing that so the whole thing fails
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -1897,14 +1897,14 @@ fn builtin_simple_unaudited_nested_weaker_req_needs_dep_criteria() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(3), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(3), SAFE_TO_DEPLOY)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "transitive-third-party1".to_string(),
-        vec![unaudited(ver(4), SAFE_TO_RUN)],
+        vec![exemptions(ver(4), SAFE_TO_RUN)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1918,7 +1918,7 @@ fn builtin_simple_unaudited_nested_weaker_req_needs_dep_criteria() {
 }
 
 #[test]
-fn builtin_simple_unaudited_nested_stronger_req() {
+fn builtin_simple_exemptions_nested_stronger_req() {
     // (Pass) A dep that has stronger requirements on its dep
 
     let _enter = TEST_RUNTIME.enter();
@@ -1957,14 +1957,14 @@ fn builtin_simple_unaudited_nested_stronger_req() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "third-party1".to_string(),
-        vec![unaudited(ver(3), SAFE_TO_RUN)],
+        vec![exemptions(ver(3), SAFE_TO_RUN)],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "transitive-third-party1".to_string(),
-        vec![unaudited(ver(4), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(4), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -1975,9 +1975,9 @@ fn builtin_simple_unaudited_nested_stronger_req() {
 }
 
 #[test]
-fn builtin_simple_deps_unaudited_adds_uneeded_criteria() {
+fn builtin_simple_deps_exemptions_adds_uneeded_criteria() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple_deps();
@@ -1994,8 +1994,8 @@ fn builtin_simple_deps_unaudited_adds_uneeded_criteria() {
     );
 
     config
-        .unaudited
-        .insert("dev".to_string(), vec![unaudited(ver(5), SAFE_TO_DEPLOY)]);
+        .exemptions
+        .insert("dev".to_string(), vec![exemptions(ver(5), SAFE_TO_DEPLOY)]);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -2008,9 +2008,9 @@ fn builtin_simple_deps_unaudited_adds_uneeded_criteria() {
 }
 
 #[test]
-fn builtin_dev_detection_unaudited_adds_uneeded_criteria_indirect() {
+fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect() {
     // (Pass) An audited entry overlaps a full audit which is the cur version and isn't needed
-    // (This test could warn if we try to detect "useless unaudited" eagerly)
+    // (This test could warn if we try to detect "useless exemptions" eagerly)
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::dev_detection();
@@ -2026,9 +2026,9 @@ fn builtin_dev_detection_unaudited_adds_uneeded_criteria_indirect() {
         ],
     );
 
-    config.unaudited.insert(
+    config.exemptions.insert(
         "simple-dev-indirect".to_string(),
-        vec![unaudited(ver(5), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(5), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -2323,14 +2323,14 @@ fn builtin_haunted_init() {
 }
 
 #[test]
-fn builtin_haunted_no_unaudited() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_haunted_no_exemptions() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::haunted_tree();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
@@ -2340,14 +2340,14 @@ fn builtin_haunted_no_unaudited() {
 }
 
 #[test]
-fn builtin_haunted_no_unaudited_deeper() {
-    // (Fail) Should look the same as a fresh 'vet init' but with all 'unaudited' entries deleted.
+fn builtin_haunted_no_exemptions_deeper() {
+    // (Fail) Should look the same as a fresh 'vet init' but with all 'exemptions' entries deleted.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::haunted_tree();
 
     let metadata = mock.metadata();
-    let (config, audits, imports) = builtin_files_no_unaudited(&metadata);
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Deep);
@@ -2424,9 +2424,9 @@ fn builtin_simple_audit_as_default_root() {
     config
         .policy
         .insert("root-package".to_string(), audit_as_policy(Some(true)));
-    config.unaudited.insert(
+    config.exemptions.insert(
         "root-package".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -2449,9 +2449,9 @@ fn builtin_simple_audit_as_default_root_too_weak() {
     config
         .policy
         .insert("root-package".to_string(), audit_as_policy(Some(true)));
-    config.unaudited.insert(
+    config.exemptions.insert(
         "root-package".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_RUN)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_RUN)],
     );
 
     let store = Store::mock(config, audits, imports);
@@ -2478,9 +2478,9 @@ fn builtin_simple_audit_as_weaker_root() {
             ..audit_as_policy(Some(true))
         },
     );
-    config.unaudited.insert(
+    config.exemptions.insert(
         "root-package".to_string(),
-        vec![unaudited(ver(DEFAULT_VER), SAFE_TO_RUN)],
+        vec![exemptions(ver(DEFAULT_VER), SAFE_TO_RUN)],
     );
 
     let store = Store::mock(config, audits, imports);

--- a/src/tests/violations.rs
+++ b/src/tests/violations.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 #[test]
-fn mock_simple_violation_cur_unaudited() {
-    // (Fail) All marked 'unaudited' but a 'violation' entry matches a current version.
+fn mock_simple_violation_cur_exemptions() {
+    // (Fail) All marked 'exemptions' but a 'violation' entry matches a current version.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -124,31 +124,29 @@ GLOBAL OPTIONS:
 
 SUBCOMMANDS:
     check
-            [default] Check that the current project has been vetted
+            \[default\] Check that the current project has been vetted
+    suggest
+            Suggest some low-hanging fruit to review
     init
             Initialize cargo-vet for your project
-    accept-criteria-change
-            Accept changes that a foreign audits.toml made to their criteria
     inspect
-            Fetch the source of `$package $version`
+            Fetch the source of a package
     diff
             Yield a diff against the last reviewed version
     certify
-            Mark `$package $version` as reviewed
-    add-unaudited
-            Mark `$package $version` as unaudited
+            Mark a package as audited
+    regenerate
+            Explicitly regenerate various pieces of information
+    add-exemption
+            Mark a package as exempted from review
     record-violation
-            Mark `$package $version` as a violation of policy
-    suggest
-            Suggest some low-hanging fruit to review
+            Declare that some versions of a package violate certain audit criteria
     fmt
             Reformat all of vet's files (in case you hand-edited them)
     fetch-imports
             Explicitly fetch the imports (foreign audit files)
-    regenerate-unaudited
-            Regenerate the 'unaudited' entries to try to minimize them and make the vet pass
     dump-graph
-            Print a mermaid-js visualization of the cargo build graph as understood by cargo-vet
+            Print the cargo build graph as understood by `cargo vet`
     gc
             Clean up old packages from the vet cache
     help

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -209,7 +209,7 @@ is failing, because this will just give you worse information.
 If you don't consider an exemption to be "backlog", add `suggest = false` to its entry and we won't
 remove it while suggesting.
 
-See also `regenerate unaudited`, which can be used to "garbage collect" your backlog (if you run it
+See also `regenerate exemptions`, which can be used to "garbage collect" your backlog (if you run it
 while `check` is passing).
 
 ### USAGE
@@ -479,10 +479,10 @@ cargo vet add-exemption [OPTIONS] <PACKAGE> <VERSION>
 
 ### ARGS
 #### `<PACKAGE>`
-The package to mark as unaudited (trusted)
+The package to mark as exempted
 
 #### `<VERSION>`
-The version to mark as unaudited
+The version to mark as exempted
 
 ### OPTIONS
 #### `--criteria <CRITERIA>`
@@ -491,7 +491,7 @@ The criteria to assume (trust)
 If not provided, we will prompt you for this information.
 
 #### `--dependency-criteria <DEPENDENCY_CRITERIA>`
-The dependency-criteria to require for this unaudited entry to be valid
+The dependency-criteria to require for this exemption to be valid
 
 If not provided, we will still implicitly require dependencies to satisfy `criteria`.
 
@@ -501,7 +501,7 @@ A free-form string to include with the new forbid entry
 If not provided, there will be no notes.
 
 #### `--no-suggest`
-Suppress suggesting this unaudited entry
+Suppress suggesting this exemption for review
 
 #### `-h, --help`
 Print help information

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -132,27 +132,52 @@ tested)
 graph
 
 ### SUBCOMMANDS
-* [check](#cargo-vet-check): \[default] Check that the current project has been vetted  
-* [init](#cargo-vet-init): Initialize cargo-vet for your project
-* [accept-criteria-change](#cargo-vet-accept-criteria-change): Accept changes that a foreign audits.toml made to their criteria
-* [inspect](#cargo-vet-inspect): Fetch the source of `$package $version`
-* [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
-* [certify](#cargo-vet-certify): Mark `$package $version` as reviewed
-* [add-unaudited](#cargo-vet-add-unaudited): Mark `$package $version` as unaudited
-* [record-violation](#cargo-vet-record-violation): Mark `$package $version` as a violation of policy
+* [check](#cargo-vet-check): \[default\] Check that the current project has been vetted
 * [suggest](#cargo-vet-suggest): Suggest some low-hanging fruit to review
+* [init](#cargo-vet-init): Initialize cargo-vet for your project
+* [inspect](#cargo-vet-inspect): Fetch the source of a package
+* [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
+* [certify](#cargo-vet-certify): Mark a package as audited
+* [regenerate](#cargo-vet-regenerate): Explicitly regenerate various pieces of information
+* [add-exemption](#cargo-vet-add-exemption): Mark a package as exempted from review
+* [record-violation](#cargo-vet-record-violation): Declare that some versions of a package violate certain audit criteria
 * [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
 * [fetch-imports](#cargo-vet-fetch-imports): Explicitly fetch the imports (foreign audit files)
-* [regenerate-unaudited](#cargo-vet-regenerate-unaudited): Regenerate the 'unaudited' entries to try to minimize them and make the vet pass
-* [dump-graph](#cargo-vet-dump-graph): Print a mermaid-js visualization of the cargo build graph as understood by cargo-vet
+* [dump-graph](#cargo-vet-dump-graph): Print the cargo build graph as understood by `cargo vet`
 * [gc](#cargo-vet-gc): Clean up old packages from the vet cache
 * [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 
 <br><br><br>
 ## cargo vet check
-\[default] Check that the current project has been vetted  
+\[default\] Check that the current project has been vetted
 
 This is the default behaviour if no subcommand is specified.
+
+If the check fails due to lack of audits, we will do our best to explain why vetting failed, and
+what should be done to fix it. This can involve a certain amount of guesswork, as there are many
+possible solutions and we only want to recommend the "best" one to keep things simple.
+
+Failures and suggestions can either be "Certain" or "Speculative". Speculative items are greyed
+out and sorted lower to indicate that the Certain entries should be looked at first. Speculative
+items are for packages that probably need audits too, but only appear as transitive dependencies of
+Certain items.
+
+During review of Certain issues you may take various actions that change what's needed for the
+Speculative ones. For instance you may discover you're enabling a feature you don't need, and
+that's the only reason the Speculative package is in your tree. Or you may determine that the
+Certain package only needs to be safe-to-run, which may make the Speculative requirements weaker or
+completely resolved. For these reasons we recommend fixing problems "top down", and Certain items
+are The Top.
+
+Suggested fixes are grouped by the criteria they should be reviewed for and sorted by how easy the
+review should be (in terms of lines of code). We only ever suggest audits (and provide the command
+you need to run to do it), but there are other possible fixes like an `exemption` or `policy`
+change.
+
+The most aggressive solution is to run `cargo vet regenerate exemptions` which will add whatever
+exemptions necessary to make `check` pass (and remove uneeded ones). Ideally you should avoid doing
+this and prefer adding audits, but if you've done all the audits you plan on doing, that's the way
+to finish the job.
 
 ### USAGE
 ```
@@ -174,8 +199,47 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
+## cargo vet suggest
+Suggest some low-hanging fruit to review
+
+This is essentially the same as `check` but with all your `exemptions` temporarily removed as a way
+to inspect your "review backlog". As such, we recommend against running this command while `check`
+is failing, because this will just give you worse information.
+
+If you don't consider an exemption to be "backlog", add `suggest = false` to its entry and we won't
+remove it while suggesting.
+
+See also `regenerate unaudited`, which can be used to "garbage collect" your backlog (if you run it
+while `check` is passing).
+
+### USAGE
+```
+cargo vet suggest [OPTIONS]
+```
+
+### OPTIONS
+#### `--shallow`
+Avoid suggesting audits for dependencies of unaudited dependencies.
+
+By default, if a dependency doesn't have sufficient audits for *itself* then we try to
+speculate that its dependencies require the criteria. This flag disables that behaviour,
+causing only suggestions which we're certain of the requirements for to be emitted.
+
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
 ## cargo vet init
 Initialize cargo-vet for your project
+
+This will add `exemptions` and `audit-as-crates-io = false` for all packages that need it to make
+`check` pass immediately and make it easy to start using vet with your project.
+
+At this point you can either configure your project further or start working on your review backlog
+with `suggest`.
 
 ### USAGE
 ```
@@ -190,24 +254,11 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet accept-criteria-change
-Accept changes that a foreign audits.toml made to their criteria
-
-### USAGE
-```
-cargo vet accept-criteria-change [OPTIONS]
-```
-
-### OPTIONS
-#### `-h, --help`
-Print help information
-
-### GLOBAL OPTIONS
-This subcommand accepts all the [global options](#global-options)
-
-<br><br><br>
 ## cargo vet inspect
-Fetch the source of `$package $version`
+Fetch the source of a package
+
+We will attempt to guess what criteria you want to audit the package for based on the current check/
+suggest status, and show you the meaning of those criteria ahead of time.
 
 ### USAGE
 ```
@@ -231,6 +282,9 @@ This subcommand accepts all the [global options](#global-options)
 <br><br><br>
 ## cargo vet diff
 Yield a diff against the last reviewed version
+
+We will attempt to guess what criteria you want to audit the package for based on the current check/
+suggest status, and show you the meaning of those criteria ahead of time.
 
 ### USAGE
 ```
@@ -256,7 +310,20 @@ This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet certify
-Mark `$package $version` as reviewed
+Mark a package as audited
+
+This command will do its best to guess what you want to be certifying.
+
+If invoked with no args, it will try to certify the last thing you looked at with `inspect` or
+`diff`. Otherwise you must either supply the package name and one version (for a full audit) or two
+versions (for a delta audit).
+
+Once the package+version(s) have been selected, we will try to guess what criteria to certify it
+for. First we will `check`, and if the check fails and your audit would seemingly fix this package,
+we will use the criteria recommended for that fix. If `check` passes, we will assume you are working
+on your backlog and instead use the recommendations of `suggest`.
+
+If this removes the need for an `exemption` will we automatically remove it.
 
 ### USAGE
 ```
@@ -304,12 +371,110 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet add-unaudited
-Mark `$package $version` as unaudited
+## cargo vet regenerate
+Explicitly regenerate various pieces of information
+
+There are several things that `cargo vet` *can* do for you automatically but we choose to make
+manual just to keep a human in the loop of those decisions. Some of these might one day become
+automatic if we agree they're boring/reliable enough.
+
+See the subcommands for specifics.
 
 ### USAGE
 ```
-cargo vet add-unaudited [OPTIONS] <PACKAGE> <VERSION>
+cargo vet regenerate [OPTIONS] <SUBCOMMAND>
+```
+
+### OPTIONS
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+### SUBCOMMANDS
+* [exemptions](#cargo-vet-exemptions): 
+* [imports](#cargo-vet-imports): Suggest some low-hanging fruit to review
+* [audit-as-crates-io](#cargo-vet-audit-as-crates-io): Initialize cargo-vet for your project
+* [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
+
+<br><br><br>
+## cargo vet exemptions
+
+### USAGE
+```
+cargo vet regenerate exemptions [OPTIONS]
+```
+
+### OPTIONS
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## cargo vet imports
+Suggest some low-hanging fruit to review
+
+### USAGE
+```
+cargo vet regenerate imports [OPTIONS]
+```
+
+### OPTIONS
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## cargo vet audit-as-crates-io
+Initialize cargo-vet for your project
+
+### USAGE
+```
+cargo vet regenerate audit-as-crates-io [OPTIONS]
+```
+
+### OPTIONS
+#### `-h, --help`
+Print help information
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## cargo vet help
+Print this message or the help of the given subcommand(s)
+
+### USAGE
+```
+cargo vet regenerate help [OPTIONS] [SUBCOMMAND]...
+```
+
+### ARGS
+#### `<SUBCOMMAND>...`
+The subcommand whose help message to display
+
+### GLOBAL OPTIONS
+This subcommand accepts all the [global options](#global-options)
+
+<br><br><br>
+## cargo vet add-exemption
+Mark a package as exempted from review
+
+Exemptions are *usually* just "backlog" and the expectation is that you will review them
+"eventually". You should usually only be trying to remove them, but sometimes additions are
+necessary to make progress.
+
+`regenerate exemptions` will do this for your automatically to make `check` pass (and remove any
+unnecessary ones), so we recommend using that over `add-exemption`. This command mostly exists as
+"plumbing" for building tools on top of `cargo vet`.
+
+### USAGE
+```
+cargo vet add-exemption [OPTIONS] <PACKAGE> <VERSION>
 ```
 
 ### ARGS
@@ -346,7 +511,28 @@ This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet record-violation
-Mark `$package $version` as a violation of policy
+Declare that some versions of a package violate certain audit criteria
+
+**IMPORTANT**: violations take *VersionReqs* not *Versions*. This is the same syntax used by
+Cargo.toml when specifying dependencies. A bare `1.0.0` actually means `^1.0.0`. If you want to
+forbid a *specific* version, use `=1.0.0`. This command can be a bit awkward because syntax like `*`
+has special meaning in scripts and terminals. It's probably easier to just manually add the entry to
+your audits.toml, but the command's here in case you want it.
+
+Violations are essentially treated as integrity constraints on your supply-chain, and will only
+result in errors if you have `exemptions` or `audits` (including imported ones) that claim criteria
+that are contradicted by the `violation`. It is not inherently an error to depend on a package with
+a `violation`.
+
+For instance, someone may review a package and determine that it's horribly unsound in the face of
+untrusted inputs, and therefore *un*safe-to-deploy. They would then add a "safe-to-deploy" violation
+for whatever versions of that package seem to have that problem. But if the package basically works
+fine on trusted inputs, it might still be safe-to-run. So if you use it in your tests and have an
+audit that only claims safe-to-run, we won't mention it.
+
+When a violation *does* cause an integrity error, it's up to you and your peers to figure out what
+to do about it. There isn't yet a mechanism for dealing with disagreements with a peer's published
+violations.
 
 ### USAGE
 ```
@@ -383,33 +569,11 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet suggest
-Suggest some low-hanging fruit to review
-
-### USAGE
-```
-cargo vet suggest [OPTIONS]
-```
-
-### OPTIONS
-#### `--shallow`
-Avoid suggesting audits for dependencies of unaudited dependencies.
-
-By default, if a dependency doesn't have sufficient audits for *itself* then we try to
-speculate that its dependencies require the criteria. This flag disables that behaviour,
-causing only suggestions which we're certain of the requirements for to be emitted.
-
-#### `-h, --help`
-Print help information
-
-### GLOBAL OPTIONS
-This subcommand accepts all the [global options](#global-options)
-
-<br><br><br>
 ## cargo vet fmt
 Reformat all of vet's files (in case you hand-edited them)
 
-All commands that access the store (supply-chain) will implicitly do this.
+Most commands will implicitly do this, so this mostly exists as "plumbing" for building tools on top
+of vet, or in case you don't want to run another command.
 
 ### USAGE
 ```
@@ -427,7 +591,8 @@ This subcommand accepts all the [global options](#global-options)
 ## cargo vet fetch-imports
 Explicitly fetch the imports (foreign audit files)
 
-`cargo vet check` will implicitly do this.
+`cargo vet check` will implicitly do this, so this mostly exists as "plumbing" for building tools on
+top of vet.
 
 ### USAGE
 ```
@@ -442,24 +607,22 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet regenerate-unaudited
-Regenerate the 'unaudited' entries to try to minimize them and make the vet pass
-
-### USAGE
-```
-cargo vet regenerate-unaudited [OPTIONS]
-```
-
-### OPTIONS
-#### `-h, --help`
-Print help information
-
-### GLOBAL OPTIONS
-This subcommand accepts all the [global options](#global-options)
-
-<br><br><br>
 ## cargo vet dump-graph
-Print a mermaid-js visualization of the cargo build graph as understood by cargo-vet
+Print the cargo build graph as understood by `cargo vet`
+
+This is a debugging command, the output's format is not guaranteed. Use `cargo metadata` to get a
+stable version of what *cargo* thinks the build graph is. Our graph is based on that result.
+
+With `--output-format=human` (the default) this will print out mermaid-js diagrams, which things
+like github natively support rendering of.
+
+With `--output-format=json` we will print out more raw statistics for you to search/analyze.
+
+Most projects will have unreadably complex build graphs, so you may want to use the global
+`--filter-graph` argument to narrow your focus on an interesting subgraph. `--filter-graph` is
+applied *before* doing any semantic analysis, so if you filter out a package and it was the problem,
+the problem will disappear. This can be used to bisect a problem if you get ambitious enough with
+your filters.
 
 ### USAGE
 ```
@@ -483,7 +646,7 @@ This subcommand accepts all the [global options](#global-options)
 ## cargo vet gc
 Clean up old packages from the vet cache
 
-Removes  packages which haven't been accessed in a while, and deletes any extra files which aren't
+Removes packages which haven't been accessed in a while, and deletes any extra files which aren't
 recognized by cargo-vet.
 
 In the future, many cargo-vet subcommands will implicitly do this.

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -392,13 +392,22 @@ Print help information
 ### GLOBAL OPTIONS
 This subcommand accepts all the [global options](#global-options)
 ### SUBCOMMANDS
-* [exemptions](#cargo-vet-exemptions): 
-* [imports](#cargo-vet-imports): Suggest some low-hanging fruit to review
-* [audit-as-crates-io](#cargo-vet-audit-as-crates-io): Initialize cargo-vet for your project
+* [exemptions](#cargo-vet-exemptions): Regenerate your exemptions to make `check` pass minimally
+* [imports](#cargo-vet-imports): Regenerate your imports and accept changes to criteria
+* [audit-as-crates-io](#cargo-vet-audit-as-crates-io): Regenerate you audit-as-crates-io entries to make `check` pass
 * [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 
 <br><br><br>
 ## cargo vet exemptions
+Regenerate your exemptions to make `check` pass minimally
+
+This command can be used for two purposes: to force your supply-chain to pass `check` when it's
+currently failing, or to minimize/garbage-collect your exemptions when it's already passing. These
+are ultimately the same operation.
+
+We will try our best to preserve existing exemptions, removing only those that aren't needed,
+and adding only those that are needed. Exemptions that are overbroad may also be weakened (i.e.
+safe-to-deploy may be reduced to safe-to-run).
 
 ### USAGE
 ```
@@ -414,7 +423,10 @@ This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet imports
-Suggest some low-hanging fruit to review
+Regenerate your imports and accept changes to criteria
+
+This is equivalent to `cargo vet fetch-imports` but it won't produce an error if the descriptions of
+foreign criteria change.
 
 ### USAGE
 ```
@@ -430,7 +442,9 @@ This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet audit-as-crates-io
-Initialize cargo-vet for your project
+Regenerate you audit-as-crates-io entries to make `check` pass
+
+This will just set any problematic entries to `audit-as-crates-io = false`.
 
 ### USAGE
 ```

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -55,23 +55,20 @@ GLOBAL OPTIONS:
             Filter out different parts of the build graph and pretend that's the true graph
 
 SUBCOMMANDS:
-    check                     [default] Check that the current project has been vetted
-    init                      Initialize cargo-vet for your project
-    accept-criteria-change    Accept changes that a foreign audits.toml made to their criteria
-    inspect                   Fetch the source of `$package $version`
-    diff                      Yield a diff against the last reviewed version
-    certify                   Mark `$package $version` as reviewed
-    add-unaudited             Mark `$package $version` as unaudited
-    record-violation          Mark `$package $version` as a violation of policy
-    suggest                   Suggest some low-hanging fruit to review
-    fmt                       Reformat all of vet's files (in case you hand-edited them)
-    fetch-imports             Explicitly fetch the imports (foreign audit files)
-    regenerate-unaudited      Regenerate the 'unaudited' entries to try to minimize them and
-                                  make the vet pass
-    dump-graph                Print a mermaid-js visualization of the cargo build graph as
-                                  understood by cargo-vet
-    gc                        Clean up old packages from the vet cache
-    help                      Print this message or the help of the given subcommand(s)
+    check               \[default\] Check that the current project has been vetted
+    suggest             Suggest some low-hanging fruit to review
+    init                Initialize cargo-vet for your project
+    inspect             Fetch the source of a package
+    diff                Yield a diff against the last reviewed version
+    certify             Mark a package as audited
+    regenerate          Explicitly regenerate various pieces of information
+    add-exemption       Mark a package as exempted from review
+    record-violation    Declare that some versions of a package violate certain audit criteria
+    fmt                 Reformat all of vet's files (in case you hand-edited them)
+    fetch-imports       Explicitly fetch the imports (foreign audit files)
+    dump-graph          Print the cargo build graph as understood by `cargo vet`
+    gc                  Clean up old packages from the vet cache
+    help                Print this message or the help of the given subcommand(s)
 
 stderr:
 

--- a/tests/snapshots/test_cli__test-project-json.snap
+++ b/tests/snapshots/test_cli__test-project-json.snap
@@ -33,7 +33,7 @@ stdout:
       "version": "0.3.7"
     }
   ],
-  "vetted_with_unaudited": [
+  "vetted_with_exemptions": [
     {
       "name": "libc",
       "version": "0.2.123"

--- a/tests/snapshots/test_cli__test-project.snap
+++ b/tests/snapshots/test_cli__test-project.snap
@@ -3,7 +3,7 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-Vetting Succeeded (5 fully audited, 1 partially audited, 98 unaudited)
+Vetting Succeeded (5 fully audited, 1 partially audited, 98 exempted)
 
 stderr:
 

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -4,401 +4,401 @@
 [policy.test-project]
 audit-as-crates-io = false
 
-[[unaudited.bumpalo]]
+[[exemptions.bumpalo]]
 version = "3.9.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.bytes]]
+[[exemptions.bytes]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.cc]]
+[[exemptions.cc]]
 version = "1.0.73"
 criteria = "safe-to-deploy"
 
-[[unaudited.cfg-if]]
+[[exemptions.cfg-if]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.core-foundation]]
+[[exemptions.core-foundation]]
 version = "0.9.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.core-foundation-sys]]
+[[exemptions.core-foundation-sys]]
 version = "0.8.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.encoding_rs]]
+[[exemptions.encoding_rs]]
 version = "0.8.31"
 criteria = "safe-to-deploy"
 
-[[unaudited.fastrand]]
+[[exemptions.fastrand]]
 version = "1.7.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.fnv]]
+[[exemptions.fnv]]
 version = "1.0.7"
 criteria = "safe-to-deploy"
 
-[[unaudited.foreign-types]]
+[[exemptions.foreign-types]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.foreign-types-shared]]
+[[exemptions.foreign-types-shared]]
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.form_urlencoded]]
+[[exemptions.form_urlencoded]]
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.futures-channel]]
+[[exemptions.futures-channel]]
 version = "0.3.21"
 criteria = "safe-to-deploy"
 
-[[unaudited.futures-core]]
+[[exemptions.futures-core]]
 version = "0.3.21"
 criteria = "safe-to-deploy"
 
-[[unaudited.futures-sink]]
+[[exemptions.futures-sink]]
 version = "0.3.21"
 criteria = "safe-to-deploy"
 
-[[unaudited.futures-task]]
+[[exemptions.futures-task]]
 version = "0.3.21"
 criteria = "safe-to-deploy"
 
-[[unaudited.futures-util]]
+[[exemptions.futures-util]]
 version = "0.3.21"
 criteria = "safe-to-deploy"
 
-[[unaudited.h2]]
+[[exemptions.h2]]
 version = "0.3.13"
 criteria = "safe-to-deploy"
 
-[[unaudited.hashbrown]]
+[[exemptions.hashbrown]]
 version = "0.11.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.hermit-abi]]
+[[exemptions.hermit-abi]]
 version = "0.1.19"
 criteria = "safe-to-deploy"
 
-[[unaudited.http]]
+[[exemptions.http]]
 version = "0.2.6"
 criteria = "safe-to-deploy"
 
-[[unaudited.http-body]]
+[[exemptions.http-body]]
 version = "0.4.4"
 criteria = "safe-to-deploy"
 
-[[unaudited.httparse]]
+[[exemptions.httparse]]
 version = "1.7.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.httpdate]]
+[[exemptions.httpdate]]
 version = "1.0.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.hyper]]
+[[exemptions.hyper]]
 version = "0.14.18"
 criteria = "safe-to-deploy"
 
-[[unaudited.hyper-tls]]
+[[exemptions.hyper-tls]]
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.idna]]
+[[exemptions.idna]]
 version = "0.2.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.indexmap]]
+[[exemptions.indexmap]]
 version = "1.8.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.instant]]
+[[exemptions.instant]]
 version = "0.1.12"
 criteria = "safe-to-deploy"
 
-[[unaudited.ipnet]]
+[[exemptions.ipnet]]
 version = "2.4.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.itoa]]
+[[exemptions.itoa]]
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.js-sys]]
+[[exemptions.js-sys]]
 version = "0.3.57"
 criteria = "safe-to-deploy"
 
-[[unaudited.lazy_static]]
+[[exemptions.lazy_static]]
 version = "1.4.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.libc]]
+[[exemptions.libc]]
 version = "0.2.123"
 criteria = "safe-to-deploy"
 
-[[unaudited.log]]
+[[exemptions.log]]
 version = "0.4.16"
 criteria = "safe-to-deploy"
 
-[[unaudited.matches]]
+[[exemptions.matches]]
 version = "0.1.9"
 criteria = "safe-to-deploy"
 
-[[unaudited.memchr]]
+[[exemptions.memchr]]
 version = "2.4.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.mime]]
+[[exemptions.mime]]
 version = "0.3.16"
 criteria = "safe-to-deploy"
 
-[[unaudited.mio]]
+[[exemptions.mio]]
 version = "0.8.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.miow]]
+[[exemptions.miow]]
 version = "0.3.7"
 criteria = "safe-to-deploy"
 
-[[unaudited.native-tls]]
+[[exemptions.native-tls]]
 version = "0.2.10"
 criteria = "safe-to-deploy"
 
-[[unaudited.ntapi]]
+[[exemptions.ntapi]]
 version = "0.3.7"
 criteria = "safe-to-deploy"
 
-[[unaudited.once_cell]]
+[[exemptions.once_cell]]
 version = "1.10.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.openssl]]
+[[exemptions.openssl]]
 version = "0.10.38"
 criteria = "safe-to-deploy"
 
-[[unaudited.openssl-probe]]
+[[exemptions.openssl-probe]]
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
-[[unaudited.openssl-sys]]
+[[exemptions.openssl-sys]]
 version = "0.9.72"
 criteria = "safe-to-deploy"
 
-[[unaudited.os_str_bytes]]
+[[exemptions.os_str_bytes]]
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.percent-encoding]]
+[[exemptions.percent-encoding]]
 version = "2.1.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.pin-project-lite]]
+[[exemptions.pin-project-lite]]
 version = "0.2.8"
 criteria = "safe-to-deploy"
 
-[[unaudited.pin-utils]]
+[[exemptions.pin-utils]]
 version = "0.1.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.pkg-config]]
+[[exemptions.pkg-config]]
 version = "0.3.25"
 criteria = "safe-to-deploy"
 
-[[unaudited.proc-macro2]]
+[[exemptions.proc-macro2]]
 version = "1.0.37"
 criteria = "safe-to-deploy"
 
-[[unaudited.quote]]
+[[exemptions.quote]]
 version = "1.0.18"
 criteria = "safe-to-deploy"
 
-[[unaudited.redox_syscall]]
+[[exemptions.redox_syscall]]
 version = "0.2.13"
 criteria = "safe-to-deploy"
 
-[[unaudited.remove_dir_all]]
+[[exemptions.remove_dir_all]]
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.reqwest]]
+[[exemptions.reqwest]]
 version = "0.11.10"
 criteria = "safe-to-deploy"
 
-[[unaudited.ryu]]
+[[exemptions.ryu]]
 version = "1.0.9"
 criteria = "safe-to-deploy"
 
-[[unaudited.schannel]]
+[[exemptions.schannel]]
 version = "0.1.19"
 criteria = "safe-to-deploy"
 
-[[unaudited.security-framework]]
+[[exemptions.security-framework]]
 version = "2.6.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.security-framework-sys]]
+[[exemptions.security-framework-sys]]
 version = "2.6.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.serde]]
+[[exemptions.serde]]
 version = "1.0.136"
 criteria = "safe-to-deploy"
 
-[[unaudited.serde_json]]
+[[exemptions.serde_json]]
 version = "1.0.79"
 criteria = "safe-to-deploy"
 
-[[unaudited.serde_urlencoded]]
+[[exemptions.serde_urlencoded]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.slab]]
+[[exemptions.slab]]
 version = "0.4.6"
 criteria = "safe-to-deploy"
 
-[[unaudited.socket2]]
+[[exemptions.socket2]]
 version = "0.4.4"
 criteria = "safe-to-deploy"
 
-[[unaudited.strsim]]
+[[exemptions.strsim]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
 suggest = false
 
-[[unaudited.syn]]
+[[exemptions.syn]]
 version = "1.0.91"
 criteria = "safe-to-deploy"
 
-[[unaudited.tempfile]]
+[[exemptions.tempfile]]
 version = "3.3.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.termcolor]]
+[[exemptions.termcolor]]
 version = "1.1.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.textwrap]]
+[[exemptions.textwrap]]
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.tinyvec]]
+[[exemptions.tinyvec]]
 version = "1.5.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.tinyvec_macros]]
+[[exemptions.tinyvec_macros]]
 version = "0.1.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.tokio]]
+[[exemptions.tokio]]
 version = "1.17.0"
 criteria = "safe-to-deploy"
 notes = "this message shouldn't get randomly clobbered"
 
-[[unaudited.tokio-native-tls]]
+[[exemptions.tokio-native-tls]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.tokio-util]]
+[[exemptions.tokio-util]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.tower-service]]
+[[exemptions.tower-service]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
-[[unaudited.tracing]]
+[[exemptions.tracing]]
 version = "0.1.33"
 criteria = "safe-to-deploy"
 
-[[unaudited.tracing-attributes]]
+[[exemptions.tracing-attributes]]
 version = "0.1.20"
 criteria = "safe-to-deploy"
 
-[[unaudited.tracing-core]]
+[[exemptions.tracing-core]]
 version = "0.1.25"
 criteria = "safe-to-deploy"
 
-[[unaudited.try-lock]]
+[[exemptions.try-lock]]
 version = "0.2.3"
 criteria = "safe-to-deploy"
 
-[[unaudited.unicode-bidi]]
+[[exemptions.unicode-bidi]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.unicode-normalization]]
+[[exemptions.unicode-normalization]]
 version = "0.1.19"
 criteria = "safe-to-deploy"
 
-[[unaudited.unicode-xid]]
+[[exemptions.unicode-xid]]
 version = "0.2.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.url]]
+[[exemptions.url]]
 version = "2.2.2"
 criteria = "safe-to-deploy"
 
-[[unaudited.vcpkg]]
+[[exemptions.vcpkg]]
 version = "0.2.15"
 criteria = "safe-to-deploy"
 
-[[unaudited.want]]
+[[exemptions.want]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasi]]
+[[exemptions.wasi]]
 version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen]]
+[[exemptions.wasm-bindgen]]
 version = "0.2.80"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen-backend]]
+[[exemptions.wasm-bindgen-backend]]
 version = "0.2.80"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen-futures]]
+[[exemptions.wasm-bindgen-futures]]
 version = "0.4.30"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen-macro]]
+[[exemptions.wasm-bindgen-macro]]
 version = "0.2.80"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen-macro-support]]
+[[exemptions.wasm-bindgen-macro-support]]
 version = "0.2.80"
 criteria = "safe-to-deploy"
 
-[[unaudited.wasm-bindgen-shared]]
+[[exemptions.wasm-bindgen-shared]]
 version = "0.2.80"
 criteria = "safe-to-deploy"
 
-[[unaudited.web-sys]]
+[[exemptions.web-sys]]
 version = "0.3.57"
 criteria = "safe-to-deploy"
 
-[[unaudited.winapi]]
+[[exemptions.winapi]]
 version = "0.3.9"
 criteria = "safe-to-deploy"
 
-[[unaudited.winapi-i686-pc-windows-gnu]]
+[[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.winapi-util]]
+[[exemptions.winapi-util]]
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
-[[unaudited.winapi-x86_64-pc-windows-gnu]]
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[unaudited.winreg]]
+[[exemptions.winreg]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 


### PR DESCRIPTION
Fixes #228 
Fixes #193 

* first commit: mostly doc/cli changes that get cleaned up in subsequent commits. (initial shifts to "exemptions" happens here and is smeared through the commits, but most changes are in the last commit)

* second commit: `regenerate audit-as-crates-io` impl, just runs check_audit_as_crates_io and sets all erroring policies to `Some(false)`. This is now implicitly performed by `init` so that `check` will be guaranteed to pass again.

* third commit: `regenerate imports` impl. This is identical to `fetch imports` except it sets an `accept_changes` flag to true. The bulk of the change here is to execute `eula_for_criteria` while fetching the imports to cache the value in `description` if it has a `description_url` and to check if it differs from the previously cached value (if it exists). The `accept_changes` flag determines if a mismatch is an error.

* fourth commit: "exemptions" rename. I avoided renaming some of the test files to minimize the diff on the tests. We can finish that in a second pass.

The second and third commit both merit me writing some tests for that functionality. The second is kinda trivial, while the third would require me setting up a new kind of test that can mock the fetch..?
