### PR TITLE
Update imports.lock less frequently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "similar",
  "tar",
  "tempfile",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,4 @@ features = [
 
 [dev-dependencies]
 insta = "1.15.0"
+similar = "2.1.0"

--- a/src/format.rs
+++ b/src/format.rs
@@ -162,6 +162,14 @@ pub struct AuditEntry {
     pub criteria: Vec<Spanned<CriteriaName>>,
     pub kind: AuditKind,
     pub notes: Option<String>,
+    /// A non-serialized member which indicates whether this audit is a "fresh"
+    /// audit. This will be set for all audits imported found in the remote
+    /// audits file which aren't also found in the local `imports.lock` cache.
+    ///
+    /// This should almost always be `false`, and only set to `true` by the
+    /// import handling code.
+    #[serde(skip)]
+    pub is_fresh_import: bool,
 }
 
 /// Implement PartialOrd manually because the order we want for sorting is

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -234,6 +234,9 @@ pub mod audit {
                 notes: val.notes,
                 criteria: val.criteria,
                 kind: kind?,
+                // By default, always read entries as non-fresh. The import code
+                // will set this flag to true for imported entries.
+                is_fresh_import: false,
             })
         }
     }
@@ -605,6 +608,7 @@ mod test {
                         dependency_criteria: dc_long,
                     },
                     notes: Some("notes go here!".to_owned()),
+                    is_fresh_import: false, // ignored
                 },
                 AuditEntry {
                     who: None,
@@ -614,6 +618,7 @@ mod test {
                         dependency_criteria: dc_short,
                     },
                     notes: Some("notes go here!".to_owned()),
+                    is_fresh_import: true, // ignored
                 },
             ],
         );

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -273,6 +273,26 @@ impl Store {
         Ok(())
     }
 
+    /// Mock `commit`. Returns the serialized value for each file in the store.
+    /// Doesn't take `self` by value so that it can continue to be used.
+    #[cfg(test)]
+    pub fn mock_commit(&self) -> SortedMap<String, String> {
+        let mut audits = Vec::new();
+        let mut config = Vec::new();
+        let mut imports = Vec::new();
+        store_audits(&mut audits, self.audits.clone()).unwrap();
+        store_config(&mut config, self.config.clone()).unwrap();
+        store_imports(&mut imports, self.imports.clone()).unwrap();
+
+        [
+            (AUDITS_TOML.to_owned(), String::from_utf8(audits).unwrap()),
+            (CONFIG_TOML.to_owned(), String::from_utf8(config).unwrap()),
+            (IMPORTS_LOCK.to_owned(), String::from_utf8(imports).unwrap()),
+        ]
+        .into_iter()
+        .collect()
+    }
+
     /// Validate the store's integrity
     #[allow(clippy::for_kv_map)]
     pub fn validate(&self) -> Result<(), StoreValidateErrors> {

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -1,0 +1,738 @@
+use super::*;
+
+// Helper function for imports tests. Performs a vet and updates imports based
+// on it, returning a diff of the two.
+fn get_imports_file_changes(metadata: &Metadata, store: &Store, force_updates: bool) -> String {
+    // Run the resolver before calling `get_imports_file` to compute the new
+    // imports file.
+    let report = crate::resolver::resolve(metadata, None, store, ResolveDepth::Shallow);
+    let new_imports = store.get_updated_imports_file(&report, force_updates);
+
+    // Format the old and new files as TOML, and write out a diff using `similar`.
+    let old_imports = crate::serialization::to_formatted_toml(&store.imports)
+        .unwrap()
+        .to_string();
+    let new_imports = crate::serialization::to_formatted_toml(new_imports)
+        .unwrap()
+        .to_string();
+
+    generate_diff(&old_imports, &new_imports)
+}
+
+// Test cases:
+
+#[test]
+fn new_peer_import() {
+    // (Pass) We import all audits for our third-party packages from a brand-new
+    // peer even though we are already fully audited. This won't force an import
+    // from existing peers.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [
+            (
+                "third-party2".to_owned(),
+                vec![delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY)],
+            ),
+            (
+                "unused-package".to_owned(),
+                vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    let old_other_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    let new_other_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![delta_audit(ver(200), ver(300), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    imports
+        .audits
+        .insert(OTHER_FOREIGN.to_owned(), old_other_foreign_audits);
+
+    config.imports.insert(
+        OTHER_FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: OTHER_FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![
+            (FOREIGN.to_owned(), new_foreign_audits),
+            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
+        ],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_skip_import() {
+    // (Pass) If we've previously imported from a peer, we don't import
+    // audits for a package unless it's useful.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [
+            (
+                "third-party2".to_owned(),
+                vec![delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY)],
+            ),
+            (
+                "unused-package".to_owned(),
+                vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_remove_unused() {
+    // (Pass) We'll remove unused audits when unlocked, even if our peer hasn't
+    // changed.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [
+            (
+                "third-party2".to_owned(),
+                vec![delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY)],
+            ),
+            (
+                "unused-package".to_owned(),
+                vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    let new_foreign_audits = old_foreign_audits.clone();
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_import_delta_audit() {
+    // (Pass) If a new delta audit from a peer is useful, we'll import it and
+    // all other audits for that crate, including from other peers.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    audits.audits.remove("third-party2");
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![full_audit(ver(9), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [
+            // A new audit for third-party2 should fix our audit, so we should
+            // import all of these.
+            (
+                "third-party2".to_owned(),
+                vec![
+                    full_audit(ver(9), SAFE_TO_DEPLOY),
+                    delta_audit(ver(9), ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+                    delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY),
+                ],
+            ),
+            // This audit won't change things for us, so we won't import it to
+            // avoid churn.
+            (
+                "third-party1".to_owned(),
+                vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    let old_other_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    let new_other_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        // We'll also import unrelated audits from other sources.
+        audits: [(
+            "third-party2".to_owned(),
+            vec![delta_audit(ver(200), ver(300), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    imports
+        .audits
+        .insert(OTHER_FOREIGN.to_owned(), old_other_foreign_audits);
+
+    config.imports.insert(
+        OTHER_FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: OTHER_FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![
+            (FOREIGN.to_owned(), new_foreign_audits),
+            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
+        ],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_import_custom_criteria() {
+    // (Pass) We'll immediately import criteria changes wen unlocked, even if
+    // our peer hasn't changed or we aren't mapping them locally. This doesn't
+    // force an import of other crates.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: [(
+            "fuzzed".to_string(),
+            CriteriaEntry {
+                implies: vec![],
+                description: Some("fuzzed".to_string()),
+                description_url: None,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![
+                full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+                delta_audit(ver(DEFAULT_VER), ver(11), SAFE_TO_DEPLOY),
+            ],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn new_audit_for_unused_criteria_basic() {
+    // (Pass) If a peer adds an audit for an unused criteria, we shouldn't
+    // vendor in the changes unnecessarily.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+    let old_foreign_audits = AuditsFile {
+        criteria: [(
+            "fuzzed".to_string(),
+            CriteriaEntry {
+                implies: vec![],
+                description: Some("fuzzed".to_string()),
+                description_url: None,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let mut new_foreign_audits = old_foreign_audits.clone();
+    new_foreign_audits
+        .audits
+        .get_mut("third-party2")
+        .unwrap()
+        .push(full_audit(ver(DEFAULT_VER), "fuzzed"));
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn new_audit_for_unused_criteria_transitive() {
+    // (Pass) If a peer adds an audit for an unused criteria of a transitive
+    // dependency, we shouldn't vendor in the changes unnecessarily.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+    let old_foreign_audits = AuditsFile {
+        criteria: [(
+            "fuzzed".to_string(),
+            CriteriaEntry {
+                implies: vec![],
+                description: Some("fuzzed".to_string()),
+                description_url: None,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party1".to_owned(),
+            vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let mut new_foreign_audits = old_foreign_audits.clone();
+    new_foreign_audits
+        .audits
+        .get_mut("third-party1")
+        .unwrap()
+        .push(full_audit(ver(DEFAULT_VER), "fuzzed"));
+    new_foreign_audits.audits.insert(
+        "transitive-third-party1".to_owned(),
+        vec![full_audit(ver(DEFAULT_VER), "fuzzed")],
+    );
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_revoked_audit() {
+    // (Pass) If a previously-imported audit is removed, we should also remove
+    // it locally, even if we don't use it.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn existing_peer_add_violation() {
+    // (Pass) If a peer adds a violation for any version of a crate we use, we
+    // should immediately import it. We won't immediately import other audits
+    // added for that crate, however.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![
+                delta_audit(ver(100), ver(200), SAFE_TO_DEPLOY),
+                delta_audit(ver(200), ver(300), SAFE_TO_DEPLOY),
+                violation(VersionReq::parse("99.*").unwrap(), SAFE_TO_DEPLOY),
+            ],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn peer_audits_exemption_no_minimize() {
+    // (Pass) We don't import audits for a package which would replace an
+    // exemption unless we're regenerating exemptions.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_inited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    let output = get_imports_file_changes(&metadata, &store, false);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn peer_audits_exemption_minimize() {
+    // (Pass) We do import audits for a package which would replace an exemption
+    // when we're regenerating exemptions.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, mut imports) = builtin_files_inited(&metadata);
+
+    let old_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: SortedMap::new(),
+    };
+
+    let new_foreign_audits = AuditsFile {
+        criteria: SortedMap::new(),
+        audits: [(
+            "third-party2".to_owned(),
+            vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    imports
+        .audits
+        .insert(FOREIGN.to_owned(), old_foreign_audits);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: FOREIGN_URL.to_owned(),
+            criteria_map: Vec::new(),
+        },
+    );
+
+    let mut store = Store::mock_online(
+        config,
+        audits,
+        imports,
+        vec![(FOREIGN.to_owned(), new_foreign_audits)],
+        true,
+    )
+    .unwrap();
+
+    // Capture the old imports before minimizing exemptions
+    let old = store.mock_commit();
+
+    crate::minimize_exemptions(&mock_cfg(&metadata), &mut store, None).unwrap();
+
+    // Capture after minimizing exemptions, and generate a diff.
+    let new = store.mock_commit();
+
+    let output = diff_store_commits(&old, &new);
+    insta::assert_snapshot!(output);
+}
+
+// Other tests worth adding:
+//
+// - used edges with dependency-criteria should cause criteria to be imported

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 
 mod audit_as_crates_io;
 mod certify;
+mod import;
 mod regenerate_unaudited;
 mod store_parsing;
 mod vet;
@@ -299,6 +300,7 @@ fn delta_audit(from: Version, to: Version, criteria: CriteriaStr) -> AuditEntry 
             delta,
             dependency_criteria: DependencyCriteria::default(),
         },
+        is_fresh_import: false,
     }
 }
 
@@ -331,6 +333,7 @@ fn delta_audit_dep(
                 })
                 .collect(),
         },
+        is_fresh_import: false,
     }
 }
 
@@ -343,6 +346,7 @@ fn full_audit(version: Version, criteria: CriteriaStr) -> AuditEntry {
             version,
             dependency_criteria: DependencyCriteria::default(),
         },
+        is_fresh_import: false,
     }
 }
 
@@ -358,6 +362,7 @@ fn full_audit_m(
             version,
             dependency_criteria: DependencyCriteria::default(),
         },
+        is_fresh_import: false,
     }
 }
 
@@ -387,6 +392,7 @@ fn full_audit_dep(
                 })
                 .collect(),
         },
+        is_fresh_import: false,
     }
 }
 
@@ -396,6 +402,7 @@ fn violation_hard(version: VersionReq) -> AuditEntry {
         notes: None,
         criteria: vec![SAFE_TO_RUN.to_string().into()],
         kind: AuditKind::Violation { violation: version },
+        is_fresh_import: false,
     }
 }
 #[allow(dead_code)]
@@ -405,6 +412,7 @@ fn violation(version: VersionReq, criteria: CriteriaStr) -> AuditEntry {
         notes: None,
         criteria: vec![criteria.to_string().into()],
         kind: AuditKind::Violation { violation: version },
+        is_fresh_import: false,
     }
 }
 #[allow(dead_code)]
@@ -417,6 +425,7 @@ fn violation_m(
         notes: None,
         criteria: criteria.into_iter().map(|s| s.into().into()).collect(),
         kind: AuditKind::Violation { violation: version },
+        is_fresh_import: false,
     }
 }
 

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_add_violation.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_add_violation.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "100.0.0 -> 200.0.0"
++
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++violation = "99.*"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_custom_criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_custom_criteria.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
++[audits.peer-company.criteria.fuzzed]
++description = "fuzzed"
++
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_delta_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_delta_audit.snap
@@ -1,0 +1,22 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "9.0.0"
+ 
+-[audits.rival-company.audits]
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++delta = "9.0.0 -> 10.0.0"
++
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++delta = "100.0.0 -> 200.0.0"
++
++[[audits.rival-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++delta = "200.0.0 -> 300.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "100.0.0 -> 200.0.0"
+-
+-[[audits.peer-company.audits.unused-package]]
+-criteria = "safe-to-deploy"
+-version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit.snap
@@ -1,0 +1,10 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+-[[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-deploy"
+-delta = "100.0.0 -> 200.0.0"
++[audits.peer-company.audits]
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_skip_import.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_skip_import.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [audits.peer-company.audits]
+

--- a/src/tests/snapshots/cargo_vet__tests__import__new_audit_for_unused_criteria_basic.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_audit_for_unused_criteria_basic.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [audits.peer-company.criteria.fuzzed]
+ description = "fuzzed"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__new_audit_for_unused_criteria_transitive.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_audit_for_unused_criteria_transitive.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [audits.peer-company.criteria.fuzzed]
+ description = "fuzzed"
+ 
+ [[audits.peer-company.audits.third-party1]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__new_peer_import.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_peer_import.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++delta = "100.0.0 -> 200.0.0"
++
+ [audits.rival-company.audits]
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+audits.toml: (unchanged)
+config.toml:
+ 
+ # cargo-vet config file
+ 
+ [imports.peer-company]
+ url = "https://peercompany.co.uk"
+ criteria-map = []
+ 
+ [[exemptions.third-party1]]
+ version = "10.0.0"
+ criteria = "safe-to-deploy"
+ 
+-[[exemptions.third-party2]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+-
+ [[exemptions.transitive-third-party1]]
+ version = "10.0.0"
+ criteria = "safe-to-deploy"
+ 
+
+imports.lock:
+ 
+ # cargo-vet imports lock
+ 
+-[audits.peer-company.audits]
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
+ 
+
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_no_minimize.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_no_minimize.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [audits.peer-company.audits]
+

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (1 fully audited, 3 exempted)
+Vetting Succeeded (4 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (1 fully audited, 3 exempted)
+Vetting Succeeded (4 exempted)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.snap
@@ -2,5 +2,5 @@
 source: src/tests/vet.rs
 expression: output
 ---
-Vetting Succeeded (5 fully audited, 1 partially audited)
+Vetting Succeeded (6 fully audited)
 


### PR DESCRIPTION
This patch reduces the frequency that imports.lock updates by doing a
few things:

 * Imports are only updated when necessary for the vet to pass. If vet
   would successfully pass without the new audits, only changes to
   notes, criteria descriptions, revoked audits, and violations will be
   pulled.

 * Some commands, such as suggest, will always run against the live
   copy when not --locked, providing the most accurate results possible.

 * Only audits for crates in your crate graph will be imported.

 * When an update is required, all new audits for the given crate will
   be fetched and locked, to batch updates as much as possible.

This required doing some changes to how imports are handled under the
hood, as well as a number of changes to the resolver in order to track
whether fresh imports are required with sufficient accuracy. Imports are
also now fetched in more APIs in order to have the most up-to-date
information.

The changes to the resolver involved piping through "caveats" which are
determined when solving paths. This is an expansion on the existing
"needs_exemption"/"fully_audited" flags which were being used to
generate stats after a successful vet to also handle freshly imported
audits which should only be used when necessary.

Special handling was also needed to make sure that audits for unused
criteria are not counted by tracking caveats on a per-criteria basis and
bubbling them out.

Fixes #272 