### PR TITLE
Generate json snapshots in all snapshot tests

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2706,7 +2706,7 @@ impl<'a> ResolveReport<'a> {
         Ok(())
     }
 
-    /// Print a full human-readable report
+    /// Print a full json report
     pub fn print_json(
         &self,
         out: &Arc<dyn Out>,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -23,6 +23,21 @@ use crate::{
     PackageExt, PartialConfig, SortedMap, Store,
 };
 
+/// Helper for performing an `assert_snapshot!` for the report output of a
+/// resolver invocation. This will generate both human and JSON reports for the
+/// given resolve report, and snapshot both. The JSON reports will have the
+/// suffix `.json`.
+///
+/// Unlike a normal `assert_snapshot!` the snapshot name isn't inferred by this
+/// macro, as multiple snapshots with different names need to be generated.
+macro_rules! assert_report_snapshot {
+    ($name:expr, $metadata:expr, $report:expr) => {{
+        let (human, json) = $crate::tests::get_reports(&$metadata, $report);
+        insta::assert_snapshot!($name, human);
+        insta::assert_snapshot!(concat!($name, ".json"), json);
+    }};
+}
+
 mod audit_as_crates_io;
 mod certify;
 mod regenerate_unaudited;
@@ -1051,18 +1066,23 @@ where
     }
 }
 
-fn get_report(metadata: &Metadata, report: ResolveReport) -> String {
+fn get_reports(metadata: &Metadata, report: ResolveReport) -> (String, String) {
     // FIXME: Figure out how to handle disabling output colours better in tests.
     console::set_colors_enabled(false);
     console::set_colors_enabled_stderr(false);
 
     let cfg = mock_cfg(metadata);
-    let output = BasicTestOutput::new();
     let suggest = report.compute_suggest(&cfg, None, true).unwrap();
+
+    let human_output = BasicTestOutput::new();
     report
-        .print_human(&output.clone().as_dyn(), &cfg, suggest.as_ref())
+        .print_human(&human_output.clone().as_dyn(), &cfg, suggest.as_ref())
         .unwrap();
-    output.to_string()
+    let json_output = BasicTestOutput::new();
+    report
+        .print_json(&json_output.clone().as_dyn(), &cfg, suggest.as_ref())
+        .unwrap();
+    (human_output.to_string(), json_output.to_string())
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-full-audited.json.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-inited.json.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-minimal-audited.json.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
@@ -1,0 +1,166 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 25,
+              "raw": "+25"
+            },
+            "from": "0.0.0",
+            "to": "5.0.0"
+          }
+        },
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "thirdA",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "thirdAB",
+          "notable_parents": "firstAB",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 25,
+            "raw": "+25"
+          },
+          "from": "0.0.0",
+          "to": "5.0.0"
+        }
+      },
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "thirdA",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "thirdAB",
+        "notable_parents": "firstAB",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 325
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-full-audited.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-inited.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-minimal-audited.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
@@ -1,0 +1,94 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev-cycle",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "normal",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "normal",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "dev-cycle",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "dev-cycle",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-full.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-minimal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-cursed-minimal.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
@@ -1,0 +1,242 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "simple-dev",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "simple-dev-indirect",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "both",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "normal",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "dev-cycle-direct",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "simple-dev",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "dev-cycle-indirect",
+          "notable_parents": "dev-cycle-direct",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "simple-dev-indirect",
+          "notable_parents": "simple-dev",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "both",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "dev-cycle-direct",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "simple-dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "dev-cycle-indirect",
+        "notable_parents": "dev-cycle-direct",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "simple-dev-indirect",
+        "notable_parents": "simple-dev",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 600
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
@@ -1,0 +1,168 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "simple-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "both",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "normal",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "dev-cycle-direct",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "simple-dev",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "both",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "dev-cycle-direct",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "simple-dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 400
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "both",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-cycle-direct",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev-indirect",
+      "version": "10.0.0"
+    },
+    {
+      "name": "simple-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-full-audited.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-init.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-dev",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-minimal-audited.json.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
@@ -1,0 +1,94 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "third-dev",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-normal",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-normal",
+          "notable_parents": "first",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "third-dev",
+          "notable_parents": "first",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-dev",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-normal",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
@@ -1,0 +1,94 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "third-dev",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-normal",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-normal",
+          "notable_parents": "first",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "third-dev",
+          "notable_parents": "first",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-dev",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-normal",
+        "notable_parents": "first",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-no-deps.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-no-deps.json.snap
@@ -1,0 +1,10 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-only-first-deps.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-only-first-deps.json.snap
@@ -1,0 +1,10 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "root-package",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "root-package",
+          "notable_parents": "",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "root-package",
+        "notable_parents": "",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "root-package",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "root-package",
+          "notable_parents": "",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "root-package",
+        "notable_parents": "",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
@@ -1,0 +1,28 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "root-package",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
@@ -1,0 +1,28 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "root-package",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-cycle.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 15,
+              "raw": "+15"
+            },
+            "from": "7.0.0",
+            "to": "8.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 15,
+            "raw": "+15"
+          },
+          "from": "7.0.0",
+          "to": "8.0.0"
+        }
+      }
+    ],
+    "total_lines": 15
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-broken-double-cycle.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 9,
+              "raw": "+9"
+            },
+            "from": "4.0.0",
+            "to": "5.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 9,
+            "raw": "+9"
+          },
+          "from": "4.0.0",
+          "to": "5.0.0"
+        }
+      }
+    ],
+    "total_lines": 9
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-cycle.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-double-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-delta-double-cycle.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-full-audited.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-init.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-minimal-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-minimal-audited.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
@@ -1,0 +1,242 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-run"
+      ],
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "build",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "build-proc-macro",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "normal",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "proc-macro",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ],
+      "safe-to-run": [
+        {
+          "name": "dev",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "dev-proc-macro",
+          "notable_parents": "root",
+          "suggested_criteria": [
+            "safe-to-run"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "build",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "build-proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "dev",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "dev-proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-run"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "normal",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "proc-macro",
+        "notable_parents": "root",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 600
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
@@ -1,0 +1,36 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-full-audited.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-init.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-long-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-long-cycle.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-noop-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-noop-delta.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-not-a-real-dep.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-not-a-real-dep.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-extra.json.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-delta.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-direct-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-direct-full.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-full.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-in-full.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-stronger-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-stronger-req.json.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "safe-to-deploy"
+      ],
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "safe-to-deploy": [
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req.json.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-overbroad.json.snap
@@ -1,0 +1,36 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-partial-twins.json.snap
@@ -1,0 +1,28 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-twins.json.snap
@@ -1,0 +1,28 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-useless-long-cycle.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-useless-long-cycle.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_audited.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "peer-company::reviewed"
+      ],
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "peer-company::reviewed": [
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "peer-company::reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "peer-company::reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_pass.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_tag_team.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_mega_foreign_tag_team.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 25,
+              "raw": "+25"
+            },
+            "from": "0.0.0",
+            "to": "5.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 25,
+            "raw": "+25"
+          },
+          "from": "0.0.0",
+          "to": "5.0.0"
+        }
+      }
+    ],
+    "total_lines": 25
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-full-audited.json.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-inited.json.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "5.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 25,
+              "raw": "+25"
+            },
+            "from": "0.0.0",
+            "to": "5.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 25,
+            "raw": "+25"
+          },
+          "from": "0.0.0",
+          "to": "5.0.0"
+        }
+      }
+    ],
+    "total_lines": 25
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
@@ -1,0 +1,166 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-core",
+      "version": "5.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "thirdA",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "thirdAB",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-core",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 25,
+              "raw": "+25"
+            },
+            "from": "0.0.0",
+            "to": "5.0.0"
+          }
+        },
+        {
+          "name": "third-core",
+          "notable_parents": "firstB, thirdA, thirdAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "thirdA",
+          "notable_parents": "firstA",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "thirdAB",
+          "notable_parents": "firstAB",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-core",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 25,
+            "raw": "+25"
+          },
+          "from": "0.0.0",
+          "to": "5.0.0"
+        }
+      },
+      {
+        "name": "third-core",
+        "notable_parents": "firstB, thirdA, thirdAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "thirdA",
+        "notable_parents": "firstA",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "thirdAB",
+        "notable_parents": "firstAB",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 325
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 9,
+              "raw": "-9"
+            },
+            "from": "5.0.0",
+            "to": "4.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 9,
+            "raw": "-9"
+          },
+          "from": "5.0.0",
+          "to": "4.0.0"
+        }
+      }
+    ],
+    "total_lines": 9
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 24,
+              "raw": "+24"
+            },
+            "from": "5.0.0",
+            "to": "7.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 24,
+            "raw": "+24"
+          },
+          "from": "5.0.0",
+          "to": "7.0.0"
+        }
+      }
+    ],
+    "total_lines": 24
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 25,
+              "raw": "+25"
+            },
+            "from": "0.0.0",
+            "to": "5.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 25,
+            "raw": "+25"
+          },
+          "from": "0.0.0",
+          "to": "5.0.0"
+        }
+      }
+    ],
+    "total_lines": 25
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 9,
+              "raw": "-9"
+            },
+            "from": "5.0.0",
+            "to": "4.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 9,
+            "raw": "-9"
+          },
+          "from": "5.0.0",
+          "to": "4.0.0"
+        }
+      }
+    ],
+    "total_lines": 9
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 24,
+              "raw": "+24"
+            },
+            "from": "5.0.0",
+            "to": "7.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 24,
+            "raw": "+24"
+          },
+          "from": "5.0.0",
+          "to": "7.0.0"
+        }
+      }
+    ],
+    "total_lines": 24
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited.json.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-full-audited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-full-audited.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 19,
+              "raw": "+19"
+            },
+            "from": "9.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 19,
+            "raw": "+19"
+          },
+          "from": "9.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 19
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 21,
+              "raw": "-21"
+            },
+            "from": "11.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 21,
+            "raw": "-21"
+          },
+          "from": "11.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 21
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-init.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [],
+  "vetted_partially": [],
+  "vetted_with_exemptions": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ]
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 19,
+              "raw": "+19"
+            },
+            "from": "9.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 19,
+            "raw": "+19"
+          },
+          "from": "9.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 19
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-full-audit.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reverse-delta-to-unaudited.json.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "transitive-third-party1",
+          "notable_parents": "third-party1",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "transitive-third-party1",
+        "notable_parents": "third-party1",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req-using-implies.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req-using-implies.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-weaker-transitive-req.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 75,
+              "raw": "+75"
+            },
+            "from": "5.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 75,
+            "raw": "+75"
+          },
+          "from": "5.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 75
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_mapped.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "fuzzed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "fuzzed": [
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "fuzzed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "fuzzed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-stronger.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-stronger.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker-needed.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker-needed.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-weaker.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "fuzzed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "fuzzed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "fuzzed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "fuzzed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 100
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-policy-redundant.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-policy-redundant.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-weaker.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-weaker.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "fail (vetting)",
+  "failures": [
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "missing_criteria": [
+        "strong-reviewed"
+      ],
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "suggest": {
+    "suggest_by_criteria": {
+      "strong-reviewed": [
+        {
+          "name": "third-party1",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        },
+        {
+          "name": "third-party2",
+          "notable_parents": "first-party",
+          "suggested_criteria": [
+            "strong-reviewed"
+          ],
+          "suggested_diff": {
+            "diffstat": {
+              "count": 100,
+              "raw": "+100"
+            },
+            "from": "0.0.0",
+            "to": "10.0.0"
+          }
+        }
+      ]
+    },
+    "suggestions": [
+      {
+        "name": "third-party1",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      },
+      {
+        "name": "third-party2",
+        "notable_parents": "first-party",
+        "suggested_criteria": [
+          "strong-reviewed"
+        ],
+        "suggested_diff": {
+          "diffstat": {
+            "count": 100,
+            "raw": "+100"
+          },
+          "from": "0.0.0",
+          "to": "10.0.0"
+        }
+      }
+    ],
+    "total_lines": 200
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-weaker.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-weaker.json.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/vet.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "transitive-third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party1",
+      "version": "10.0.0"
+    },
+    {
+      "name": "third-party2",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-dodged.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-dodged.json.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "success",
+  "vetted_fully": [
+    {
+      "name": "build",
+      "version": "10.0.0"
+    },
+    {
+      "name": "build-proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "normal",
+      "version": "10.0.0"
+    },
+    {
+      "name": "proc-macro",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
+      "name": "dev-proc-macro",
+      "version": "10.0.0"
+    }
+  ],
+  "vetted_partially": [],
+  "vetted_with_exemptions": []
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-high-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-high-hit.json.snap
@@ -1,0 +1,33 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "dev:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-imply-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-imply-hit.json.snap
@@ -1,0 +1,33 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "dev:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-low-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-low-hit.json.snap
@@ -1,0 +1,33 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "dev:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-redundant-low-hit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__builtin-simple-deps-violation-redundant-low-hit.json.snap
@@ -1,0 +1,36 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "dev:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": [
+              "safe-to-run",
+              "safe-to-deploy"
+            ],
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-full-audit.json.snap
@@ -1,0 +1,33 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=10",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-cur-unaudited.json.snap
@@ -1,0 +1,29 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "UnauditedConflict": {
+          "exemptions": {
+            "criteria": "reviewed",
+            "notes": null,
+            "version": "10.0.0"
+          },
+          "violation": {
+            "criteria": "weak-reviewed",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=10",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-delta.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": "3.0.0 -> 5.0.0",
+            "notes": null,
+            "version": null,
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=5.0.0",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      },
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": "5.0.0 -> 10.0.0",
+            "notes": null,
+            "version": null,
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=5.0.0",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-full-audit.json.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": "3.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=3.0.0",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      },
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": "3.0.0 -> 5.0.0",
+            "notes": null,
+            "version": null,
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "=3.0.0",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-hit-with-extra-junk.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-hit-with-extra-junk.json.snap
@@ -1,0 +1,36 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": [
+              "safe-to-run",
+              "fuzzed"
+            ],
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-wildcard.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__violations__mock-simple-violation-wildcard.json.snap
@@ -1,0 +1,33 @@
+---
+source: src/tests/violations.rs
+expression: json
+---
+{
+  "conclusion": "fail (violation)",
+  "violations": {
+    "third-party1:10.0.0": [
+      {
+        "AuditConflict": {
+          "audit": {
+            "criteria": "safe-to-deploy",
+            "delta": null,
+            "notes": null,
+            "version": "10.0.0",
+            "violation": null,
+            "who": null
+          },
+          "audit_source": "Local",
+          "violation": {
+            "criteria": "safe-to-run",
+            "delta": null,
+            "notes": null,
+            "version": null,
+            "violation": "*",
+            "who": null
+          },
+          "violation_source": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -14,8 +14,7 @@ fn mock_simple_init() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-init", output);
+    assert_report_snapshot!("mock-simple-init", &metadata, report);
 }
 
 #[test]
@@ -31,8 +30,7 @@ fn mock_simple_no_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-no-unaudited", output);
+    assert_report_snapshot!("mock-simple-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -48,8 +46,7 @@ fn mock_simple_full_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-full-audited", output);
+    assert_report_snapshot!("mock-simple-full-audited", &metadata, report);
 }
 
 #[test]
@@ -64,8 +61,7 @@ fn builtin_simple_init() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-init", output);
+    assert_report_snapshot!("builtin-simple-init", &metadata, report);
 }
 
 #[test]
@@ -81,8 +77,7 @@ fn builtin_simple_no_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-no-unaudited", output);
+    assert_report_snapshot!("builtin-simple-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -98,8 +93,7 @@ fn builtin_simple_full_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-full-audited", output);
+    assert_report_snapshot!("builtin-simple-full-audited", &metadata, report);
 }
 
 #[test]
@@ -121,8 +115,7 @@ fn mock_simple_missing_transitive() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-missing-transitive", output);
+    assert_report_snapshot!("mock-simple-missing-transitive", &metadata, report);
 }
 
 #[test]
@@ -140,8 +133,7 @@ fn mock_simple_missing_direct_internal() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-missing-direct-internal", output);
+    assert_report_snapshot!("mock-simple-missing-direct-internal", &metadata, report);
 }
 
 #[test]
@@ -159,8 +151,7 @@ fn mock_simple_missing_direct_leaf() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-missing-direct-leaf", output);
+    assert_report_snapshot!("mock-simple-missing-direct-leaf", &metadata, report);
 }
 
 #[test]
@@ -183,8 +174,7 @@ fn mock_simple_missing_leaves() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-missing-leaves", output);
+    assert_report_snapshot!("mock-simple-missing-leaves", &metadata, report);
 }
 
 #[test]
@@ -212,8 +202,7 @@ fn mock_simple_weaker_transitive_req() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-weaker-transitive-req", output);
+    assert_report_snapshot!("mock-simple-weaker-transitive-req", &metadata, report);
 }
 
 #[test]
@@ -242,8 +231,11 @@ fn mock_simple_weaker_transitive_req_using_implies() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-weaker-transitive-req-using-implies", output);
+    assert_report_snapshot!(
+        "mock-simple-weaker-transitive-req-using-implies",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -263,8 +255,7 @@ fn mock_simple_lower_version_review() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-lower-version-review", output);
+    assert_report_snapshot!("mock-simple-lower-version-review", &metadata, report);
 }
 
 #[test]
@@ -284,8 +275,7 @@ fn mock_simple_higher_version_review() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-higher-version-review", output);
+    assert_report_snapshot!("mock-simple-higher-version-review", &metadata, report);
 }
 
 #[test]
@@ -308,8 +298,11 @@ fn mock_simple_higher_and_lower_version_review() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-higher-and-lower-version-review", output);
+    assert_report_snapshot!(
+        "mock-simple-higher-and-lower-version-review",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -329,8 +322,7 @@ fn mock_simple_reviewed_too_weakly() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-reviewed-too-weakly", output);
+    assert_report_snapshot!("mock-simple-reviewed-too-weakly", &metadata, report);
 }
 
 #[test]
@@ -360,8 +352,7 @@ fn mock_simple_delta_to_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-unaudited", output);
+    assert_report_snapshot!("mock-simple-delta-to-unaudited", &metadata, report);
 }
 
 #[test]
@@ -391,8 +382,11 @@ fn mock_simple_delta_to_exemptions_overshoot() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-unaudited-overshoot", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-unaudited-overshoot",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -422,8 +416,11 @@ fn mock_simple_delta_to_exemptions_undershoot() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-unaudited-undershoot", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-unaudited-undershoot",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -448,8 +445,7 @@ fn mock_simple_delta_to_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-full-audit", output);
+    assert_report_snapshot!("mock-simple-delta-to-full-audit", &metadata, report);
 }
 
 #[test]
@@ -474,8 +470,11 @@ fn mock_simple_delta_to_full_audit_overshoot() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-full-audit-overshoot", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-full-audit-overshoot",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -500,8 +499,11 @@ fn mock_simple_delta_to_full_audit_undershoot() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-full-audit-undershoot", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-full-audit-undershoot",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -526,8 +528,7 @@ fn mock_simple_reverse_delta_to_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-reverse-delta-to-full-audit", output);
+    assert_report_snapshot!("mock-simple-reverse-delta-to-full-audit", &metadata, report);
 }
 
 #[test]
@@ -557,8 +558,7 @@ fn mock_simple_reverse_delta_to_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-reverse-delta-to-unaudited", output);
+    assert_report_snapshot!("mock-simple-reverse-delta-to-unaudited", &metadata, report);
 }
 
 #[test]
@@ -588,8 +588,11 @@ fn mock_simple_wrongly_reversed_delta_to_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-wrongly-reversed-delta-to-unaudited", output);
+    assert_report_snapshot!(
+        "mock-simple-wrongly-reversed-delta-to-unaudited",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -614,8 +617,11 @@ fn mock_simple_wrongly_reversed_delta_to_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-wrongly-reversed-delta-to-full-audit", output);
+    assert_report_snapshot!(
+        "mock-simple-wrongly-reversed-delta-to-full-audit",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -645,8 +651,11 @@ fn mock_simple_needed_reversed_delta_to_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-needed-reversed-delta-to-unaudited", output);
+    assert_report_snapshot!(
+        "mock-simple-needed-reversed-delta-to-unaudited",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -676,8 +685,7 @@ fn mock_simple_delta_to_exemptions_too_weak() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-unaudited-too-weak", output);
+    assert_report_snapshot!("mock-simple-delta-to-unaudited-too-weak", &metadata, report);
 }
 
 #[test]
@@ -702,8 +710,11 @@ fn mock_simple_delta_to_full_audit_too_weak() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-full-audit-too-weak", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-full-audit-too-weak",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -728,8 +739,11 @@ fn mock_simple_delta_to_too_weak_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-delta-to-too-weak-full-audit", output);
+    assert_report_snapshot!(
+        "mock-simple-delta-to-too-weak-full-audit",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -743,8 +757,7 @@ fn mock_complex_inited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-inited", output);
+    assert_report_snapshot!("mock-complex-inited", &metadata, report);
 }
 
 #[test]
@@ -758,8 +771,7 @@ fn mock_complex_no_exemptions() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-no-unaudited", output);
+    assert_report_snapshot!("mock-complex-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -773,8 +785,7 @@ fn mock_complex_full_audited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-full-audited", output);
+    assert_report_snapshot!("mock-complex-full-audited", &metadata, report);
 }
 
 #[test]
@@ -788,8 +799,7 @@ fn builtin_complex_inited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-complex-inited", output);
+    assert_report_snapshot!("builtin-complex-inited", &metadata, report);
 }
 
 #[test]
@@ -803,8 +813,7 @@ fn builtin_complex_no_exemptions() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-complex-no-unaudited", output);
+    assert_report_snapshot!("builtin-complex-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -818,8 +827,7 @@ fn builtin_complex_full_audited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-complex-full-audited", output);
+    assert_report_snapshot!("builtin-complex-full-audited", &metadata, report);
 }
 
 #[test]
@@ -833,8 +841,7 @@ fn builtin_complex_minimal_audited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-complex-minimal-audited", output);
+    assert_report_snapshot!("builtin-complex-minimal-audited", &metadata, report);
 }
 
 #[test]
@@ -853,8 +860,7 @@ fn mock_complex_missing_core5() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-missing-core5", output);
+    assert_report_snapshot!("mock-complex-missing-core5", &metadata, report);
 }
 
 #[test]
@@ -873,8 +879,7 @@ fn mock_complex_missing_core10() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-missing-core10", output);
+    assert_report_snapshot!("mock-complex-missing-core10", &metadata, report);
 }
 
 #[test]
@@ -896,8 +901,7 @@ fn mock_complex_core10_too_weak() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-core10-too-weak", output);
+    assert_report_snapshot!("mock-complex-core10-too-weak", &metadata, report);
 }
 
 #[test]
@@ -931,8 +935,7 @@ fn mock_complex_core10_partially_too_weak() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-complex-core10-partially-too-weak", output);
+    assert_report_snapshot!("mock-complex-core10-partially-too-weak", &metadata, report);
 }
 
 #[test]
@@ -966,10 +969,10 @@ fn mock_complex_core10_partially_too_weak_via_weak_delta() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(
+    assert_report_snapshot!(
         "mock-complex-core10-partially-too-weak-via-weak-delta",
-        output
+        &metadata,
+        report
     );
 }
 
@@ -1010,10 +1013,10 @@ fn mock_complex_core10_partially_too_weak_via_strong_delta() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(
+    assert_report_snapshot!(
         "mock-complex-core10-partially-too-weak-via-strong-delta",
-        output
+        &metadata,
+        report
     );
 }
 
@@ -1032,8 +1035,7 @@ fn mock_simple_policy_root_too_strong() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-root-too-strong", output);
+    assert_report_snapshot!("simple-policy-root-too-strong", &metadata, report);
 }
 
 #[test]
@@ -1051,8 +1053,7 @@ fn mock_simple_policy_root_weaker() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-root-weaker", output);
+    assert_report_snapshot!("simple-policy-root-weaker", &metadata, report);
 }
 
 #[test]
@@ -1070,8 +1071,7 @@ fn mock_simple_policy_first_too_strong() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-too-strong", output);
+    assert_report_snapshot!("simple-policy-first-too-strong", &metadata, report);
 }
 
 #[test]
@@ -1089,8 +1089,7 @@ fn mock_simple_policy_first_weaker() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-weaker", output);
+    assert_report_snapshot!("simple-policy-first-weaker", &metadata, report);
 }
 
 #[test]
@@ -1109,8 +1108,7 @@ fn mock_simple_policy_root_dep_weaker() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-root-dep-weaker", output);
+    assert_report_snapshot!("simple-policy-root-dep-weaker", &metadata, report);
 }
 
 #[test]
@@ -1129,8 +1127,7 @@ fn mock_simple_policy_root_dep_too_strong() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-root-dep-too-strong", output);
+    assert_report_snapshot!("simple-policy-root-dep-too-strong", &metadata, report);
 }
 
 #[test]
@@ -1149,8 +1146,7 @@ fn mock_simple_policy_first_dep_weaker() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-weaker", output);
+    assert_report_snapshot!("simple-policy-first-dep-weaker", &metadata, report);
 }
 
 #[test]
@@ -1169,8 +1165,7 @@ fn mock_simple_policy_first_dep_too_strong() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-too-strong", output);
+    assert_report_snapshot!("simple-policy-first-dep-too-strong", &metadata, report);
 }
 
 #[test]
@@ -1194,8 +1189,7 @@ fn mock_simple_policy_first_dep_stronger() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-stronger", output);
+    assert_report_snapshot!("simple-policy-first-dep-stronger", &metadata, report);
 }
 
 #[test]
@@ -1219,8 +1213,7 @@ fn mock_simple_policy_first_dep_weaker_needed() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-weaker-needed", output);
+    assert_report_snapshot!("simple-policy-first-dep-weaker-needed", &metadata, report);
 }
 
 #[test]
@@ -1247,8 +1240,7 @@ fn mock_simple_policy_first_dep_extra() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-extra", output);
+    assert_report_snapshot!("simple-policy-first-dep-extra", &metadata, report);
 }
 
 #[test]
@@ -1272,8 +1264,7 @@ fn mock_simple_policy_first_dep_extra_missing() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-dep-extra-missing", output);
+    assert_report_snapshot!("simple-policy-first-dep-extra-missing", &metadata, report);
 }
 
 #[test]
@@ -1300,8 +1291,11 @@ fn mock_simple_policy_first_extra_partially_missing() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-extra-partially-missing", output);
+    assert_report_snapshot!(
+        "simple-policy-first-extra-partially-missing",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -1320,8 +1314,7 @@ fn mock_simple_first_policy_redundant() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("simple-policy-first-policy-redundant", output);
+    assert_report_snapshot!("simple-policy-first-policy-redundant", &metadata, report);
 }
 
 #[test]
@@ -1335,8 +1328,7 @@ fn builtin_simple_deps_inited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-init", output);
+    assert_report_snapshot!("builtin-simple-deps-init", &metadata, report);
 }
 
 #[test]
@@ -1352,8 +1344,7 @@ fn builtin_simple_deps_no_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-no-unaudited", output);
+    assert_report_snapshot!("builtin-simple-deps-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -1369,8 +1360,7 @@ fn builtin_simple_deps_full_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-full-audited", output);
+    assert_report_snapshot!("builtin-simple-deps-full-audited", &metadata, report);
 }
 
 #[test]
@@ -1386,8 +1376,7 @@ fn builtin_simple_deps_minimal_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-minimal-audited", output);
+    assert_report_snapshot!("builtin-simple-deps-minimal-audited", &metadata, report);
 }
 
 #[test]
@@ -1408,8 +1397,7 @@ fn builtin_no_deps() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-no-deps", output);
+    assert_report_snapshot!("builtin-no-deps", &metadata, report);
 }
 
 #[test]
@@ -1438,8 +1426,7 @@ fn builtin_only_first_deps() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-only-first-deps", output);
+    assert_report_snapshot!("builtin-only-first-deps", &metadata, report);
 }
 
 #[test]
@@ -1453,8 +1440,7 @@ fn builtin_cycle_inited() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-cycle-inited", output);
+    assert_report_snapshot!("builtin-cycle-inited", &metadata, report);
 }
 
 #[test]
@@ -1470,8 +1456,7 @@ fn builtin_cycle_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-cycle-unaudited", output);
+    assert_report_snapshot!("builtin-cycle-unaudited", &metadata, report);
 }
 
 #[test]
@@ -1487,8 +1472,7 @@ fn builtin_cycle_full_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-cycle-full-audited", output);
+    assert_report_snapshot!("builtin-cycle-full-audited", &metadata, report);
 }
 
 #[test]
@@ -1504,8 +1488,7 @@ fn builtin_cycle_minimal_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-cycle-minimal-audited", output);
+    assert_report_snapshot!("builtin-cycle-minimal-audited", &metadata, report);
 }
 
 #[test]
@@ -1546,8 +1529,7 @@ fn builtin_dev_detection() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-dev-detection", output);
+    assert_report_snapshot!("builtin-dev-detection", &metadata, report);
 }
 
 #[test]
@@ -1563,8 +1545,7 @@ fn builtin_dev_detection_empty() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-dev-detection-empty", output);
+    assert_report_snapshot!("builtin-dev-detection-empty", &metadata, report);
 }
 
 #[test]
@@ -1580,8 +1561,7 @@ fn builtin_dev_detection_empty_deeper() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Deep);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-dev-detection-empty-deeper", output);
+    assert_report_snapshot!("builtin-dev-detection-empty-deeper", &metadata, report);
 }
 
 #[test]
@@ -1608,8 +1588,7 @@ fn builtin_simple_exemptions_extra() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-extra", output);
+    assert_report_snapshot!("builtin-simple-unaudited-extra", &metadata, report);
 }
 
 #[test]
@@ -1631,8 +1610,7 @@ fn builtin_simple_exemptions_not_a_real_dep() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-not-a-real-dep", output);
+    assert_report_snapshot!("builtin-simple-not-a-real-dep", &metadata, report);
 }
 
 #[test]
@@ -1656,8 +1634,7 @@ fn builtin_simple_deps_exemptions_overbroad() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-overbroad", output);
+    assert_report_snapshot!("builtin-simple-unaudited-overbroad", &metadata, report);
 }
 
 #[test]
@@ -1683,8 +1660,7 @@ fn builtin_complex_exemptions_twins() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-twins", output);
+    assert_report_snapshot!("builtin-simple-unaudited-twins", &metadata, report);
 }
 
 #[test]
@@ -1710,8 +1686,7 @@ fn builtin_complex_exemptions_partial_twins() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-partial-twins", output);
+    assert_report_snapshot!("builtin-simple-unaudited-partial-twins", &metadata, report);
 }
 
 #[test]
@@ -1742,8 +1717,7 @@ fn builtin_simple_exemptions_in_delta() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-in-delta", output);
+    assert_report_snapshot!("builtin-simple-unaudited-in-delta", &metadata, report);
 }
 
 #[test]
@@ -1774,8 +1748,7 @@ fn builtin_simple_exemptions_in_full() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-in-full", output);
+    assert_report_snapshot!("builtin-simple-unaudited-in-full", &metadata, report);
 }
 
 #[test]
@@ -1802,8 +1775,7 @@ fn builtin_simple_exemptions_in_direct_full() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-in-direct-full", output);
+    assert_report_snapshot!("builtin-simple-unaudited-in-direct-full", &metadata, report);
 }
 
 #[test]
@@ -1859,8 +1831,11 @@ fn builtin_simple_exemptions_nested_weaker_req() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-nested-weaker-req", output);
+    assert_report_snapshot!(
+        "builtin-simple-unaudited-nested-weaker-req",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -1912,10 +1887,10 @@ fn builtin_simple_exemptions_nested_weaker_req_needs_dep_criteria() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(
+    assert_report_snapshot!(
         "builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria",
-        output
+        &metadata,
+        report
     );
 }
 
@@ -1972,8 +1947,11 @@ fn builtin_simple_exemptions_nested_stronger_req() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-unaudited-nested-stronger-req", output);
+    assert_report_snapshot!(
+        "builtin-simple-unaudited-nested-stronger-req",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2002,10 +1980,10 @@ fn builtin_simple_deps_exemptions_adds_uneeded_criteria() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(
+    assert_report_snapshot!(
         "builtin-simple-deps-unaudited-adds-uneeded-criteria",
-        output
+        &metadata,
+        report
     );
 }
 
@@ -2036,10 +2014,10 @@ fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(
+    assert_report_snapshot!(
         "builtin-dev-detection-unaudited-adds-uneeded-criteria-indirect",
-        output
+        &metadata,
+        report
     );
 }
 
@@ -2070,8 +2048,7 @@ fn builtin_dev_detection_cursed_full() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-dev-detection-cursed-full", output);
+    assert_report_snapshot!("builtin-dev-detection-cursed-full", &metadata, report);
 }
 
 #[test]
@@ -2096,8 +2073,7 @@ fn builtin_dev_detection_cursed_minimal() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-dev-detection-cursed-minimal", output);
+    assert_report_snapshot!("builtin-dev-detection-cursed-minimal", &metadata, report);
 }
 
 #[test]
@@ -2124,8 +2100,7 @@ fn builtin_simple_delta_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-delta-cycle", output);
+    assert_report_snapshot!("builtin-simple-delta-cycle", &metadata, report);
 }
 
 #[test]
@@ -2153,8 +2128,7 @@ fn builtin_simple_noop_delta() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-noop-delta", output);
+    assert_report_snapshot!("builtin-simple-noop-delta", &metadata, report);
 }
 
 #[test]
@@ -2185,8 +2159,7 @@ fn builtin_simple_delta_double_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-delta-double-cycle", output);
+    assert_report_snapshot!("builtin-simple-delta-double-cycle", &metadata, report);
 }
 
 #[test]
@@ -2217,8 +2190,11 @@ fn builtin_simple_delta_broken_double_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-delta-broken-double-cycle", output);
+    assert_report_snapshot!(
+        "builtin-simple-delta-broken-double-cycle",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2246,8 +2222,7 @@ fn builtin_simple_delta_broken_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-delta-broken-cycle", output);
+    assert_report_snapshot!("builtin-simple-delta-broken-cycle", &metadata, report);
 }
 
 #[test]
@@ -2275,8 +2250,7 @@ fn builtin_simple_long_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-long-cycle", output);
+    assert_report_snapshot!("builtin-simple-long-cycle", &metadata, report);
 }
 
 #[test]
@@ -2304,8 +2278,7 @@ fn builtin_simple_useless_long_cycle() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-useless-long-cycle", output);
+    assert_report_snapshot!("builtin-simple-useless-long-cycle", &metadata, report);
 }
 
 #[test]
@@ -2320,8 +2293,7 @@ fn builtin_haunted_init() {
 
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-haunted-init", output);
+    assert_report_snapshot!("builtin-haunted-init", &metadata, report);
 }
 
 #[test]
@@ -2337,8 +2309,7 @@ fn builtin_haunted_no_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-haunted-no-unaudited", output);
+    assert_report_snapshot!("builtin-haunted-no-unaudited", &metadata, report);
 }
 
 #[test]
@@ -2354,8 +2325,7 @@ fn builtin_haunted_no_exemptions_deeper() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Deep);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-haunted-no-unaudited-deeper", output);
+    assert_report_snapshot!("builtin-haunted-no-unaudited-deeper", &metadata, report);
 }
 
 #[test]
@@ -2371,8 +2341,7 @@ fn builtin_haunted_full_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-haunted-full-audited", output);
+    assert_report_snapshot!("builtin-haunted-full-audited", &metadata, report);
 }
 
 #[test]
@@ -2388,8 +2357,7 @@ fn builtin_haunted_minimal_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-haunted-minimal-audited", output);
+    assert_report_snapshot!("builtin-haunted-minimal-audited", &metadata, report);
 }
 
 #[test]
@@ -2409,8 +2377,11 @@ fn builtin_simple_audit_as_default_root_no_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-audit-as-default-root-no-audit", output);
+    assert_report_snapshot!(
+        "builtin-simple-audit-as-default-root-no-audit",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2434,8 +2405,7 @@ fn builtin_simple_audit_as_default_root() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-audit-as-default-root", output);
+    assert_report_snapshot!("builtin-simple-audit-as-default-root", &metadata, report);
 }
 
 #[test]
@@ -2459,8 +2429,11 @@ fn builtin_simple_audit_as_default_root_too_weak() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-audit-as-default-root-too-weak", output);
+    assert_report_snapshot!(
+        "builtin-simple-audit-as-default-root-too-weak",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2488,8 +2461,7 @@ fn builtin_simple_audit_as_weaker_root() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-audit-as-weaker-root", output);
+    assert_report_snapshot!("builtin-simple-audit-as-weaker-root", &metadata, report);
 }
 
 #[test]
@@ -2514,8 +2486,7 @@ fn builtin_simple_foreign_audited() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!("builtin_simple_foreign_audited", &metadata, report);
 }
 
 #[test]
@@ -2541,8 +2512,11 @@ fn mock_simple_foreign_audited_pun_no_mapping() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!(
+        "mock_simple_foreign_audited_pun_no_mapping",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2570,8 +2544,7 @@ fn mock_simple_foreign_audited_pun_mapped() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!("mock_simple_foreign_audited_pun_mapped", &metadata, report);
 }
 
 #[test]
@@ -2610,8 +2583,11 @@ fn mock_simple_foreign_audited_pun_wrong_mapped() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!(
+        "mock_simple_foreign_audited_pun_wrong_mapped",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2650,8 +2626,7 @@ fn builtin_simple_foreign_tag_team() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!("builtin_simple_foreign_tag_team", &metadata, report);
 }
 
 #[test]
@@ -2709,8 +2684,7 @@ fn builtin_simple_mega_foreign_tag_team() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!("builtin_simple_mega_foreign_tag_team", &metadata, report);
 }
 
 #[test]
@@ -2760,8 +2734,11 @@ fn builtin_simple_foreign_dep_criteria_fail() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!(
+        "builtin_simple_foreign_dep_criteria_fail",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -2817,6 +2794,9 @@ fn builtin_simple_foreign_dep_criteria_pass() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!(output);
+    assert_report_snapshot!(
+        "builtin_simple_foreign_dep_criteria_pass",
+        &metadata,
+        report
+    );
 }

--- a/src/tests/violations.rs
+++ b/src/tests/violations.rs
@@ -20,8 +20,7 @@ fn mock_simple_violation_cur_exemptions() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-cur-unaudited", output);
+    assert_report_snapshot!("mock-simple-violation-cur-unaudited", &metadata, report);
 }
 
 #[test]
@@ -46,8 +45,7 @@ fn mock_simple_violation_cur_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-cur-full-audit", output);
+    assert_report_snapshot!("mock-simple-violation-cur-full-audit", &metadata, report);
 }
 
 #[test]
@@ -74,8 +72,7 @@ fn mock_simple_violation_delta() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-delta", output);
+    assert_report_snapshot!("mock-simple-violation-delta", &metadata, report);
 }
 
 #[test]
@@ -102,8 +99,7 @@ fn mock_simple_violation_full_audit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-full-audit", output);
+    assert_report_snapshot!("mock-simple-violation-full-audit", &metadata, report);
 }
 
 #[test]
@@ -128,8 +124,7 @@ fn mock_simple_violation_wildcard() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-wildcard", output);
+    assert_report_snapshot!("mock-simple-violation-wildcard", &metadata, report);
 }
 
 #[test]
@@ -153,8 +148,7 @@ fn builtin_simple_deps_violation_dodged() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-violation-dodged", output);
+    assert_report_snapshot!("builtin-simple-deps-violation-dodged", &metadata, report);
 }
 
 #[test]
@@ -178,8 +172,7 @@ fn builtin_simple_deps_violation_low_hit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-violation-low-hit", output);
+    assert_report_snapshot!("builtin-simple-deps-violation-low-hit", &metadata, report);
 }
 
 #[test]
@@ -203,8 +196,7 @@ fn builtin_simple_deps_violation_high_hit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-violation-high-hit", output);
+    assert_report_snapshot!("builtin-simple-deps-violation-high-hit", &metadata, report);
 }
 
 #[test]
@@ -228,8 +220,7 @@ fn builtin_simple_deps_violation_imply_hit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-violation-imply-hit", output);
+    assert_report_snapshot!("builtin-simple-deps-violation-imply-hit", &metadata, report);
 }
 
 #[test]
@@ -253,8 +244,11 @@ fn builtin_simple_deps_violation_redundant_low_hit() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("builtin-simple-deps-violation-redundant-low-hit", output);
+    assert_report_snapshot!(
+        "builtin-simple-deps-violation-redundant-low-hit",
+        &metadata,
+        report
+    );
 }
 
 #[test]
@@ -278,6 +272,9 @@ fn mock_simple_violation_hit_with_extra_junk() {
     let store = Store::mock(config, audits, imports);
     let report = crate::resolver::resolve(&metadata, None, &store, ResolveDepth::Shallow);
 
-    let output = get_report(&metadata, report);
-    insta::assert_snapshot!("mock-simple-violation-hit-with-extra-junk", output);
+    assert_report_snapshot!(
+        "mock-simple-violation-hit-with-extra-junk",
+        &metadata,
+        report
+    );
 }


### PR DESCRIPTION
Previously these tests would only generate snapshots for the human
output of cargo vet. With this change, json snapshots are also produced.
This both acts as a test for the json output from cargo vet, as well as
a way to see more information about the vet's results, as json output is
occasionally more detailed than human output.

Finally, it also acts as a source of examples for the JSON output.