### PR TITLE
Improve the precision and exemption re-use of "regenerate exemptions"

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -170,6 +170,21 @@ Specifies the exact version which should be exempted.
 
 Specifies the criteria covered by the exemption.
 
+#### `dependency-criteria`
+
+Allows overriding the criteria requirements for dependencies on a per-dependency basis.
+Similar in format to the [equivalent field](audit-entries.md#dependency-criteria) in audit entries.
+
+This serves the same purposes as the field on audit entries, allowing the
+exemption to relax or strengthen the requirements which it places on
+dependencies when it is used.
+
+This can be used when a crate still needs to be exempted (e.g. because it hasn't
+been audited enough to publish an audit), but it has been determined that a
+particular subtree should be held to different audit requirements. This may both
+be useful for dependencies which only need to be `safe-to-run`, or for adding
+extra requirements for specific dependencies of an exempted crate.
+
 #### `notes`
 
 Free-form string for recording rationale or other relevant information.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -135,17 +135,16 @@ pub enum InitError {
 }
 
 //////////////////////////////////////////////////////////
-// MinimizeUnauditedError
+// RegenerateExemptionsError
 //////////////////////////////////////////////////////////
 
 #[derive(Debug, Error, Diagnostic)]
 #[non_exhaustive]
-pub enum MinimizeUnauditedError {
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    Suggest(#[from] SuggestError),
-    #[error("An unknown error occured while trying to minimize exemptions entries")]
-    Unknown,
+pub enum RegenerateExemptionsError {
+    #[error(
+        "Regenerating exemptions failed due to violation conflicts. Run 'cargo vet' for details"
+    )]
+    ViolationConflict,
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -524,7 +524,8 @@ impl Store {
     #[must_use]
     pub fn get_updated_imports_file(
         &self,
-        report: &resolver::ResolveReport<'_>,
+        graph: &resolver::DepGraph<'_>,
+        conclusion: &resolver::Conclusion,
         force_update: bool,
     ) -> ImportsFile {
         if self.live_imports.is_none() {
@@ -534,14 +535,14 @@ impl Store {
 
         // Determine which packages were used.
         let mut used_packages = SortedMap::new();
-        for package in report.graph.nodes.iter() {
+        for package in graph.nodes.iter() {
             used_packages.insert(package.name, false);
         }
 
         // If we succeeded, also record which packages need fresh imports.
-        if let Conclusion::Success(success) = &report.conclusion {
+        if let Conclusion::Success(success) = conclusion {
             for &node_idx in &success.needed_fresh_imports {
-                let package = &report.graph.nodes[node_idx];
+                let package = &graph.nodes[node_idx];
                 used_packages.insert(package.name, true);
             }
         }
@@ -612,7 +613,8 @@ impl Store {
             // to do less work.
             resolver::ResolveDepth::Shallow,
         );
-        self.imports = self.get_updated_imports_file(&report, force_update);
+        self.imports =
+            self.get_updated_imports_file(&report.graph, &report.conclusion, force_update);
     }
 }
 

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -6,7 +6,8 @@ fn get_imports_file_changes(metadata: &Metadata, store: &Store, force_updates: b
     // Run the resolver before calling `get_imports_file` to compute the new
     // imports file.
     let report = crate::resolver::resolve(metadata, None, store, ResolveDepth::Shallow);
-    let new_imports = store.get_updated_imports_file(&report, force_updates);
+    let new_imports =
+        store.get_updated_imports_file(&report.graph, &report.conclusion, force_updates);
 
     // Format the old and new files as TOML, and write out a diff using `similar`.
     let old_imports = crate::serialization::to_formatted_toml(&store.imports)
@@ -724,7 +725,7 @@ fn peer_audits_exemption_minimize() {
     // Capture the old imports before minimizing exemptions
     let old = store.mock_commit();
 
-    crate::minimize_exemptions(&mock_cfg(&metadata), &mut store, None).unwrap();
+    crate::resolver::regenerate_exemptions(&mock_cfg(&metadata), &mut store).unwrap();
 
     // Capture after minimizing exemptions, and generate a diff.
     let new = store.mock_commit();

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-broaden-basic.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-broaden-basic.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/regenerate_unaudited.rs
+expression: exemptions
+---
+[[third-party1]]
+version = "5.0.0"
+criteria = "safe-to-deploy"
+
+[[third-party2]]
+version = "10.0.0"
+criteria = "safe-to-deploy"
+
+[[transitive-third-party1]]
+version = "5.0.0"
+criteria = "safe-to-deploy"
+
+[[transitive-third-party1]]
+version = "5.0.0"
+criteria = "safe-to-run"
+suggest = false
+

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-larger-diff-regenerate.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-larger-diff-regenerate.snap
@@ -3,10 +3,14 @@ source: src/tests/regenerate_unaudited.rs
 expression: exemptions
 ---
 [[third-party1]]
-version = "3.0.0"
-criteria = "safe-to-run"
+version = "11.0.0"
+criteria = "safe-to-deploy"
+
+[[third-party2]]
+version = "10.0.0"
+criteria = "safe-to-deploy"
 
 [[transitive-third-party1]]
-version = "4.0.0"
+version = "10.0.0"
 criteria = "safe-to-deploy"
 

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-unaudited-nested-weaker-req-regenerate.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-unaudited-nested-weaker-req-regenerate.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/regenerate_unaudited.rs
-expression: unaudited
+expression: exemptions
 ---
 [[third-party1]]
 version = "3.0.0"
@@ -10,6 +10,6 @@ criteria = "safe-to-deploy"
 transitive-third-party1 = "safe-to-run"
 
 [[transitive-third-party1]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
+version = "4.0.0"
+criteria = "safe-to-run"
 

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-unaudited-twins-regenerate.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-unaudited-twins-regenerate.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tests/regenerate_unaudited.rs
-expression: unaudited
+expression: exemptions
 ---
 [[third-core]]
-version = "10.0.0"
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[third-core]]
-version = "5.0.0"
+version = "10.0.0"
 criteria = "safe-to-deploy"
 


### PR DESCRIPTION
This patch reworks the `minimize_exemptions` logic to be more precise
and fix issues such as those found in #292.

This new algorithm doesn't use the `suggest` backend, instead
iteratively selecting exemptions which are required to allow resolve to
proceed, and then re-trying the resolver as-necessary. This is an
improvement over the existing logic as it is able to be much more
precise while prioritizing keeping exemptions pinned in the past over
crate sizes.

The algorithm also has logic to attempt to preserve some special
exemptions, such as those with `dependency_criteria` or which have been
marked `suggest = false`, so that they are not lost when regenerating,
while not allowing the criteria they're exempting to expand (as that
would be potentially surprising for both cases).

If there are no existing audits for a crate which can be used as a
guideline for a newly-required audit, the new algorithm will always bias
toward doing a full-exemption for the current crate version, over trying
to pick an arbitrary node to audit, as this simplifies the logic
substantially and should produce acceptable results for a newly added
dependency subtree.

Unlike the previous approach, there should be no cases where `vet` fails
after a successful `cargo vet regenerate`, as it correctly handles
`dependency_criteria` due to the iterative resolver calls.

If we decide to eventually run this automatically when a `vet` is
successful (e.g. in `cargo vet certify` to fix #262), it would be fairly
straightforward to extend this with an option to prevent the possibility
of new exemptions being added.

Fixes #292