### PR TITLE
Fix JSON test expectations

### DIFF
--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root.json.snap
@@ -4,12 +4,7 @@ expression: json
 ---
 {
   "conclusion": "success",
-  "vetted_fully": [
-    {
-      "name": "root-package",
-      "version": "10.0.0"
-    }
-  ],
+  "vetted_fully": [],
   "vetted_partially": [],
   "vetted_with_exemptions": [
     {
@@ -22,6 +17,10 @@ expression: json
     },
     {
       "name": "third-party2",
+      "version": "10.0.0"
+    },
+    {
+      "name": "root-package",
       "version": "10.0.0"
     }
   ]

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-weaker-root.json.snap
@@ -4,12 +4,7 @@ expression: json
 ---
 {
   "conclusion": "success",
-  "vetted_fully": [
-    {
-      "name": "root-package",
-      "version": "10.0.0"
-    }
-  ],
+  "vetted_fully": [],
   "vetted_partially": [],
   "vetted_with_exemptions": [
     {
@@ -22,6 +17,10 @@ expression: json
     },
     {
       "name": "third-party2",
+      "version": "10.0.0"
+    },
+    {
+      "name": "root-package",
       "version": "10.0.0"
     }
   ]

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-unaudited-adds-uneeded-criteria.json.snap
@@ -22,15 +22,14 @@ expression: json
       "version": "10.0.0"
     },
     {
+      "name": "dev",
+      "version": "10.0.0"
+    },
+    {
       "name": "dev-proc-macro",
       "version": "10.0.0"
     }
   ],
-  "vetted_partially": [
-    {
-      "name": "dev",
-      "version": "10.0.0"
-    }
-  ],
+  "vetted_partially": [],
   "vetted_with_exemptions": []
 }


### PR DESCRIPTION
The changes in #296 changed some test expectations which were only added
in #299, so when both were landed, it caused test failures. This fixes
those test failures.