### PR TITLE
remove references to unimplemented 'targets' handling

### DIFF
--- a/book/src/audit-entries.md
+++ b/book/src/audit-entries.md
@@ -37,19 +37,6 @@ the dependency even if it's listed in the `unaudited` table.
 
 Specifies the relevant criteria for this audit. This field is required.
 
-## `targets`
-
-A string or array of strings specifying the targets for which this audit is
-valid.
-
-Unless otherwise specified, audit entries are assumed to apply to all platforms.
-However, they can optionally be restricted to certain platforms (so that, for
-example, an auditor can skim over complicated assembly code for a platform that
-their project doesn't target).
-
-The syntax for this field mirrors Cargo's syntax for [platform-specific
-dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies).
-
 ## `who`
 
 A string identifying the auditor. When invoking `cargo vet certify`, the

--- a/book/src/config.md
+++ b/book/src/config.md
@@ -146,21 +146,6 @@ entries.
 
 Defaults to the empty set and is not inherited.
 
-#### `targets`
-
-A string or array of target specifiers for the platforms of interest for this
-top-level crate. These are the platforms that `cargo vet` will require audits
-for when traversing the subtree (audits can optionally [restrict their
-validity](audit-entries.md#targets) to a set of targets).
-
-For top-level crates, defaults to all platforms.
-
-#### `dev-targets`
-
-Same as the above, but applied to dev-dependencies.
-
-For top-level crates, defaults to all platforms.
-
 #### `notes`
 
 Free-form string for recording rationale or other relevant information.

--- a/book/src/specifying-policies.md
+++ b/book/src/specifying-policies.md
@@ -11,10 +11,6 @@ requirements more precisely, such as:
 * **Using different criteria for different top-level crates.** Your workspace
   might contain both a production product and an internal tool, which might
 require different levels of audits for their dependencies.
-* **Ignoring targets you don't support.** Some dependencies are only built for
-  certain platforms. Additionally, audit records can [specify](audit-entries.md#targets)
-  that they do not cover platform-specific code for certain targets. You can
-  leverage these details by scoping `cargo vet` to your platforms of interest.
 
 If the default behavior works for you, there's no need to specify anything. If
 you wish to encode policies such as the above, you can do so in

--- a/src/format.rs
+++ b/src/format.rs
@@ -356,13 +356,6 @@ pub struct PolicyEntry {
     #[serde(with = "serialization::string_or_vec_or_none")]
     pub dev_criteria: Option<Vec<Spanned<CriteriaName>>>,
 
-    /// TODO: figure this out
-    pub targets: Option<Vec<String>>,
-
-    /// `targets` but for dev-deps
-    #[serde(rename = "dev-targets")]
-    pub dev_targets: Option<Vec<String>>,
-
     /// Custom criteria for a specific first-party crate's dependencies.
     ///
     /// Any dependency edge that isn't explicitly specified defaults to `criteria`.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -420,8 +420,6 @@ fn default_policy() -> PolicyEntry {
         criteria: None,
         dev_criteria: None,
         dependency_criteria: SortedMap::new(),
-        targets: None,
-        dev_targets: None,
         notes: None,
     }
 }
@@ -932,8 +930,6 @@ fn files_inited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFile) {
                         criteria: Some(vec![DEFAULT_CRIT.to_string().into()]),
                         dev_criteria: Some(vec![DEFAULT_CRIT.to_string().into()]),
                         dependency_criteria: DependencyCriteria::new(),
-                        targets: None,
-                        dev_targets: None,
                         notes: None,
                     },
                 );


### PR DESCRIPTION
This wasn't implemented, and it's not entirely clear how it would behave, so we're removing references to it to avoid confusion.

Fixes #249