### PR TITLE
Add support for imports.exclude

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -245,6 +245,9 @@ pub enum StoreValidateError {
     #[diagnostic(transparent)]
     #[error(transparent)]
     InvalidCriteria(InvalidCriteriaError),
+    #[error("imports.lock is out-of-date with respect to configuration")]
+    #[diagnostic(help("run `cargo vet` without --locked to update imports"))]
+    ImportsLockOutdated,
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -381,10 +381,14 @@ pub static DEFAULT_POLICY_CRITERIA: CriteriaStr = SAFE_TO_DEPLOY;
 pub static DEFAULT_POLICY_DEV_CRITERIA: CriteriaStr = SAFE_TO_RUN;
 
 /// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct RemoteImport {
     /// URL of the foreign audits.toml
     pub url: String,
+    /// A list of crates for which no audits or violations should be imported.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub exclude: Vec<PackageName>,
     /// A list of criteria that are implied by foreign criteria
     #[serde(rename = "criteria-map")]
     pub criteria_map: Vec<CriteriaMapping>,

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_import_exclusion.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_import_exclusion.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+-[[audits.peer-company.audits.third-party1]]
+-criteria = "safe-to-deploy"
+-violation = "*"
+-
+-[[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-deploy"
+-version = "10.0.0"
+-
+ [[audits.peer-company.audits.transitive-third-party1]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_excluded_crate.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_excluded_crate.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/store_parsing.rs
+expression: acquire_errors
+---
+
+  × Your cargo-vet store (supply-chain) has consistency errors
+
+Error: 
+  × imports.lock is out-of-date with respect to configuration
+  help: run `cargo vet` without --locked to update imports
+

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_extra_peer.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_extra_peer.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/store_parsing.rs
+expression: acquire_errors
+---
+
+  × Your cargo-vet store (supply-chain) has consistency errors
+
+Error: 
+  × imports.lock is out-of-date with respect to configuration
+  help: run `cargo vet` without --locked to update imports
+

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_missing_peer.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_missing_peer.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/store_parsing.rs
+expression: acquire_errors
+---
+
+  × Your cargo-vet store (supply-chain) has consistency errors
+
+Error: 
+  × imports.lock is out-of-date with respect to configuration
+  help: run `cargo vet` without --locked to update imports
+

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_ok.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__outdated_imports_lock_ok.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/store_parsing.rs
+expression: acquire_errors
+---
+

--- a/src/tests/store_parsing.rs
+++ b/src/tests/store_parsing.rs
@@ -108,3 +108,106 @@ implies = ["safe-to-deploy"]
     let acquire_errors = get_valid_store(config, audits, EMPTY_IMPORTS);
     insta::assert_snapshot!(acquire_errors);
 }
+
+#[test]
+fn test_outdated_imports_lock_extra_peer() {
+    let config = r##"
+[imports.peer1]
+url = "https://peer1.com"
+criteria-map = []
+
+"##;
+
+    let imports = r##"
+[[audits.peer1.audits.third-party1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+[[audits.peer2.audits.third-party2]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+"##;
+
+    let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
+    insta::assert_snapshot!(acquire_errors);
+}
+
+#[test]
+fn test_outdated_imports_lock_missing_peer() {
+    let config = r##"
+[imports.peer1]
+url = "https://peer1.com"
+criteria-map = []
+
+[imports.peer2]
+url = "https://peer2.com"
+criteria-map = []
+
+"##;
+
+    let imports = r##"
+[[audits.peer1.audits.third-party1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+"##;
+
+    let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
+    insta::assert_snapshot!(acquire_errors);
+}
+
+#[test]
+fn test_outdated_imports_lock_excluded_crate() {
+    let config = r##"
+[imports.peer1]
+url = "https://peer1.com"
+exclude = ["third-party1"]
+criteria-map = []
+
+"##;
+
+    let imports = r##"
+[[audits.peer1.audits.third-party1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+[[audits.peer1.audits.third-party2]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+
+"##;
+
+    let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
+    insta::assert_snapshot!(acquire_errors);
+}
+
+#[test]
+fn test_outdated_imports_lock_ok() {
+    let config = r##"
+[imports.peer1]
+url = "https://peer1.com"
+exclude = ["third-party2"]
+criteria-map = []
+
+[imports.peer2]
+url = "https://peer1.com"
+criteria-map = []
+
+"##;
+
+    let imports = r##"
+[[audits.peer1.audits.third-party1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+[[audits.peer2.audits.third-party2]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+"##;
+
+    let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
+    insta::assert_snapshot!(acquire_errors);
+}

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -2478,7 +2478,7 @@ fn builtin_simple_foreign_audited() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
     audits.audits.clear();
@@ -2504,7 +2504,7 @@ fn mock_simple_foreign_audited_pun_no_mapping() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
     audits.audits.clear();
@@ -2537,6 +2537,7 @@ fn mock_simple_foreign_audited_pun_mapped() {
                 ours: DEFAULT_CRIT.to_owned(),
                 theirs: vec![DEFAULT_CRIT.to_owned().into()],
             }],
+            ..Default::default()
         },
     );
     audits.audits.clear();
@@ -2570,13 +2571,14 @@ fn mock_simple_foreign_audited_pun_wrong_mapped() {
                 ours: DEFAULT_CRIT.to_owned(),
                 theirs: vec![DEFAULT_CRIT.to_owned().into()],
             }],
+            ..Default::default()
         },
     );
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: vec![],
+            ..Default::default()
         },
     );
 
@@ -2619,7 +2621,7 @@ fn builtin_simple_foreign_tag_team() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
 
@@ -2658,7 +2660,7 @@ fn builtin_simple_mega_foreign_tag_team() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
     imports.audits.insert(
@@ -2677,7 +2679,7 @@ fn builtin_simple_mega_foreign_tag_team() {
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: OTHER_FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
 
@@ -2727,7 +2729,7 @@ fn builtin_simple_foreign_dep_criteria_fail() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
 
@@ -2787,7 +2789,7 @@ fn builtin_simple_foreign_dep_criteria_pass() {
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
             url: FOREIGN_URL.to_owned(),
-            criteria_map: Vec::new(),
+            ..Default::default()
         },
     );
 


### PR DESCRIPTION
This is a fairly straightforward implementation of imports.exclude. The
configuration option is already documented in the book. After changing
this configuration value, you'll need to update imports.lock by running
a successful `cargo vet` without `--locked` (or by running `cargo vet
regenerate imports`).

I also added some validation to help catch outdated `imports.lock` files
when running with `--locked`. These will never fire when unlocked, as
`imports.lock` will be automatically updated in those cases.

Fixes #80