### PR TITLE
Automatically minimize exemptions when running certain commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,12 @@ pub struct Cli {
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub frozen: bool,
 
+    /// Prevent commands such as `check` and `certify` from automatically
+    /// cleaning up unused exemptions.
+    #[clap(long, action)]
+    #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
+    pub no_minimize_exemptions: bool,
+
     /// How verbose logging should be (log level)
     #[clap(long, action)]
     #[clap(default_value_t = LevelFilter::WARN)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -637,19 +637,6 @@ impl Store {
 
         new_imports
     }
-
-    pub fn maybe_update_imports_file(&mut self, cfg: &Config, force_update: bool) {
-        let report = resolver::resolve(
-            &cfg.metadata,
-            cfg.cli.filter_graph.as_ref(),
-            self,
-            // Resolve depth only impacts error results, so we can use Shallow
-            // to do less work.
-            resolver::ResolveDepth::Shallow,
-        );
-        self.imports =
-            self.get_updated_imports_file(&report.graph, &report.conclusion, force_update);
-    }
 }
 
 /// Process imported audits from the network, generating a `LiveImports`

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -725,7 +725,7 @@ fn peer_audits_exemption_minimize() {
     // Capture the old imports before minimizing exemptions
     let old = store.mock_commit();
 
-    crate::resolver::regenerate_exemptions(&mock_cfg(&metadata), &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&mock_cfg(&metadata), &mut store, true, false).unwrap();
 
     // Capture after minimizing exemptions, and generate a diff.
     let new = store.mock_commit();

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -30,7 +30,7 @@ fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", exemptions);
@@ -56,7 +56,7 @@ fn builtin_simple_deps_exemptions_overbroad_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", exemptions);
@@ -85,7 +85,7 @@ fn builtin_complex_exemptions_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", exemptions);
@@ -114,7 +114,7 @@ fn builtin_complex_exemptions_partial_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -150,7 +150,7 @@ fn builtin_simple_exemptions_in_delta_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", exemptions);
@@ -183,7 +183,7 @@ fn builtin_simple_exemptions_in_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", exemptions);
@@ -214,7 +214,7 @@ fn builtin_simple_deps_exemptions_adds_uneeded_criteria_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -250,7 +250,7 @@ fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect_regenerate() 
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -282,7 +282,7 @@ fn builtin_simple_exemptions_extra_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", exemptions);
@@ -311,7 +311,7 @@ fn builtin_simple_exemptions_in_direct_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -371,7 +371,7 @@ fn builtin_simple_exemptions_nested_weaker_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -432,7 +432,7 @@ fn builtin_simple_exemptions_nested_stronger_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -461,7 +461,7 @@ fn builtin_simple_audit_as_default_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -494,7 +494,7 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", exemptions);
@@ -522,7 +522,7 @@ fn builtin_simple_exemptions_larger_diff_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -582,8 +582,169 @@ fn builtin_simple_exemptions_broaden_basic() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-broaden-basic", exemptions);
+}
+
+#[test]
+fn builtin_simple_exemptions_regenerate_merge() {
+    // (Pass) minimize_exemptions will merge exemptions if it's allowed to.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = builtin_files_full_audited(&metadata);
+
+    audits.criteria.insert(
+        "criteria1".to_owned(),
+        CriteriaEntry {
+            description: Some(String::new()),
+            description_url: None,
+            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
+        },
+    );
+    audits.criteria.insert(
+        "criteria2".to_owned(),
+        CriteriaEntry {
+            description: Some(String::new()),
+            description_url: None,
+            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
+        },
+    );
+
+    audits.audits.insert(
+        "third-party1".to_owned(),
+        vec![full_audit_dep(
+            ver(DEFAULT_VER),
+            SAFE_TO_DEPLOY,
+            [("transitive-third-party1", ["criteria1", "criteria2"])],
+        )],
+    );
+
+    audits.audits.insert(
+        "transitive-third-party1".to_owned(),
+        vec![
+            delta_audit(ver(5), ver(DEFAULT_VER), "criteria1"),
+            delta_audit(ver(5), ver(DEFAULT_VER), "criteria2"),
+        ],
+    );
+    config.exemptions.insert(
+        "transitive-third-party1".to_owned(),
+        vec![
+            exemptions(ver(5), "criteria1"),
+            exemptions(ver(5), "criteria2"),
+        ],
+    );
+
+    let mut store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!("builtin-simple-exemptions-regenerate-merge", exemptions);
+}
+
+#[test]
+fn builtin_simple_exemptions_regenerate_merge_nonew() {
+    // (Pass) minimize_exemptions will not merge exemptions if it's not allowed to.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = builtin_files_full_audited(&metadata);
+
+    audits.criteria.insert(
+        "criteria1".to_owned(),
+        CriteriaEntry {
+            description: Some(String::new()),
+            description_url: None,
+            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
+        },
+    );
+    audits.criteria.insert(
+        "criteria2".to_owned(),
+        CriteriaEntry {
+            description: Some(String::new()),
+            description_url: None,
+            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
+        },
+    );
+
+    audits.audits.insert(
+        "third-party1".to_owned(),
+        vec![full_audit_dep(
+            ver(DEFAULT_VER),
+            SAFE_TO_DEPLOY,
+            [("transitive-third-party1", ["criteria1", "criteria2"])],
+        )],
+    );
+
+    audits.audits.insert(
+        "transitive-third-party1".to_owned(),
+        vec![
+            delta_audit(ver(5), ver(DEFAULT_VER), "criteria1"),
+            delta_audit(ver(5), ver(DEFAULT_VER), "criteria2"),
+        ],
+    );
+    config.exemptions.insert(
+        "transitive-third-party1".to_owned(),
+        vec![
+            exemptions(ver(5), "criteria1"),
+            exemptions(ver(5), "criteria2"),
+        ],
+    );
+
+    let mut store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, false, false).unwrap();
+
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!(
+        "builtin-simple-exemptions-regenerate-merge-nonew",
+        exemptions
+    );
+}
+
+#[test]
+fn builtin_simple_exemptions_regenerate_nonew_failed() {
+    // (Pass) minimize_exemptions will be a no-op if no new exemptions are
+    // allowed, and vet is failing.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, audits, imports) = builtin_files_inited(&metadata);
+
+    config.exemptions.clear();
+
+    config.exemptions.insert(
+        "transitive-third-party1".to_owned(),
+        vec![
+            exemptions(ver(300), SAFE_TO_DEPLOY),
+            exemptions(ver(400), SAFE_TO_DEPLOY),
+        ],
+    );
+    config.exemptions.insert(
+        "third-party1".to_owned(),
+        vec![exemptions(ver(300), SAFE_TO_DEPLOY)],
+    );
+    config.exemptions.insert(
+        "random-crate".to_owned(),
+        vec![exemptions(ver(300), SAFE_TO_DEPLOY)],
+    );
+
+    let mut store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, false, false).unwrap();
+
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!(
+        "builtin-simple-exemptions-regenerate-nonew-failed",
+        exemptions
+    );
 }

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-merge-nonew.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-merge-nonew.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/regenerate_unaudited.rs
+expression: exemptions
+---
+[[transitive-third-party1]]
+version = "5.0.0"
+criteria = "criteria1"
+
+[[transitive-third-party1]]
+version = "5.0.0"
+criteria = "criteria2"
+

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-merge.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-merge.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/regenerate_unaudited.rs
+expression: exemptions
+---
+[[transitive-third-party1]]
+version = "5.0.0"
+criteria = [
+    "criteria1",
+    "criteria2",
+]
+

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-nonew-failed.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-nonew-failed.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/regenerate_unaudited.rs
+expression: exemptions
+---
+[[random-crate]]
+version = "300.0.0"
+criteria = "safe-to-deploy"
+
+[[third-party1]]
+version = "300.0.0"
+criteria = "safe-to-deploy"
+
+[[transitive-third-party1]]
+version = "300.0.0"
+criteria = "safe-to-deploy"
+
+[[transitive-third-party1]]
+version = "400.0.0"
+criteria = "safe-to-deploy"
+

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -50,6 +50,10 @@ GLOBAL OPTIONS:
             Avoid the network entirely, requiring either that the cargo cache is populated or the
             dependencies are vendored. Requires --locked
 
+        --no-minimize-exemptions
+            Prevent commands such as `check` and `certify` from automatically cleaning up unused
+            exemptions
+
         --verbose <VERBOSE>
             How verbose logging should be (log level)
             

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -59,6 +59,10 @@ Do not fetch new imported audits
 Avoid the network entirely, requiring either that the cargo cache is populated or the
 dependencies are vendored. Requires --locked
 
+#### `--no-minimize-exemptions`
+Prevent commands such as `check` and `certify` from automatically cleaning up unused
+exemptions
+
 #### `--verbose <VERBOSE>`
 How verbose logging should be (log level)
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -35,6 +35,10 @@ GLOBAL OPTIONS:
             Avoid the network entirely, requiring either that the cargo cache is populated or the
             dependencies are vendored. Requires --locked
 
+        --no-minimize-exemptions
+            Prevent commands such as `check` and `certify` from automatically cleaning up unused
+            exemptions
+
         --verbose <VERBOSE>
             How verbose logging should be (log level) [default: warn] [possible values: off, error,
             warn, info, debug, trace]

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -82,7 +82,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hermit-abi]]
 version = "0.1.19"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.http]]
 version = "0.2.6"


### PR DESCRIPTION
This patch changes many commands to automatically minimize exemptions
when run under normal operation. This behaviour can be disabled using a
new command line flag: --no-minimize-exemptions.

This exemption minimizing algorithm is based on the regenerate
algorithm, but with extra guards in place to make sure that no new
exemptions can be added, and exemptions cannot have their scope
expanded.

In addition, extra flags were added to regenerate_exemptions to control
this behaviour as well as importing behaviour.

Fixes #262