### PR TITLE
namespace and map criteria properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-vet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,25 +740,30 @@ fn do_cmd_certify(
             writeln!(out);
             writeln!(out, "  0. <clear selections>");
             let implied_criteria = criteria_mapper.criteria_from_list(&chosen_criteria);
-            for (criteria_idx, (_namespace, criteria_name, _criteria_entry)) in
-                criteria_mapper.list.iter().enumerate()
-            {
-                if chosen_criteria.contains(criteria_name) {
+            for (criteria_idx, criteria_info) in criteria_mapper.list.iter().enumerate() {
+                if chosen_criteria.contains(&criteria_info.namespaced_name) {
                     writeln!(
                         out,
                         "  {}. {}",
                         criteria_idx + 1,
-                        out.style().green().apply_to(criteria_name)
+                        out.style().green().apply_to(&criteria_info.namespaced_name)
                     );
                 } else if implied_criteria.has_criteria(criteria_idx) {
                     writeln!(
                         out,
                         "  {}. {}",
                         criteria_idx + 1,
-                        out.style().yellow().apply_to(criteria_name)
+                        out.style()
+                            .yellow()
+                            .apply_to(&criteria_info.namespaced_name)
                     );
                 } else {
-                    writeln!(out, "  {}. {}", criteria_idx + 1, criteria_name);
+                    writeln!(
+                        out,
+                        "  {}. {}",
+                        criteria_idx + 1,
+                        &criteria_info.namespaced_name
+                    );
                 }
             }
 
@@ -798,7 +803,7 @@ fn do_cmd_certify(
                 writeln!(out, "error: not a valid criteria");
                 continue;
             }
-            chosen_criteria.push(criteria_mapper.list[answer - 1].1.clone());
+            chosen_criteria.push(criteria_mapper.list[answer - 1].namespaced_name.clone());
         }
         chosen_criteria
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,7 +705,12 @@ fn do_cmd_certify(
         (user_info.username, Some(who))
     };
 
-    let criteria_mapper = CriteriaMapper::new(&store.audits.criteria);
+    //let foreign_criteria = store.imports.iter().map();
+    let criteria_mapper = CriteriaMapper::new(
+        &store.audits.criteria,
+        &store.imports,
+        &store.config.imports,
+    );
 
     let criteria_names = if sub_args.criteria.is_empty() {
         let (from, to) = match &kind {
@@ -735,7 +740,7 @@ fn do_cmd_certify(
             writeln!(out);
             writeln!(out, "  0. <clear selections>");
             let implied_criteria = criteria_mapper.criteria_from_list(&chosen_criteria);
-            for (criteria_idx, (criteria_name, _criteria_entry)) in
+            for (criteria_idx, (_namespace, criteria_name, _criteria_entry)) in
                 criteria_mapper.list.iter().enumerate()
             {
                 if chosen_criteria.contains(criteria_name) {
@@ -793,7 +798,7 @@ fn do_cmd_certify(
                 writeln!(out, "error: not a valid criteria");
                 continue;
             }
-            chosen_criteria.push(criteria_mapper.list[answer - 1].0.clone());
+            chosen_criteria.push(criteria_mapper.list[answer - 1].1.clone());
         }
         chosen_criteria
     } else {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -534,7 +534,7 @@ impl CriteriaMapper {
         namespace: &CriteriaNamespace,
         criteria: CriteriaStr,
     ) {
-        set.set_criteria(self.index[namespace][criteria])
+        set.unioned_with(&self.implied_criteria[self.index[namespace][criteria]])
     }
     pub fn clear_criteria(&self, set: &mut CriteriaFailureSet, criteria: CriteriaStr) {
         self.clear_namespaced_criteria(set, &CriteriaNamespace::Local, criteria)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -34,6 +34,12 @@ mod violations;
 const DEFAULT_VER: u64 = 10;
 const DEFAULT_CRIT: CriteriaStr = "reviewed";
 
+// Some strings for imports
+const FOREIGN: &str = "peer-company";
+const FOREIGN_URL: &str = "https://peercompany.co.uk";
+const OTHER_FOREIGN: &str = "rival-company";
+const OTHER_FOREIGN_URL: &str = "https://rivalcompany.ca";
+
 lazy_static::lazy_static! {
     static ref TEST_RUNTIME: tokio::runtime::Runtime = {
         let error_colors_enabled = false;
@@ -1156,15 +1162,6 @@ impl Out for BasicTestOutput {
 //      * which is a third-party
 //      * with different policies
 //         * where only the weaker one is satisfied (fail but give good diagnostic)
-//
-// * foreign mappings
-//   * only using builtins
-//   * 1:1 explicit mappings
-//   * asymmetric cases
-//   * missing mappings
-//   * foreign has criteria with the same name, unmapped (don't accidentally mix it up)
-//   * foreign has criteria with the same name, mapped to that name
-//   * foreign has criteria with the same name, mapped to a different name
 //
 // * misc
 //   * git deps are first party but not in workspace

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-certify-flow.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-simple-certify-flow.snap
@@ -6,12 +6,12 @@ OUTPUT:
 <<<CLEAR SCREEN>>>
 choose criteria to certify for third-party1:10.0.0
   0. <clear selections>
-  1. fuzzed
-  2. reviewed
-  3. strong-reviewed
-  4. weak-reviewed
-  5. safe-to-deploy
-  6. safe-to-run
+  1. safe-to-run
+  2. safe-to-deploy
+  3. fuzzed
+  4. reviewed
+  5. strong-reviewed
+  6. weak-reviewed
 
 current selection: ["reviewed"]
 (press ENTER to accept the current criteria)

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Succeeded (3 fully audited)
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Failed!
+
+1 unvetted dependencies:
+  transitive-third-party1:10.0.0 missing ["peer-company::reviewed"]
+
+recommended audits for peer-company::reviewed:
+    cargo vet inspect transitive-third-party1 10.0.0  (used by third-party1)  (100 lines)
+
+estimated audit backlog: 100 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/vet.rs
-assertion_line: 2821
 expression: output
 ---
 Vetting Succeeded (3 fully audited)

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.snap.new
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.snap.new
@@ -1,0 +1,7 @@
+---
+source: src/tests/vet.rs
+assertion_line: 2821
+expression: output
+---
+Vetting Succeeded (3 fully audited)
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Succeeded (3 fully audited)
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Succeeded (3 fully audited)
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Succeeded (3 fully audited)
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.snap
@@ -1,0 +1,18 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Failed!
+
+2 unvetted dependencies:
+  third-party1:10.0.0 missing ["reviewed"]
+  third-party2:10.0.0 missing ["reviewed"]
+
+recommended audits for reviewed:
+    cargo vet inspect third-party1 10.0.0  (used by first-party)  (100 lines)
+    cargo vet inspect third-party2 10.0.0  (used by first-party)  (100 lines)
+
+estimated audit backlog: 200 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.snap
@@ -1,0 +1,18 @@
+---
+source: src/tests/vet.rs
+expression: output
+---
+Vetting Failed!
+
+2 unvetted dependencies:
+  third-party1:10.0.0 missing ["reviewed"]
+  third-party2:10.0.0 missing ["reviewed"]
+
+recommended audits for reviewed:
+    cargo vet inspect third-party1 10.0.0  (used by first-party)  (100 lines)
+    cargo vet inspect third-party2 10.0.0  (used by first-party)  (100 lines)
+
+estimated audit backlog: 200 lines
+
+Use |cargo vet certify| to record the audits.
+

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -3,7 +3,7 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-cargo-vet 0.1.0
+cargo-vet 0.2.0
 Supply-chain security for Rust
 
 When run without a subcommand, `cargo vet` will invoke the `check` subcommand. See `cargo vet help

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -7,7 +7,7 @@ stdout:
 
 > This manual can be regenerated with `cargo vet help-markdown`
 
-Version: `cargo-vet 0.1.0`
+Version: `cargo-vet 0.2.0`
 
 Supply-chain security for Rust
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -3,7 +3,7 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-cargo-vet 0.1.0
+cargo-vet 0.2.0
 Supply-chain security for Rust
 
 USAGE:


### PR DESCRIPTION
fixes #240 in principle, but needs ALLLL the tests

This ended up being less gnarly than I expected, I especially like that it results in a bunch of duplication getting removed. 

Right now I have duped all the APIs as `criteria_mapper.blah(...)` and `criteria_mapper.namespaced_blah(namespace, ...)`. The non-namespaced version is implicitly Local. It's convenient but a potential footgun. Not sure if it should be removed in favour of all call-sites being explicit (anything from audits.toml and config.toml is always local, except for the foreign mappings themselves). 