### PR TITLE
Stop using 0.0.0 as the root version

### DIFF
--- a/book/src/algorithm.md
+++ b/book/src/algorithm.md
@@ -360,9 +360,8 @@ Each edge has a list of criteria is claims to certify, and dependency_criteria t
 dependencies of this package must satisfy for the edge to be considered "valid" (see
 the next section for details).
 
-There is an implicit Root Version which represents an empty package. As of this writing
-the Root Version is simply 0.0.0, but this isn't really correct and nodes should be more
-like `Option<Version>`.
+There is an implicit Root Version which represents an empty package, meaning that throughout
+much of the audit graph, versions are represented as `Option<Version>`.
 
 When trying to validate whether a particular version of a package is audited, we also add
 a Target Version to the graph (if it doesn't exist already).
@@ -768,10 +767,9 @@ This is slightly brain melty at first but nothing really needs to specially hand
 it Just Works.
 
 Any diff we recommend from the Root Version is "resugared" into recommending a full audit,
-(and is also computed by diffing against an empty directory). It should be impossible to
-recommend a diff *to* the Root Version because there should never be audits of the Root
-Version (barring the fact that we're sloppy right now and use 0.0.0 which totally can be
-published).
+(and is also computed by diffing against an empty directory). It is impossible
+to recommend a diff *to* the Root Version, because there cannot be audits of the
+Root Version.
 
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use tracing::{error, info, trace, warn};
 use crate::cli::*;
 use crate::errors::{CommandError, DownloadError, RegenerateExemptionsError};
 use crate::format::{
-    AuditEntry, AuditKind, AuditsFile, ConfigFile, CriteriaEntry, Delta, DependencyCriteria,
+    AuditEntry, AuditKind, AuditsFile, ConfigFile, CriteriaEntry, DependencyCriteria,
     ExemptedDependency, FetchCommand, ImportsFile, MetaConfig, MetaConfigInstance, PackageStr,
     SortedMap, StoreInfo,
 };
@@ -668,10 +668,8 @@ fn do_cmd_certify(
         if let Some(v2) = &sub_args.version2 {
             // This is a delta audit
             AuditKind::Delta {
-                delta: Delta {
-                    from: v1.clone(),
-                    to: v2.clone(),
-                },
+                from: v1.clone(),
+                to: v2.clone(),
                 dependency_criteria,
             }
         } else {
@@ -691,10 +689,8 @@ fn do_cmd_certify(
             FetchCommand::Diff {
                 version1, version2, ..
             } => AuditKind::Delta {
-                delta: Delta {
-                    from: version1,
-                    to: version2,
-                },
+                from: version1,
+                to: version2,
                 dependency_criteria,
             },
         }
@@ -719,7 +715,7 @@ fn do_cmd_certify(
     let criteria_names = if sub_args.criteria.is_empty() {
         let (from, to) = match &kind {
             AuditKind::Full { version, .. } => (None, version),
-            AuditKind::Delta { delta, .. } => (Some(&delta.from), &delta.to),
+            AuditKind::Delta { from, to, .. } => (Some(from), to),
             _ => unreachable!(),
         };
 
@@ -738,7 +734,7 @@ fn do_cmd_certify(
             write!(out, "choose criteria to certify for {}", package);
             match &kind {
                 AuditKind::Full { version, .. } => write!(out, ":{}", version),
-                AuditKind::Delta { delta, .. } => write!(out, ":{} -> {}", delta.from, delta.to),
+                AuditKind::Delta { from, to, .. } => write!(out, ":{} -> {}", from, to),
                 AuditKind::Violation { .. } => unreachable!(),
             }
             writeln!(out);
@@ -832,8 +828,8 @@ fn do_cmd_certify(
         AuditKind::Full { version, .. } => {
             format!("version {}", version)
         }
-        AuditKind::Delta { delta, .. } => {
-            format!("the changes from version {} to {}", delta.from, delta.to)
+        AuditKind::Delta { from, to, .. } => {
+            format!("the changes from version {} to {}", from, to)
         }
         AuditKind::Violation { .. } => unreachable!(),
     };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,8 +13,8 @@ use serde_json::{json, Value};
 use crate::{
     editor::Editor,
     format::{
-        AuditKind, CriteriaName, CriteriaStr, Delta, DependencyCriteria, FastMap, MetaConfig,
-        PackageName, PackageStr, PolicyEntry, SortedSet, VersionReq, SAFE_TO_DEPLOY, SAFE_TO_RUN,
+        AuditKind, CriteriaName, CriteriaStr, DependencyCriteria, FastMap, MetaConfig, PackageName,
+        PackageStr, PolicyEntry, SortedSet, VersionReq, SAFE_TO_DEPLOY, SAFE_TO_RUN,
     },
     init_files,
     out::Out,
@@ -306,13 +306,13 @@ fn exemptions_dep(
 }
 
 fn delta_audit(from: Version, to: Version, criteria: CriteriaStr) -> AuditEntry {
-    let delta = Delta { from, to };
     AuditEntry {
         who: None,
         notes: None,
         criteria: vec![criteria.to_string().into()],
         kind: AuditKind::Delta {
-            delta,
+            from,
+            to,
             dependency_criteria: DependencyCriteria::default(),
         },
         is_fresh_import: false,
@@ -331,13 +331,13 @@ fn delta_audit_dep(
         ),
     >,
 ) -> AuditEntry {
-    let delta = Delta { from, to };
     AuditEntry {
         who: None,
         notes: None,
         criteria: vec![criteria.to_string().into()],
         kind: AuditKind::Delta {
-            delta,
+            from,
+            to,
             dependency_criteria: dependency_criteria
                 .into_iter()
                 .map(|(k, v)| {

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-complex-no-unaudited.json.snap
@@ -48,7 +48,7 @@ expression: json
               "count": 25,
               "raw": "+25"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "5.0.0"
           }
         },
@@ -63,7 +63,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -78,7 +78,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -93,7 +93,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -111,7 +111,7 @@ expression: json
             "count": 25,
             "raw": "+25"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "5.0.0"
         }
       },
@@ -126,7 +126,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -141,7 +141,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -156,7 +156,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -51,7 +51,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -69,7 +69,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -84,7 +84,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
@@ -62,7 +62,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -77,7 +77,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -94,7 +94,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -109,7 +109,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -124,7 +124,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -139,7 +139,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -157,7 +157,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -172,7 +172,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -187,7 +187,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -202,7 +202,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -217,7 +217,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -232,7 +232,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
@@ -48,7 +48,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -63,7 +63,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -80,7 +80,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -95,7 +95,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -113,7 +113,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -128,7 +128,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -143,7 +143,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -158,7 +158,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -51,7 +51,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -69,7 +69,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -84,7 +84,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -51,7 +51,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -69,7 +69,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -84,7 +84,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-no-audit.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-audit-as-default-root-too-weak.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
@@ -62,7 +62,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -77,7 +77,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -92,7 +92,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -107,7 +107,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -124,7 +124,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -139,7 +139,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -157,7 +157,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -172,7 +172,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -187,7 +187,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -202,7 +202,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -217,7 +217,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -232,7 +232,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-no-unaudited.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-unaudited-nested-weaker-req-needs-dep-criteria.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin_simple_foreign_dep_criteria_fail.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 25,
               "raw": "+25"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "5.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 25,
             "raw": "+25"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "5.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 25,
               "raw": "+25"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "5.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 25,
             "raw": "+25"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "5.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
@@ -48,7 +48,7 @@ expression: json
               "count": 25,
               "raw": "+25"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "5.0.0"
           }
         },
@@ -63,7 +63,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -78,7 +78,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -93,7 +93,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -111,7 +111,7 @@ expression: json
             "count": 25,
             "raw": "+25"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "5.0.0"
         }
       },
@@ -126,7 +126,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -141,7 +141,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -156,7 +156,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 25,
               "raw": "+25"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "5.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 25,
             "raw": "+25"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "5.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-extra-missing.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-dep-too-strong.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-extra-partially-missing.json.snap
@@ -27,7 +27,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -45,7 +45,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-first-too-strong.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-dep-too-strong.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__simple-policy-root-too-strong.json.snap
@@ -34,7 +34,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         },
@@ -49,7 +49,7 @@ expression: json
               "count": 100,
               "raw": "+100"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "10.0.0"
           }
         }
@@ -67,7 +67,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       },
@@ -82,7 +82,7 @@ expression: json
             "count": 100,
             "raw": "+100"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "10.0.0"
         }
       }

--- a/tests/diff-cache.toml
+++ b/tests/diff-cache.toml
@@ -1,1757 +1,1758 @@
+version = "1"
 
-[alsa."0.0.0 -> 0.4.3"]
+[diffs.alsa."0.4.3"]
 raw = """
  23 files changed, 12197 insertions(+)
 """
 count = 12197
 
-[anyhow."0.0.0 -> 1.0.52"]
+[diffs.anyhow."1.0.52"]
 raw = """
  49 files changed, 6219 insertions(+)
 """
 count = 6219
 
-[app_units."0.0.0 -> 0.7.1"]
+[diffs.app_units."0.7.1"]
 raw = """
  8 files changed, 507 insertions(+)
 """
 count = 507
 
-[arbitrary."0.0.0 -> 1.0.3"]
+[diffs.arbitrary."1.0.3"]
 raw = """
  19 files changed, 3159 insertions(+)
 """
 count = 3159
 
-[arrayref."0.0.0 -> 0.3.6"]
+[diffs.arrayref."0.3.6"]
 raw = """
  13 files changed, 986 insertions(+)
 """
 count = 986
 
-[arrayvec."0.0.0 -> 0.5.2"]
+[diffs.arrayvec."0.5.2"]
 raw = """
  22 files changed, 3776 insertions(+)
 """
 count = 3776
 
-[arrayvec."0.0.0 -> 0.7.2"]
+[diffs.arrayvec."0.7.2"]
 raw = """
  22 files changed, 3998 insertions(+)
 """
 count = 3998
 
-[ash."0.0.0 -> 0.37.0+1.3.209"]
+[diffs.ash."0.37.0+1.3.209"]
 raw = """
  91 files changed, 112995 insertions(+)
 """
 count = 112995
 
-[async-trait."0.0.0 -> 0.1.52"]
+[diffs.async-trait."0.1.52"]
 raw = """
  42 files changed, 3626 insertions(+)
 """
 count = 3626
 
-[atomic_refcell."0.0.0 -> 0.1.8"]
+[diffs.atomic_refcell."0.1.8"]
 raw = """
  9 files changed, 720 insertions(+)
 """
 count = 720
 
-[atty."0.0.0 -> 0.2.14"]
+[diffs.atty."0.2.14"]
 raw = """
  12 files changed, 508 insertions(+)
 """
 count = 508
 
-[audio_thread_priority."0.0.0 -> 0.26.1"]
+[diffs.audio_thread_priority."0.26.1"]
 raw = """
  17 files changed, 2069 insertions(+)
 """
 count = 2069
 
-[authenticator."0.0.0 -> 0.3.1"]
+[diffs.authenticator."0.3.1"]
 raw = """
  86 files changed, 10263 insertions(+)
 """
 count = 10263
 
-[base64."0.0.0 -> 0.10.1"]
+[diffs.base64."0.10.1"]
 raw = """
  27 files changed, 5450 insertions(+)
 """
 count = 5450
 
-[base64."0.0.0 -> 0.12.3"]
+[diffs.base64."0.12.3"]
 raw = """
  31 files changed, 7929 insertions(+)
 """
 count = 7929
 
-[bincode."0.0.0 -> 1.3.3"]
+[diffs.bincode."1.3.3"]
 raw = """
  24 files changed, 5153 insertions(+)
 """
 count = 5153
 
-[bindgen."0.0.0 -> 0.56.0"]
+[diffs.bindgen."0.56.0"]
 raw = """
  56 files changed, 27831 insertions(+)
 """
 count = 27831
 
-[bit-set."0.0.0 -> 0.5.2"]
+[diffs.bit-set."0.5.2"]
 raw = """
  11 files changed, 1786 insertions(+)
 """
 count = 1786
 
-[bitflags."0.0.0 -> 1.3.2"]
+[diffs.bitflags."1.3.2"]
 raw = """
  39 files changed, 3004 insertions(+)
 """
 count = 3004
 
-[bitflags_serde_shim."0.0.0 -> 0.2.2"]
+[diffs.bitflags_serde_shim."0.2.2"]
 raw = """
  4 files changed, 174 insertions(+)
 """
 count = 174
 
-[bitreader."0.0.0 -> 0.3.5"]
+[diffs.bitreader."0.3.5"]
 raw = """
  11 files changed, 1106 insertions(+)
 """
 count = 1106
 
-[block."0.0.0 -> 0.1.6"]
+[diffs.block."0.1.6"]
 raw = """
  5 files changed, 493 insertions(+)
 """
 count = 493
 
-[build-parallel."0.0.0 -> 0.1.2"]
+[diffs.build-parallel."0.1.2"]
 raw = """
  6 files changed, 284 insertions(+)
 """
 count = 284
 
-[bumpalo."0.0.0 -> 3.9.1"]
+[diffs.bumpalo."3.9.1"]
 raw = """
  19 files changed, 10106 insertions(+)
 """
 count = 10106
 
-[byteorder."0.0.0 -> 1.4.3"]
+[diffs.byteorder."1.4.3"]
 raw = """
  15 files changed, 6460 insertions(+)
 """
 count = 6460
 
-[bytes."0.0.0 -> 0.5.6"]
+[diffs.bytes."0.5.6"]
 raw = """
  44 files changed, 8795 insertions(+)
 """
 count = 8795
 
-[bytes."0.0.0 -> 1.1.0"]
+[diffs.bytes."1.1.0"]
 raw = """
  45 files changed, 9213 insertions(+)
 """
 count = 9213
 
-[cc."0.0.0 -> 1.0.72"]
+[diffs.cc."1.0.72"]
 raw = """
  22 files changed, 6650 insertions(+)
 """
 count = 6650
 
-[cc."0.0.0 -> 1.0.73"]
+[diffs.cc."1.0.73"]
 raw = """
  22 files changed, 6671 insertions(+)
 """
 count = 6671
 
-[cfg-if."0.0.0 -> 0.1.10"]
+[diffs.cfg-if."0.1.10"]
 raw = """
  11 files changed, 585 insertions(+)
 """
 count = 585
 
-[cfg-if."0.0.0 -> 1.0.0"]
+[diffs.cfg-if."1.0.0"]
 raw = """
  11 files changed, 588 insertions(+)
 """
 count = 588
 
-[cfg_aliases."0.0.0 -> 0.1.1"]
+[diffs.cfg_aliases."0.1.1"]
 raw = """
  9 files changed, 572 insertions(+)
 """
 count = 572
 
-[chrono."0.0.0 -> 0.4.19"]
+[diffs.chrono."0.4.19"]
 raw = """
  43 files changed, 21364 insertions(+)
 """
 count = 21364
 
-[clap."0.0.0 -> 3.0.10"]
+[diffs.clap."3.0.10"]
 raw = """
  112 files changed, 30563 insertions(+)
 """
 count = 30563
 
-[codespan-reporting."0.0.0 -> 0.11.1"]
+[diffs.codespan-reporting."0.11.1"]
 raw = """
  112 files changed, 7370 insertions(+)
 """
 count = 7370
 
-[comedy."0.0.0 -> 0.2.0"]
+[diffs.comedy."0.2.0"]
 raw = """
  11 files changed, 1258 insertions(+)
 """
 count = 1258
 
-[cookie."0.0.0 -> 0.12.0"]
+[diffs.cookie."0.12.0"]
 raw = """
  20 files changed, 3581 insertions(+)
 """
 count = 3581
 
-[copyless."0.0.0 -> 0.1.5"]
+[diffs.copyless."0.1.5"]
 raw = """
  15 files changed, 498 insertions(+)
 """
 count = 498
 
-[core-foundation."0.0.0 -> 0.9.2"]
+[diffs.core-foundation."0.9.2"]
 raw = """
  28 files changed, 3950 insertions(+)
 """
 count = 3950
 
-[core-foundation."0.0.0 -> 0.9.3"]
+[diffs.core-foundation."0.9.3"]
 raw = """
  28 files changed, 3960 insertions(+)
 """
 count = 3960
 
-[core-foundation-sys."0.0.0 -> 0.8.3"]
+[diffs.core-foundation-sys."0.8.3"]
 raw = """
  28 files changed, 1971 insertions(+)
 """
 count = 1971
 
-[core-graphics."0.0.0 -> 0.22.3"]
+[diffs.core-graphics."0.22.3"]
 raw = """
  27 files changed, 3893 insertions(+)
 """
 count = 3893
 
-[core-graphics-types."0.0.0 -> 0.1.1"]
+[diffs.core-graphics-types."0.1.1"]
 raw = """
  7 files changed, 297 insertions(+)
 """
 count = 297
 
-[core-text."0.0.0 -> 19.2.0"]
+[diffs.core-text."19.2.0"]
 raw = """
  20 files changed, 2175 insertions(+)
 """
 count = 2175
 
-[coremidi-sys."0.0.0 -> 3.0.1"]
+[diffs.coremidi-sys."3.0.1"]
 raw = """
  12 files changed, 1144 insertions(+)
 """
 count = 1144
 
-[cose-c."0.0.0 -> 0.1.5"]
+[diffs.cose-c."0.1.5"]
 raw = """
  7 files changed, 541 insertions(+)
 """
 count = 541
 
-[cranelift-codegen."0.0.0 -> 0.74.0"]
+[diffs.cranelift-codegen."0.74.0"]
 raw = """
  197 files changed, 122486 insertions(+)
 """
 count = 122486
 
-[cranelift-wasm."0.0.0 -> 0.74.0"]
+[diffs.cranelift-wasm."0.74.0"]
 raw = """
  72 files changed, 75262 insertions(+)
 """
 count = 75262
 
-[crossbeam-channel."0.0.0 -> 0.5.4"]
+[diffs.crossbeam-channel."0.5.4"]
 raw = """
  44 files changed, 20248 insertions(+)
 """
 count = 20248
 
-[cssparser."0.0.0 -> 0.29.2"]
+[diffs.cssparser."0.29.2"]
 raw = """
  26 files changed, 7500 insertions(+)
 """
 count = 7500
 
-[cstr."0.0.0 -> 0.2.9"]
+[diffs.cstr."0.2.9"]
 raw = """
  25 files changed, 605 insertions(+)
 """
 count = 605
 
-[darling."0.0.0 -> 0.13.1"]
+[diffs.darling."0.13.1"]
 raw = """
  39 files changed, 2356 insertions(+)
 """
 count = 2356
 
-[derive_more."0.0.0 -> 0.99.11"]
+[diffs.derive_more."0.99.11"]
 raw = """
  67 files changed, 10748 insertions(+)
 """
 count = 10748
 
-[dirs."0.0.0 -> 2.0.2"]
+[diffs.dirs."2.0.2"]
 raw = """
  15 files changed, 888 insertions(+)
 """
 count = 888
 
-[dns-parser."0.0.0 -> 0.8.0"]
+[diffs.dns-parser."0.8.0"]
 raw = """
  44 files changed, 3006 insertions(+)
 """
 count = 3006
 
-[dogear."0.0.0 -> 0.4.0"]
+[diffs.dogear."0.4.0"]
 raw = """
  16 files changed, 8372 insertions(+)
 """
 count = 8372
 
-[dwrote."0.0.0 -> 0.11.0"]
+[diffs.dwrote."0.11.0"]
 raw = """
  28 files changed, 3177 insertions(+)
 """
 count = 3177
 
-[encoding_c."0.0.0 -> 0.9.8"]
+[diffs.encoding_c."0.9.8"]
 raw = """
  16 files changed, 3963 insertions(+)
 """
 count = 3963
 
-[encoding_c_mem."0.0.0 -> 0.2.6"]
+[diffs.encoding_c_mem."0.2.6"]
 raw = """
  14 files changed, 2495 insertions(+)
 """
 count = 2495
 
-[encoding_rs."0.0.0 -> 0.8.22"]
+[diffs.encoding_rs."0.8.22"]
 raw = """
  102 files changed, 506887 insertions(+)
 """
 count = 506887
 
-[encoding_rs."0.0.0 -> 0.8.31"]
+[diffs.encoding_rs."0.8.31"]
 raw = """
  104 files changed, 507252 insertions(+)
 """
 count = 507252
 
-[enumset."0.0.0 -> 1.0.8"]
+[diffs.enumset."1.0.8"]
 raw = """
  16 files changed, 1979 insertions(+)
 """
 count = 1979
 
-[env_logger."0.0.0 -> 0.8.4"]
+[diffs.env_logger."0.8.4"]
 raw = """
  26 files changed, 4661 insertions(+)
 """
 count = 4661
 
-[etagere."0.0.0 -> 0.2.6"]
+[diffs.etagere."0.2.6"]
 raw = """
  10 files changed, 2347 insertions(+)
 """
 count = 2347
 
-[euclid."0.0.0 -> 0.22.6"]
+[diffs.euclid."0.22.6"]
 raw = """
  32 files changed, 16357 insertions(+)
 """
 count = 16357
 
-[fallible_collections."0.0.0 -> 0.4.2"]
+[diffs.fallible_collections."0.4.2"]
 raw = """
  21 files changed, 7560 insertions(+)
 """
 count = 7560
 
-[fastrand."0.0.0 -> 1.7.0"]
+[diffs.fastrand."1.7.0"]
 raw = """
  12 files changed, 1375 insertions(+)
 """
 count = 1375
 
-[ffi-support."0.0.0 -> 0.4.4"]
+[diffs.ffi-support."0.4.4"]
 raw = """
  18 files changed, 3952 insertions(+)
 """
 count = 3952
 
-[filetime_win."0.0.0 -> 0.2.0"]
+[diffs.filetime_win."0.2.0"]
 raw = """
  8 files changed, 564 insertions(+)
 """
 count = 564
 
-[fluent."0.0.0 -> 0.16.0"]
+[diffs.fluent."0.16.0"]
 raw = """
  8 files changed, 519 insertions(+)
 """
 count = 519
 
-[fluent-bundle."0.0.0 -> 0.15.2"]
+[diffs.fluent-bundle."0.15.2"]
 raw = """
  29 files changed, 4238 insertions(+)
 """
 count = 4238
 
-[fluent-fallback."0.0.0 -> 0.6.0"]
+[diffs.fluent-fallback."0.6.0"]
 raw = """
  29 files changed, 3102 insertions(+)
 """
 count = 3102
 
-[fluent-langneg."0.0.0 -> 0.13.0"]
+[diffs.fluent-langneg."0.13.0"]
 raw = """
  11 files changed, 1329 insertions(+)
 """
 count = 1329
 
-[fluent-pseudo."0.0.0 -> 0.3.1"]
+[diffs.fluent-pseudo."0.3.1"]
 raw = """
  8 files changed, 464 insertions(+)
 """
 count = 464
 
-[fnv."0.0.0 -> 1.0.7"]
+[diffs.fnv."1.0.7"]
 raw = """
  10 files changed, 736 insertions(+)
 """
 count = 736
 
-[foreign-types."0.0.0 -> 0.3.2"]
+[diffs.foreign-types."0.3.2"]
 raw = """
  7 files changed, 584 insertions(+)
 """
 count = 584
 
-[foreign-types-shared."0.0.0 -> 0.1.1"]
+[diffs.foreign-types-shared."0.1.1"]
 raw = """
  6 files changed, 303 insertions(+)
 """
 count = 303
 
-[form_urlencoded."0.0.0 -> 1.0.1"]
+[diffs.form_urlencoded."1.0.1"]
 raw = """
  7 files changed, 695 insertions(+)
 """
 count = 695
 
-[freetype."0.0.0 -> 0.7.0"]
+[diffs.freetype."0.7.0"]
 raw = """
  17 files changed, 3042 insertions(+)
 """
 count = 3042
 
-[fuchsia-zircon."0.0.0 -> 0.3.3"]
+[diffs.fuchsia-zircon."0.3.3"]
 raw = """
  26 files changed, 2871 insertions(+)
 """
 count = 2871
 
-[fuchsia-zircon-sys."0.0.0 -> 0.3.3"]
+[diffs.fuchsia-zircon-sys."0.3.3"]
 raw = """
  7 files changed, 1427 insertions(+)
 """
 count = 1427
 
-[futures."0.0.0 -> 0.3.19"]
+[diffs.futures."0.3.19"]
 raw = """
  65 files changed, 8382 insertions(+)
 """
 count = 8382
 
-[futures-channel."0.0.0 -> 0.3.19"]
+[diffs.futures-channel."0.3.19"]
 raw = """
  20 files changed, 3958 insertions(+)
 """
 count = 3958
 
-[futures-channel."0.0.0 -> 0.3.21"]
+[diffs.futures-channel."0.3.21"]
 raw = """
  20 files changed, 3999 insertions(+)
 """
 count = 3999
 
-[futures-core."0.0.0 -> 0.3.21"]
+[diffs.futures-core."0.3.21"]
 raw = """
  16 files changed, 1182 insertions(+)
 """
 count = 1182
 
-[futures-sink."0.0.0 -> 0.3.21"]
+[diffs.futures-sink."0.3.21"]
 raw = """
  8 files changed, 551 insertions(+)
 """
 count = 551
 
-[futures-task."0.0.0 -> 0.3.19"]
+[diffs.futures-task."0.3.19"]
 raw = """
  16 files changed, 1188 insertions(+)
 """
 count = 1188
 
-[futures-task."0.0.0 -> 0.3.21"]
+[diffs.futures-task."0.3.21"]
 raw = """
  16 files changed, 1187 insertions(+)
 """
 count = 1187
 
-[futures-util."0.0.0 -> 0.3.21"]
+[diffs.futures-util."0.3.21"]
 raw = """
  187 files changed, 25074 insertions(+)
 """
 count = 25074
 
-[fxhash."0.0.0 -> 0.2.1"]
+[diffs.fxhash."0.2.1"]
 raw = """
  7 files changed, 539 insertions(+)
 """
 count = 539
 
-[gleam."0.0.0 -> 0.13.1"]
+[diffs.gleam."0.13.1"]
 raw = """
  16 files changed, 5765 insertions(+)
 """
 count = 5765
 
-[glean."0.0.0 -> 44.0.0"]
+[diffs.glean."44.0.0"]
 raw = """
  48 files changed, 7386 insertions(+)
 """
 count = 7386
 
-[glean-ffi."0.0.0 -> 44.0.0"]
+[diffs.glean-ffi."44.0.0"]
 raw = """
  33 files changed, 4131 insertions(+)
 """
 count = 4131
 
-[glow."0.0.0 -> 0.11.2"]
+[diffs.glow."0.11.2"]
 raw = """
  18 files changed, 47092 insertions(+)
 """
 count = 47092
 
-[glsl."0.0.0 -> 4.1.1"]
+[diffs.glsl."4.1.1"]
 raw = """
  22 files changed, 10218 insertions(+)
 """
 count = 10218
 
-[glslopt."0.0.0 -> 0.1.9"]
+[diffs.glslopt."0.1.9"]
 raw = """
  309 files changed, 184134 insertions(+)
 """
 count = 184134
 
-[goblin."0.0.0 -> 0.1.3"]
+[diffs.goblin."0.1.3"]
 raw = """
  61 files changed, 17285 insertions(+)
 """
 count = 17285
 
-[gpu-alloc."0.0.0 -> 0.5.2"]
+[diffs.gpu-alloc."0.5.2"]
 raw = """
  15 files changed, 2557 insertions(+)
 """
 count = 2557
 
-[gpu-descriptor."0.0.0 -> 0.2.1"]
+[diffs.gpu-descriptor."0.2.1"]
 raw = """
  6 files changed, 708 insertions(+)
 """
 count = 708
 
-[guid_win."0.0.0 -> 0.2.0"]
+[diffs.guid_win."0.2.0"]
 raw = """
  8 files changed, 481 insertions(+)
 """
 count = 481
 
-[h2."0.0.0 -> 0.3.13"]
+[diffs.h2."0.3.13"]
 raw = """
  66 files changed, 26066 insertions(+)
 """
 count = 26066
 
-[hashbrown."0.0.0 -> 0.11.2"]
+[diffs.hashbrown."0.11.2"]
 raw = """
  33 files changed, 14609 insertions(+)
 """
 count = 14609
 
-[hermit-abi."0.0.0 -> 0.1.19"]
+[diffs.hermit-abi."0.1.19"]
 raw = """
  11 files changed, 938 insertions(+)
 """
 count = 938
 
-[hexf-parse."0.0.0 -> 0.2.1"]
+[diffs.hexf-parse."0.2.1"]
 raw = """
  5 files changed, 572 insertions(+)
 """
 count = 572
 
-[http."0.0.0 -> 0.2.5"]
+[diffs.http."0.2.5"]
 raw = """
  41 files changed, 16823 insertions(+)
 """
 count = 16823
 
-[http."0.0.0 -> 0.2.6"]
+[diffs.http."0.2.6"]
 raw = """
  41 files changed, 16826 insertions(+)
 """
 count = 16826
 
-[http-body."0.0.0 -> 0.4.4"]
+[diffs.http-body."0.4.4"]
 raw = """
  19 files changed, 1262 insertions(+)
 """
 count = 1262
 
-[httparse."0.0.0 -> 1.7.0"]
+[diffs.httparse."1.7.0"]
 raw = """
  20 files changed, 7265 insertions(+)
 """
 count = 7265
 
-[httpdate."0.0.0 -> 1.0.2"]
+[diffs.httpdate."1.0.2"]
 raw = """
  12 files changed, 1001 insertions(+)
 """
 count = 1001
 
-[hyper."0.0.0 -> 0.13.6"]
+[diffs.hyper."0.13.6"]
 raw = """
  59 files changed, 19743 insertions(+)
 """
 count = 19743
 
-[hyper."0.0.0 -> 0.14.18"]
+[diffs.hyper."0.14.18"]
 raw = """
  72 files changed, 25617 insertions(+)
 """
 count = 25617
 
-[hyper-tls."0.0.0 -> 0.5.0"]
+[diffs.hyper-tls."0.5.0"]
 raw = """
  14 files changed, 1301 insertions(+)
 """
 count = 1301
 
-[idna."0.0.0 -> 0.2.3"]
+[diffs.idna."0.2.3"]
 raw = """
  19 files changed, 32538 insertions(+)
 """
 count = 32538
 
-[indexmap."0.0.0 -> 1.6.2"]
+[diffs.indexmap."1.6.2"]
 raw = """
  31 files changed, 8568 insertions(+)
 """
 count = 8568
 
-[indexmap."0.0.0 -> 1.8.1"]
+[diffs.indexmap."1.8.1"]
 raw = """
  33 files changed, 9452 insertions(+)
 """
 count = 9452
 
-[inherent."0.0.0 -> 0.1.6"]
+[diffs.inherent."0.1.6"]
 raw = """
  24 files changed, 924 insertions(+)
 """
 count = 924
 
-[inplace_it."0.0.0 -> 0.3.3"]
+[diffs.inplace_it."0.3.3"]
 raw = """
  26 files changed, 1269 insertions(+)
 """
 count = 1269
 
-[instant."0.0.0 -> 0.1.12"]
+[diffs.instant."0.1.12"]
 raw = """
  14 files changed, 678 insertions(+)
 """
 count = 678
 
-[intl-memoizer."0.0.0 -> 0.5.1"]
+[diffs.intl-memoizer."0.5.1"]
 raw = """
  10 files changed, 608 insertions(+)
 """
 count = 608
 
-[iovec."0.0.0 -> 0.1.4"]
+[diffs.iovec."0.1.4"]
 raw = """
  18 files changed, 804 insertions(+)
 """
 count = 804
 
-[ipnet."0.0.0 -> 2.4.0"]
+[diffs.ipnet."2.4.0"]
 raw = """
  15 files changed, 3980 insertions(+)
 """
 count = 3980
 
-[itertools."0.0.0 -> 0.8.2"]
+[diffs.itertools."0.8.2"]
 raw = """
  66 files changed, 13607 insertions(+)
 """
 count = 13607
 
-[itoa."0.0.0 -> 0.4.8"]
+[diffs.itoa."0.4.8"]
 raw = """
  15 files changed, 964 insertions(+)
 """
 count = 964
 
-[itoa."0.0.0 -> 1.0.1"]
+[diffs.itoa."1.0.1"]
 raw = """
  15 files changed, 796 insertions(+)
 """
 count = 796
 
-[js-sys."0.0.0 -> 0.3.57"]
+[diffs.js-sys."0.3.57"]
 raw = """
  63 files changed, 12875 insertions(+)
 """
 count = 12875
 
-[khronos-egl."0.0.0 -> 4.1.0"]
+[diffs.khronos-egl."4.1.0"]
 raw = """
  19 files changed, 4036 insertions(+)
 """
 count = 4036
 
-[lazy_static."0.0.0 -> 1.4.0"]
+[diffs.lazy_static."1.4.0"]
 raw = """
  13 files changed, 882 insertions(+)
 """
 count = 882
 
-[libc."0.0.0 -> 0.2.112"]
+[diffs.libc."0.2.112"]
 raw = """
  205 files changed, 91329 insertions(+)
 """
 count = 91329
 
-[libc."0.0.0 -> 0.2.123"]
+[diffs.libc."0.2.123"]
 raw = """
  217 files changed, 94067 insertions(+)
 """
 count = 94067
 
-[libloading."0.0.0 -> 0.5.2"]
+[diffs.libloading."0.5.2"]
 raw = """
  23 files changed, 1679 insertions(+)
 """
 count = 1679
 
-[libloading."0.0.0 -> 0.7.2"]
+[diffs.libloading."0.7.2"]
 raw = """
  25 files changed, 2835 insertions(+)
 """
 count = 2835
 
-[lmdb-rkv-sys."0.0.0 -> 0.11.2"]
+[diffs.lmdb-rkv-sys."0.11.2"]
 raw = """
  43 files changed, 18970 insertions(+)
 """
 count = 18970
 
-[log."0.0.0 -> 0.4.14"]
+[diffs.log."0.4.14"]
 raw = """
  21 files changed, 4965 insertions(+)
 """
 count = 4965
 
-[log."0.0.0 -> 0.4.16"]
+[diffs.log."0.4.16"]
 raw = """
  21 files changed, 5632 insertions(+)
 """
 count = 5632
 
-[malloc_size_of_derive."0.0.0 -> 0.1.2"]
+[diffs.malloc_size_of_derive."0.1.2"]
 raw = """
  8 files changed, 426 insertions(+)
 """
 count = 426
 
-[matches."0.0.0 -> 0.1.9"]
+[diffs.matches."0.1.9"]
 raw = """
  7 files changed, 211 insertions(+)
 """
 count = 211
 
-[memalloc."0.0.0 -> 0.1.0"]
+[diffs.memalloc."0.1.0"]
 raw = """
  6 files changed, 233 insertions(+)
 """
 count = 233
 
-[memchr."0.0.0 -> 2.4.1"]
+[diffs.memchr."2.4.1"]
 raw = """
  48 files changed, 8718 insertions(+)
 """
 count = 8718
 
-[memmap2."0.0.0 -> 0.2.3"]
+[diffs.memmap2."0.2.3"]
 raw = """
  16 files changed, 2571 insertions(+)
 """
 count = 2571
 
-[memmap2."0.0.0 -> 0.3.1"]
+[diffs.memmap2."0.3.1"]
 raw = """
  16 files changed, 2748 insertions(+)
 """
 count = 2748
 
-[memoffset."0.0.0 -> 0.5.6"]
+[diffs.memoffset."0.5.6"]
 raw = """
  14 files changed, 889 insertions(+)
 """
 count = 889
 
-[mime."0.0.0 -> 0.3.16"]
+[diffs.mime."0.3.16"]
 raw = """
  15 files changed, 1721 insertions(+)
 """
 count = 1721
 
-[mio."0.0.0 -> 0.8.2"]
+[diffs.mio."0.8.2"]
 raw = """
  65 files changed, 11882 insertions(+)
 """
 count = 11882
 
-[mio-extras."0.0.0 -> 2.0.6"]
+[diffs.mio-extras."2.0.6"]
 raw = """
  15 files changed, 2311 insertions(+)
 """
 count = 2311
 
-[miow."0.0.0 -> 0.3.7"]
+[diffs.miow."0.3.7"]
 raw = """
  16 files changed, 3135 insertions(+)
 """
 count = 3135
 
-[native-tls."0.0.0 -> 0.2.10"]
+[diffs.native-tls."0.2.10"]
 raw = """
  21 files changed, 4089 insertions(+)
 """
 count = 4089
 
-[net2."0.0.0 -> 0.2.37"]
+[diffs.net2."0.2.37"]
 raw = """
  22 files changed, 3296 insertions(+)
 """
 count = 3296
 
-[new_debug_unreachable."0.0.0 -> 1.0.4"]
+[diffs.new_debug_unreachable."1.0.4"]
 raw = """
  12 files changed, 193 insertions(+)
 """
 count = 193
 
-[nix."0.0.0 -> 0.15.0"]
+[diffs.nix."0.15.0"]
 raw = """
  97 files changed, 26548 insertions(+)
 """
 count = 26548
 
-[ntapi."0.0.0 -> 0.3.7"]
+[diffs.ntapi."0.3.7"]
 raw = """
  44 files changed, 21234 insertions(+)
 """
 count = 21234
 
-[num-derive."0.0.0 -> 0.3.3"]
+[diffs.num-derive."0.3.3"]
 raw = """
  20 files changed, 1799 insertions(+)
 """
 count = 1799
 
-[num-integer."0.0.0 -> 0.1.44"]
+[diffs.num-integer."0.1.44"]
 raw = """
  18 files changed, 3420 insertions(+)
 """
 count = 3420
 
-[num-traits."0.0.0 -> 0.2.14"]
+[diffs.num-traits."0.2.14"]
 raw = """
  28 files changed, 7965 insertions(+)
 """
 count = 7965
 
-[num_cpus."0.0.0 -> 1.13.1"]
+[diffs.num_cpus."1.13.1"]
 raw = """
  26 files changed, 1577 insertions(+)
 """
 count = 1577
 
-[objc."0.0.0 -> 0.2.7"]
+[diffs.objc."0.2.7"]
 raw = """
  28 files changed, 2906 insertions(+)
 """
 count = 2906
 
-[once_cell."0.0.0 -> 1.9.0"]
+[diffs.once_cell."1.9.0"]
 raw = """
  24 files changed, 4126 insertions(+)
 """
 count = 4126
 
-[once_cell."0.0.0 -> 1.10.0"]
+[diffs.once_cell."1.10.0"]
 raw = """
  24 files changed, 4140 insertions(+)
 """
 count = 4140
 
-[openssl."0.0.0 -> 0.10.38"]
+[diffs.openssl."0.10.38"]
 raw = """
  85 files changed, 28634 insertions(+)
 """
 count = 28634
 
-[openssl-probe."0.0.0 -> 0.1.5"]
+[diffs.openssl-probe."0.1.5"]
 raw = """
  12 files changed, 456 insertions(+)
 """
 count = 456
 
-[openssl-sys."0.0.0 -> 0.9.72"]
+[diffs.openssl-sys."0.9.72"]
 raw = """
  48 files changed, 9484 insertions(+)
 """
 count = 9484
 
-[origin-trial-token."0.0.0 -> 0.1.0"]
+[diffs.origin-trial-token."0.1.0"]
 raw = """
  7 files changed, 429 insertions(+)
 """
 count = 429
 
-[os_str_bytes."0.0.0 -> 6.0.0"]
+[diffs.os_str_bytes."6.0.0"]
 raw = """
  23 files changed, 2918 insertions(+)
 """
 count = 2918
 
-[owning_ref."0.0.0 -> 0.4.1"]
+[diffs.owning_ref."0.4.1"]
 raw = """
  10 files changed, 2177 insertions(+)
 """
 count = 2177
 
-[parking_lot."0.0.0 -> 0.11.1"]
+[diffs.parking_lot."0.11.1"]
 raw = """
  25 files changed, 5561 insertions(+)
 """
 count = 5561
 
-[percent-encoding."0.0.0 -> 2.1.0"]
+[diffs.percent-encoding."2.1.0"]
 raw = """
  7 files changed, 708 insertions(+)
 """
 count = 708
 
-[phf."0.0.0 -> 0.8.0"]
+[diffs.phf."0.8.0"]
 raw = """
  7 files changed, 517 insertions(+)
 """
 count = 517
 
-[phf_codegen."0.0.0 -> 0.8.0"]
+[diffs.phf_codegen."0.8.0"]
 raw = """
  5 files changed, 356 insertions(+)
 """
 count = 356
 
-[pin-project-lite."0.0.0 -> 0.2.7"]
+[diffs.pin-project-lite."0.2.7"]
 raw = """
  72 files changed, 6247 insertions(+)
 """
 count = 6247
 
-[pin-project-lite."0.0.0 -> 0.2.8"]
+[diffs.pin-project-lite."0.2.8"]
 raw = """
  72 files changed, 6107 insertions(+)
 """
 count = 6107
 
-[pin-utils."0.0.0 -> 0.1.0"]
+[diffs.pin-utils."0.1.0"]
 raw = """
  15 files changed, 544 insertions(+)
 """
 count = 544
 
-[pkcs11."0.0.0 -> 0.4.2"]
+[diffs.pkcs11."0.4.2"]
 raw = """
  15 files changed, 6743 insertions(+)
 """
 count = 6743
 
-[pkg-config."0.0.0 -> 0.3.25"]
+[diffs.pkg-config."0.3.25"]
 raw = """
  16 files changed, 1754 insertions(+)
 """
 count = 1754
 
-[plane-split."0.0.0 -> 0.17.1"]
+[diffs.plane-split."0.17.1"]
 raw = """
  17 files changed, 2300 insertions(+)
 """
 count = 2300
 
-[plist."0.0.0 -> 0.5.5"]
+[diffs.plist."0.5.5"]
 raw = """
  34 files changed, 6231 insertions(+)
 """
 count = 6231
 
-[precomputed-hash."0.0.0 -> 0.1.1"]
+[diffs.precomputed-hash."0.1.1"]
 raw = """
  6 files changed, 77 insertions(+)
 """
 count = 77
 
-[proc-macro2."0.0.0 -> 1.0.36"]
+[diffs.proc-macro2."1.0.36"]
 raw = """
  22 files changed, 5685 insertions(+)
 """
 count = 5685
 
-[proc-macro2."0.0.0 -> 1.0.37"]
+[diffs.proc-macro2."1.0.37"]
 raw = """
  22 files changed, 5702 insertions(+)
 """
 count = 5702
 
-[profiling."0.0.0 -> 1.0.5"]
+[diffs.profiling."1.0.5"]
 raw = """
  52 files changed, 4679 insertions(+)
 """
 count = 4679
 
-[prost."0.0.0 -> 0.8.0"]
+[diffs.prost."0.8.0"]
 raw = """
  19 files changed, 3723 insertions(+)
 """
 count = 3723
 
-[prost-derive."0.0.0 -> 0.8.0"]
+[diffs.prost-derive."0.8.0"]
 raw = """
  12 files changed, 2492 insertions(+)
 """
 count = 2492
 
-[qlog."0.0.0 -> 0.4.0"]
+[diffs.qlog."0.4.0"]
 raw = """
  7 files changed, 4321 insertions(+)
 """
 count = 4321
 
-[quote."0.0.0 -> 1.0.14"]
+[diffs.quote."1.0.14"]
 raw = """
  35 files changed, 3698 insertions(+)
 """
 count = 3698
 
-[quote."0.0.0 -> 1.0.18"]
+[diffs.quote."1.0.18"]
 raw = """
  35 files changed, 3845 insertions(+)
 """
 count = 3845
 
-[rand."0.0.0 -> 0.7.3"]
+[diffs.rand."0.7.3"]
 raw = """
  56 files changed, 11946 insertions(+)
 """
 count = 11946
 
-[range-alloc."0.0.0 -> 0.1.2"]
+[diffs.range-alloc."0.1.2"]
 raw = """
  5 files changed, 358 insertions(+)
 """
 count = 358
 
-[raw-window-handle."0.0.0 -> 0.4.2"]
+[diffs.raw-window-handle."0.4.2"]
 raw = """
  21 files changed, 843 insertions(+)
 """
 count = 843
 
-[rayon."0.0.0 -> 1.5.1"]
+[diffs.rayon."1.5.1"]
 raw = """
  118 files changed, 26830 insertions(+)
 """
 count = 26830
 
-[redox_syscall."0.0.0 -> 0.2.13"]
+[diffs.redox_syscall."0.2.13"]
 raw = """
  32 files changed, 3897 insertions(+)
 """
 count = 3897
 
-[regex."0.0.0 -> 1.5.5"]
+[diffs.regex."1.5.5"]
 raw = """
  85 files changed, 26202 insertions(+)
 """
 count = 26202
 
-[remove_dir_all."0.0.0 -> 0.5.3"]
+[diffs.remove_dir_all."0.5.3"]
 raw = """
  9 files changed, 598 insertions(+)
 """
 count = 598
 
-[renderdoc-sys."0.0.0 -> 0.7.1"]
+[diffs.renderdoc-sys."0.7.1"]
 raw = """
  7 files changed, 791 insertions(+)
 """
 count = 791
 
-[rental."0.0.0 -> 0.5.6"]
+[diffs.rental."0.5.6"]
 raw = """
  26 files changed, 1963 insertions(+)
 """
 count = 1963
 
-[replace_with."0.0.0 -> 0.1.7"]
+[diffs.replace_with."0.1.7"]
 raw = """
  12 files changed, 1093 insertions(+)
 """
 count = 1093
 
-[reqwest."0.0.0 -> 0.11.10"]
+[diffs.reqwest."0.11.10"]
 raw = """
  63 files changed, 21663 insertions(+)
 """
 count = 21663
 
-[rkv."0.0.0 -> 0.17.0"]
+[diffs.rkv."0.17.0"]
 raw = """
  68 files changed, 11545 insertions(+)
 """
 count = 11545
 
-[ron."0.0.0 -> 0.7.0"]
+[diffs.ron."0.7.0"]
 raw = """
  58 files changed, 7507 insertions(+)
 """
 count = 7507
 
-[rusqlite."0.0.0 -> 0.24.2"]
+[diffs.rusqlite."0.24.2"]
 raw = """
  63 files changed, 16529 insertions(+)
 """
 count = 16529
 
-[rust-ini."0.0.0 -> 0.10.3"]
+[diffs.rust-ini."0.10.3"]
 raw = """
  9 files changed, 1412 insertions(+)
 """
 count = 1412
 
-[rust_cascade."0.0.0 -> 1.2.0"]
+[diffs.rust_cascade."1.2.0"]
 raw = """
  18 files changed, 1050 insertions(+)
 """
 count = 1050
 
-[rustc-demangle."0.0.0 -> 0.1.21"]
+[diffs.rustc-demangle."0.1.21"]
 raw = """
  14 files changed, 2829 insertions(+)
 """
 count = 2829
 
-[rustc-hash."0.0.0 -> 1.1.0"]
+[diffs.rustc-hash."1.1.0"]
 raw = """
  10 files changed, 497 insertions(+)
 """
 count = 497
 
-[rustc_version."0.0.0 -> 0.2.3"]
+[diffs.rustc_version."0.2.3"]
 raw = """
  10 files changed, 795 insertions(+)
 """
 count = 795
 
-[ryu."0.0.0 -> 1.0.9"]
+[diffs.ryu."1.0.9"]
 raw = """
  37 files changed, 4531 insertions(+)
 """
 count = 4531
 
-[schannel."0.0.0 -> 0.1.19"]
+[diffs.schannel."0.1.19"]
 raw = """
  34 files changed, 4607 insertions(+)
 """
 count = 4607
 
-[security-framework."0.0.0 -> 2.6.1"]
+[diffs.security-framework."2.6.1"]
 raw = """
  45 files changed, 9776 insertions(+)
 """
 count = 9776
 
-[security-framework-sys."0.0.0 -> 2.6.1"]
+[diffs.security-framework-sys."2.6.1"]
 raw = """
  29 files changed, 2023 insertions(+)
 """
 count = 2023
 
-[semver."0.0.0 -> 0.9.0"]
+[diffs.semver."0.9.0"]
 raw = """
  14 files changed, 2401 insertions(+)
 """
 count = 2401
 
-[serde."0.0.0 -> 1.0.133"]
+[diffs.serde."1.0.133"]
 raw = """
  28 files changed, 16043 insertions(+)
 """
 count = 16043
 
-[serde."0.0.0 -> 1.0.136"]
+[diffs.serde."1.0.136"]
 raw = """
  29 files changed, 16148 insertions(+)
 """
 count = 16148
 
-[serde."1.0.0 -> 1.0.136"]
+[diffs.serde."1.0.0 -> 1.0.136"]
 raw = """
  29 files changed, 6610 insertions(+), 2168 deletions(-)
 """
 count = 8778
 
-[serde_bytes."0.0.0 -> 0.11.5"]
+[diffs.serde_bytes."0.11.5"]
 raw = """
  17 files changed, 1483 insertions(+)
 """
 count = 1483
 
-[serde_derive."0.0.0 -> 1.0.133"]
+[diffs.serde_derive."1.0.133"]
 raw = """
  26 files changed, 9082 insertions(+)
 """
 count = 9082
 
-[serde_json."0.0.0 -> 1.0.72"]
+[diffs.serde_json."1.0.72"]
 raw = """
  47 files changed, 18059 insertions(+)
 """
 count = 18059
 
-[serde_json."0.0.0 -> 1.0.79"]
+[diffs.serde_json."1.0.79"]
 raw = """
  88 files changed, 22855 insertions(+)
 """
 count = 22855
 
-[serde_repr."0.0.0 -> 0.1.7"]
+[diffs.serde_repr."0.1.7"]
 raw = """
  24 files changed, 828 insertions(+)
 """
 count = 828
 
-[serde_urlencoded."0.0.0 -> 0.7.1"]
+[diffs.serde_urlencoded."0.7.1"]
 raw = """
  19 files changed, 2127 insertions(+)
 """
 count = 2127
 
-[serde_yaml."0.0.0 -> 0.8.23"]
+[diffs.serde_yaml."0.8.23"]
 raw = """
  27 files changed, 7510 insertions(+)
 """
 count = 7510
 
-[serial_test."0.0.0 -> 0.5.1"]
+[diffs.serial_test."0.5.1"]
 raw = """
  8 files changed, 219 insertions(+)
 """
 count = 219
 
-[sfv."0.0.0 -> 0.9.1"]
+[diffs.sfv."0.9.1"]
 raw = """
  17 files changed, 3477 insertions(+)
 """
 count = 3477
 
-[sha2."0.0.0 -> 0.8.2"]
+[diffs.sha2."0.8.2"]
 raw = """
  28 files changed, 1947 insertions(+)
 """
 count = 1947
 
-[slab."0.0.0 -> 0.4.5"]
+[diffs.slab."0.4.5"]
 raw = """
  11 files changed, 2584 insertions(+)
 """
 count = 2584
 
-[slab."0.0.0 -> 0.4.6"]
+[diffs.slab."0.4.6"]
 raw = """
  11 files changed, 2622 insertions(+)
 """
 count = 2622
 
-[smallbitvec."0.0.0 -> 2.5.1"]
+[diffs.smallbitvec."2.5.1"]
 raw = """
  12 files changed, 1994 insertions(+)
 """
 count = 1994
 
-[smallvec."0.0.0 -> 1.8.0"]
+[diffs.smallvec."1.8.0"]
 raw = """
  16 files changed, 3885 insertions(+)
 """
 count = 3885
 
-[socket2."0.0.0 -> 0.3.19"]
+[diffs.socket2."0.3.19"]
 raw = """
  19 files changed, 4797 insertions(+)
 """
 count = 4797
 
-[socket2."0.0.0 -> 0.4.4"]
+[diffs.socket2."0.4.4"]
 raw = """
  13 files changed, 6018 insertions(+)
 """
 count = 6018
 
-[spirv."0.0.0 -> 0.2.0+1.5.4"]
+[diffs.spirv."0.2.0+1.5.4"]
 raw = """
  8 files changed, 4476 insertions(+)
 """
 count = 4476
 
-[stable_deref_trait."0.0.0 -> 1.2.0"]
+[diffs.stable_deref_trait."1.2.0"]
 raw = """
  9 files changed, 490 insertions(+)
 """
 count = 490
 
-[static_assertions."0.0.0 -> 1.1.0"]
+[diffs.static_assertions."1.1.0"]
 raw = """
  18 files changed, 1792 insertions(+)
 """
 count = 1792
 
-[strsim."0.0.0 -> 0.10.0"]
+[diffs.strsim."0.10.0"]
 raw = """
  15 files changed, 1574 insertions(+)
 """
 count = 1574
 
-[svg_fmt."0.0.0 -> 0.4.1"]
+[diffs.svg_fmt."0.4.1"]
 raw = """
  8 files changed, 742 insertions(+)
 """
 count = 742
 
-[syn."0.0.0 -> 1.0.85"]
+[diffs.syn."1.0.85"]
 raw = """
  98 files changed, 56943 insertions(+)
 """
 count = 56943
 
-[syn."0.0.0 -> 1.0.91"]
+[diffs.syn."1.0.91"]
 raw = """
  98 files changed, 57175 insertions(+)
 """
 count = 57175
 
-[syn."1.0.0 -> 1.0.91"]
+[diffs.syn."1.0.0 -> 1.0.91"]
 raw = """
  93 files changed, 21776 insertions(+), 6701 deletions(-)
 """
 count = 28477
 
-[synstructure."0.0.0 -> 0.12.6"]
+[diffs.synstructure."0.12.6"]
 raw = """
  8 files changed, 2991 insertions(+)
 """
 count = 2991
 
-[tempfile."0.0.0 -> 3.1.0"]
+[diffs.tempfile."3.1.0"]
 raw = """
  23 files changed, 3841 insertions(+)
 """
 count = 3841
 
-[tempfile."0.0.0 -> 3.3.0"]
+[diffs.tempfile."3.3.0"]
 raw = """
  24 files changed, 4066 insertions(+)
 """
 count = 4066
 
-[termcolor."0.0.0 -> 1.1.3"]
+[diffs.termcolor."1.1.3"]
 raw = """
  12 files changed, 2585 insertions(+)
 """
 count = 2585
 
-[textwrap."0.0.0 -> 0.15.0"]
+[diffs.textwrap."0.15.0"]
 raw = """
  18 files changed, 6165 insertions(+)
 """
 count = 6165
 
-[thin-vec."0.0.0 -> 0.2.5"]
+[diffs.thin-vec."0.2.5"]
 raw = """
  8 files changed, 2895 insertions(+)
 """
 count = 2895
 
-[thiserror."0.0.0 -> 1.0.30"]
+[diffs.thiserror."1.0.30"]
 raw = """
  66 files changed, 2448 insertions(+)
 """
 count = 2448
 
-[threadbound."0.0.0 -> 0.1.2"]
+[diffs.threadbound."0.1.2"]
 raw = """
  10 files changed, 535 insertions(+)
 """
 count = 535
 
-[time."0.0.0 -> 0.1.43"]
+[diffs.time."0.1.43"]
 raw = """
  13 files changed, 3836 insertions(+)
 """
 count = 3836
 
-[tinyvec."0.0.0 -> 1.5.1"]
+[diffs.tinyvec."1.5.1"]
 raw = """
  27 files changed, 16758 insertions(+)
 """
 count = 16758
 
-[tinyvec_macros."0.0.0 -> 0.1.0"]
+[diffs.tinyvec_macros."0.1.0"]
 raw = """
  7 files changed, 87 insertions(+)
 """
 count = 87
 
-[tokio."0.0.0 -> 0.2.25"]
+[diffs.tokio."0.2.25"]
 raw = """
  396 files changed, 67418 insertions(+)
 """
 count = 67418
 
-[tokio."0.0.0 -> 1.17.0"]
+[diffs.tokio."1.17.0"]
 raw = """
  405 files changed, 91278 insertions(+)
 """
 count = 91278
 
-[tokio-native-tls."0.0.0 -> 0.3.0"]
+[diffs.tokio-native-tls."0.3.0"]
 raw = """
  19 files changed, 1804 insertions(+)
 """
 count = 1804
 
-[tokio-util."0.0.0 -> 0.7.1"]
+[diffs.tokio-util."0.7.1"]
 raw = """
  67 files changed, 13877 insertions(+)
 """
 count = 13877
 
-[toml."0.0.0 -> 0.4.10"]
+[diffs.toml."0.4.10"]
 raw = """
  21 files changed, 7314 insertions(+)
 """
 count = 7314
 
-[tower-service."0.0.0 -> 0.3.1"]
+[diffs.tower-service."0.3.1"]
 raw = """
  8 files changed, 507 insertions(+)
 """
 count = 507
 
-[tracing."0.0.0 -> 0.1.33"]
+[diffs.tracing."0.1.33"]
 raw = """
  34 files changed, 10957 insertions(+)
 """
 count = 10957
 
-[tracing-attributes."0.0.0 -> 0.1.20"]
+[diffs.tracing-attributes."0.1.20"]
 raw = """
  20 files changed, 3964 insertions(+)
 """
 count = 3964
 
-[tracing-core."0.0.0 -> 0.1.25"]
+[diffs.tracing-core."0.1.25"]
 raw = """
  28 files changed, 6163 insertions(+)
 """
 count = 6163
 
-[tracy-rs."0.0.0 -> 0.1.2"]
+[diffs.tracy-rs."0.1.2"]
 raw = """
  10 files changed, 682 insertions(+)
 """
 count = 682
 
-[try-lock."0.0.0 -> 0.2.3"]
+[diffs.try-lock."0.2.3"]
 raw = """
  8 files changed, 386 insertions(+)
 """
 count = 386
 
-[uluru."0.0.0 -> 1.1.1"]
+[diffs.uluru."1.1.1"]
 raw = """
  10 files changed, 1016 insertions(+)
 """
 count = 1016
 
-[unic-langid."0.0.0 -> 0.9.0"]
+[diffs.unic-langid."0.9.0"]
 raw = """
  7 files changed, 363 insertions(+)
 """
 count = 363
 
-[unicode-bidi."0.0.0 -> 0.2.0"]
+[diffs.unicode-bidi."0.2.0"]
 raw = """
  14 files changed, 595897 insertions(+)
 """
 count = 595897
 
-[unicode-bidi."0.0.0 -> 0.3.7"]
+[diffs.unicode-bidi."0.3.7"]
 raw = """
  23 files changed, 3398 insertions(+)
 """
 count = 3398
 
-[unicode-normalization."0.0.0 -> 0.1.19"]
+[diffs.unicode-normalization."0.1.19"]
 raw = """
  26 files changed, 28628 insertions(+)
 """
 count = 28628
 
-[unicode-segmentation."0.0.0 -> 1.8.0"]
+[diffs.unicode-segmentation."1.8.0"]
 raw = """
  23 files changed, 8336 insertions(+)
 """
 count = 8336
 
-[unicode-xid."0.0.0 -> 0.2.2"]
+[diffs.unicode-xid."0.2.2"]
 raw = """
  14 files changed, 2050 insertions(+)
 """
 count = 2050
 
-[unix_path."0.0.0 -> 1.0.1"]
+[diffs.unix_path."1.0.1"]
 raw = """
  10 files changed, 3413 insertions(+)
 """
 count = 3413
 
-[url."0.0.0 -> 2.1.0"]
+[diffs.url."2.1.0"]
 raw = """
  25 files changed, 14675 insertions(+)
 """
 count = 14675
 
-[url."0.0.0 -> 2.2.2"]
+[diffs.url."2.2.2"]
 raw = """
  17 files changed, 16350 insertions(+)
 """
 count = 16350
 
-[uuid."0.0.0 -> 0.8.1"]
+[diffs.uuid."0.8.1"]
 raw = """
  39 files changed, 5404 insertions(+)
 """
 count = 5404
 
-[vcpkg."0.0.0 -> 0.2.15"]
+[diffs.vcpkg."0.2.15"]
 raw = """
  834 files changed, 42648 insertions(+)
 """
 count = 42648
 
-[void."0.0.0 -> 1.0.2"]
+[diffs.void."1.0.2"]
 raw = """
  6 files changed, 221 insertions(+)
 """
 count = 221
 
-[walkdir."0.0.0 -> 2.3.2"]
+[diffs.walkdir."2.3.2"]
 raw = """
  20 files changed, 3509 insertions(+)
 """
 count = 3509
 
-[want."0.0.0 -> 0.3.0"]
+[diffs.want."0.3.0"]
 raw = """
  9 files changed, 703 insertions(+)
 """
 count = 703
 
-[warp."0.0.0 -> 0.2.3"]
+[diffs.warp."0.2.3"]
 raw = """
  94 files changed, 15525 insertions(+)
 """
 count = 15525
 
-[wasi."0.0.0 -> 0.11.0+wasi-snapshot-preview1"]
+[diffs.wasi."0.11.0+wasi-snapshot-preview1"]
 raw = """
  17 files changed, 3309 insertions(+)
 """
 count = 3309
 
-[wasm-bindgen."0.0.0 -> 0.2.80"]
+[diffs.wasm-bindgen."0.2.80"]
 raw = """
  243 files changed, 20978 insertions(+)
 """
 count = 20978
 
-[wasm-bindgen-backend."0.0.0 -> 0.2.80"]
+[diffs.wasm-bindgen-backend."0.2.80"]
 raw = """
  11 files changed, 3019 insertions(+)
 """
 count = 3019
 
-[wasm-bindgen-futures."0.0.0 -> 0.4.30"]
+[diffs.wasm-bindgen-futures."0.4.30"]
 raw = """
  13 files changed, 1304 insertions(+)
 """
 count = 1304
 
-[wasm-bindgen-macro."0.0.0 -> 0.2.80"]
+[diffs.wasm-bindgen-macro."0.2.80"]
 raw = """
  46 files changed, 1275 insertions(+)
 """
 count = 1275
 
-[wasm-bindgen-macro-support."0.0.0 -> 0.2.80"]
+[diffs.wasm-bindgen-macro-support."0.2.80"]
 raw = """
  7 files changed, 1966 insertions(+)
 """
 count = 1966
 
-[wasm-bindgen-shared."0.0.0 -> 0.2.80"]
+[diffs.wasm-bindgen-shared."0.2.80"]
 raw = """
  8 files changed, 516 insertions(+)
 """
 count = 516
 
-[wasm-smith."0.0.0 -> 0.8.0"]
+[diffs.wasm-smith."0.8.0"]
 raw = """
  13 files changed, 8951 insertions(+)
 """
 count = 8951
 
-[wasmparser."0.0.0 -> 0.78.2"]
+[diffs.wasmparser."0.78.2"]
 raw = """
  42 files changed, 13591 insertions(+)
 """
 count = 13591
 
-[wat."0.0.0 -> 1.0.41"]
+[diffs.wat."1.0.41"]
 raw = """
  7 files changed, 674 insertions(+)
 """
 count = 674
 
-[web-sys."0.0.0 -> 0.3.57"]
+[diffs.web-sys."0.3.57"]
 raw = """
  2203 files changed, 197014 insertions(+)
 """
 count = 197014
 
-[webrtc-sdp."0.0.0 -> 0.3.9"]
+[diffs.webrtc-sdp."0.3.9"]
 raw = """
  69 files changed, 10569 insertions(+)
 """
 count = 10569
 
-[winapi."0.0.0 -> 0.3.9"]
+[diffs.winapi."0.3.9"]
 raw = """
  412 files changed, 181329 insertions(+)
 """
 count = 181329
 
-[winapi-i686-pc-windows-gnu."0.0.0 -> 0.4.0"]
+[diffs.winapi-i686-pc-windows-gnu."0.4.0"]
 raw = """
  1392 files changed, 1133 insertions(+)
 """
 count = 1133
 
-[winapi-util."0.0.0 -> 0.1.5"]
+[diffs.winapi-util."0.1.5"]
 raw = """
  15 files changed, 1101 insertions(+)
 """
 count = 1101
 
-[winapi-x86_64-pc-windows-gnu."0.0.0 -> 0.4.0"]
+[diffs.winapi-x86_64-pc-windows-gnu."0.4.0"]
 raw = """
  1421 files changed, 1168 insertions(+)
 """
 count = 1168
 
-[winreg."0.0.0 -> 0.5.1"]
+[diffs.winreg."0.5.1"]
 raw = """
  22 files changed, 2894 insertions(+)
 """
 count = 2894
 
-[winreg."0.0.0 -> 0.10.1"]
+[diffs.winreg."0.10.1"]
 raw = """
  29 files changed, 4276 insertions(+)
 """
 count = 4276
 
-[wio."0.0.0 -> 0.2.2"]
+[diffs.wio."0.2.2"]
 raw = """
  18 files changed, 938 insertions(+)
 """
 count = 938
 
-[xmldecl."0.0.0 -> 0.2.0"]
+[diffs.xmldecl."0.2.0"]
 raw = """
  11 files changed, 711 insertions(+)
 """
 count = 711
 
-[zip."0.0.0 -> 0.4.2"]
+[diffs.zip."0.4.2"]
 raw = """
  27 files changed, 2704 insertions(+)
 """

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -707,7 +707,7 @@ stdout:
               "count": 2585,
               "raw": " 12 files changed, 2585 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.1.3"
           }
         },
@@ -722,7 +722,7 @@ stdout:
               "count": 2918,
               "raw": " 23 files changed, 2918 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "6.0.0"
           }
         },
@@ -737,7 +737,7 @@ stdout:
               "count": 6165,
               "raw": " 18 files changed, 6165 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.15.0"
           }
         },
@@ -752,7 +752,7 @@ stdout:
               "count": 9452,
               "raw": " 33 files changed, 9452 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.8.1"
           }
         },
@@ -767,7 +767,7 @@ stdout:
               "count": 21663,
               "raw": " 63 files changed, 21663 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.11.10"
           }
         },
@@ -782,7 +782,7 @@ stdout:
               "count": 22855,
               "raw": " 88 files changed, 22855 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.79"
           }
         },
@@ -797,7 +797,7 @@ stdout:
               "count": 91278,
               "raw": " 405 files changed, 91278 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.17.0"
           }
         },
@@ -812,7 +812,7 @@ stdout:
               "count": 94067,
               "raw": " 217 files changed, 94067 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.123"
           }
         },
@@ -827,7 +827,7 @@ stdout:
               "count": 181329,
               "raw": " 412 files changed, 181329 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.9"
           }
         },
@@ -842,7 +842,7 @@ stdout:
               "count": 87,
               "raw": " 7 files changed, 87 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.0"
           }
         },
@@ -857,7 +857,7 @@ stdout:
               "count": 211,
               "raw": " 7 files changed, 211 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.9"
           }
         },
@@ -872,7 +872,7 @@ stdout:
               "count": 303,
               "raw": " 6 files changed, 303 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.1"
           }
         },
@@ -887,7 +887,7 @@ stdout:
               "count": 386,
               "raw": " 8 files changed, 386 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.3"
           }
         },
@@ -902,7 +902,7 @@ stdout:
               "count": 456,
               "raw": " 12 files changed, 456 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.5"
           }
         },
@@ -917,7 +917,7 @@ stdout:
               "count": 507,
               "raw": " 8 files changed, 507 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.1"
           }
         },
@@ -932,7 +932,7 @@ stdout:
               "count": 516,
               "raw": " 8 files changed, 516 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.80"
           }
         },
@@ -947,7 +947,7 @@ stdout:
               "count": 544,
               "raw": " 15 files changed, 544 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.0"
           }
         },
@@ -962,7 +962,7 @@ stdout:
               "count": 551,
               "raw": " 8 files changed, 551 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.21"
           }
         },
@@ -977,7 +977,7 @@ stdout:
               "count": 584,
               "raw": " 7 files changed, 584 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.2"
           }
         },
@@ -992,7 +992,7 @@ stdout:
               "count": 588,
               "raw": " 11 files changed, 588 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.0"
           }
         },
@@ -1007,7 +1007,7 @@ stdout:
               "count": 598,
               "raw": " 9 files changed, 598 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.5.3"
           }
         },
@@ -1022,7 +1022,7 @@ stdout:
               "count": 678,
               "raw": " 14 files changed, 678 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.12"
           }
         },
@@ -1037,7 +1037,7 @@ stdout:
               "count": 695,
               "raw": " 7 files changed, 695 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.1"
           }
         },
@@ -1052,7 +1052,7 @@ stdout:
               "count": 703,
               "raw": " 9 files changed, 703 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.0"
           }
         },
@@ -1067,7 +1067,7 @@ stdout:
               "count": 708,
               "raw": " 7 files changed, 708 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.1.0"
           }
         },
@@ -1082,7 +1082,7 @@ stdout:
               "count": 736,
               "raw": " 10 files changed, 736 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.7"
           }
         },
@@ -1097,7 +1097,7 @@ stdout:
               "count": 796,
               "raw": " 15 files changed, 796 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.1"
           }
         },
@@ -1112,7 +1112,7 @@ stdout:
               "count": 882,
               "raw": " 13 files changed, 882 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.4.0"
           }
         },
@@ -1127,7 +1127,7 @@ stdout:
               "count": 1001,
               "raw": " 12 files changed, 1001 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.2"
           }
         },
@@ -1142,7 +1142,7 @@ stdout:
               "count": 1101,
               "raw": " 15 files changed, 1101 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.5"
           }
         },
@@ -1157,7 +1157,7 @@ stdout:
               "count": 1133,
               "raw": " 1392 files changed, 1133 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.0"
           }
         },
@@ -1172,7 +1172,7 @@ stdout:
               "count": 1168,
               "raw": " 1421 files changed, 1168 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.0"
           }
         },
@@ -1187,7 +1187,7 @@ stdout:
               "count": 1182,
               "raw": " 16 files changed, 1182 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.21"
           }
         },
@@ -1202,7 +1202,7 @@ stdout:
               "count": 1187,
               "raw": " 16 files changed, 1187 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.21"
           }
         },
@@ -1217,7 +1217,7 @@ stdout:
               "count": 1262,
               "raw": " 19 files changed, 1262 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.4"
           }
         },
@@ -1232,7 +1232,7 @@ stdout:
               "count": 1275,
               "raw": " 46 files changed, 1275 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.80"
           }
         },
@@ -1247,7 +1247,7 @@ stdout:
               "count": 1301,
               "raw": " 14 files changed, 1301 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.5.0"
           }
         },
@@ -1262,7 +1262,7 @@ stdout:
               "count": 1304,
               "raw": " 13 files changed, 1304 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.30"
           }
         },
@@ -1277,7 +1277,7 @@ stdout:
               "count": 1375,
               "raw": " 12 files changed, 1375 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.7.0"
           }
         },
@@ -1292,7 +1292,7 @@ stdout:
               "count": 1721,
               "raw": " 15 files changed, 1721 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.16"
           }
         },
@@ -1307,7 +1307,7 @@ stdout:
               "count": 1754,
               "raw": " 16 files changed, 1754 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.25"
           }
         },
@@ -1322,7 +1322,7 @@ stdout:
               "count": 1804,
               "raw": " 19 files changed, 1804 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.0"
           }
         },
@@ -1337,7 +1337,7 @@ stdout:
               "count": 1966,
               "raw": " 7 files changed, 1966 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.80"
           }
         },
@@ -1352,7 +1352,7 @@ stdout:
               "count": 1971,
               "raw": " 28 files changed, 1971 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.8.3"
           }
         },
@@ -1367,7 +1367,7 @@ stdout:
               "count": 2023,
               "raw": " 29 files changed, 2023 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.6.1"
           }
         },
@@ -1382,7 +1382,7 @@ stdout:
               "count": 2050,
               "raw": " 14 files changed, 2050 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.2"
           }
         },
@@ -1397,7 +1397,7 @@ stdout:
               "count": 2127,
               "raw": " 19 files changed, 2127 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.7.1"
           }
         },
@@ -1412,7 +1412,7 @@ stdout:
               "count": 2622,
               "raw": " 11 files changed, 2622 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.6"
           }
         },
@@ -1427,7 +1427,7 @@ stdout:
               "count": 3019,
               "raw": " 11 files changed, 3019 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.80"
           }
         },
@@ -1442,7 +1442,7 @@ stdout:
               "count": 3135,
               "raw": " 16 files changed, 3135 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.7"
           }
         },
@@ -1457,7 +1457,7 @@ stdout:
               "count": 3309,
               "raw": " 17 files changed, 3309 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.11.0+wasi-snapshot-preview1"
           }
         },
@@ -1472,7 +1472,7 @@ stdout:
               "count": 3398,
               "raw": " 23 files changed, 3398 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.7"
           }
         },
@@ -1487,7 +1487,7 @@ stdout:
               "count": 3845,
               "raw": " 35 files changed, 3845 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.18"
           }
         },
@@ -1502,7 +1502,7 @@ stdout:
               "count": 3897,
               "raw": " 32 files changed, 3897 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.13"
           }
         },
@@ -1517,7 +1517,7 @@ stdout:
               "count": 3960,
               "raw": " 28 files changed, 3960 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.9.3"
           }
         },
@@ -1532,7 +1532,7 @@ stdout:
               "count": 3964,
               "raw": " 20 files changed, 3964 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.20"
           }
         },
@@ -1547,7 +1547,7 @@ stdout:
               "count": 3980,
               "raw": " 15 files changed, 3980 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.4.0"
           }
         },
@@ -1562,7 +1562,7 @@ stdout:
               "count": 3999,
               "raw": " 20 files changed, 3999 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.21"
           }
         },
@@ -1577,7 +1577,7 @@ stdout:
               "count": 4066,
               "raw": " 24 files changed, 4066 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "3.3.0"
           }
         },
@@ -1592,7 +1592,7 @@ stdout:
               "count": 4089,
               "raw": " 21 files changed, 4089 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.10"
           }
         },
@@ -1607,7 +1607,7 @@ stdout:
               "count": 4140,
               "raw": " 24 files changed, 4140 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.10.0"
           }
         },
@@ -1622,7 +1622,7 @@ stdout:
               "count": 4276,
               "raw": " 29 files changed, 4276 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.10.1"
           }
         },
@@ -1637,7 +1637,7 @@ stdout:
               "count": 4531,
               "raw": " 37 files changed, 4531 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.9"
           }
         },
@@ -1652,7 +1652,7 @@ stdout:
               "count": 4607,
               "raw": " 34 files changed, 4607 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.19"
           }
         },
@@ -1667,7 +1667,7 @@ stdout:
               "count": 5632,
               "raw": " 21 files changed, 5632 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.16"
           }
         },
@@ -1682,7 +1682,7 @@ stdout:
               "count": 5702,
               "raw": " 22 files changed, 5702 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.37"
           }
         },
@@ -1697,7 +1697,7 @@ stdout:
               "count": 6018,
               "raw": " 13 files changed, 6018 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.4.4"
           }
         },
@@ -1712,7 +1712,7 @@ stdout:
               "count": 6107,
               "raw": " 72 files changed, 6107 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.8"
           }
         },
@@ -1727,7 +1727,7 @@ stdout:
               "count": 6163,
               "raw": " 28 files changed, 6163 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.25"
           }
         },
@@ -1742,7 +1742,7 @@ stdout:
               "count": 6671,
               "raw": " 22 files changed, 6671 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.73"
           }
         },
@@ -1757,7 +1757,7 @@ stdout:
               "count": 7265,
               "raw": " 20 files changed, 7265 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.7.0"
           }
         },
@@ -1772,7 +1772,7 @@ stdout:
               "count": 8718,
               "raw": " 48 files changed, 8718 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.4.1"
           }
         },
@@ -1787,7 +1787,7 @@ stdout:
               "count": 9213,
               "raw": " 45 files changed, 9213 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.1.0"
           }
         },
@@ -1802,7 +1802,7 @@ stdout:
               "count": 9484,
               "raw": " 48 files changed, 9484 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.9.72"
           }
         },
@@ -1817,7 +1817,7 @@ stdout:
               "count": 9776,
               "raw": " 45 files changed, 9776 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.6.1"
           }
         },
@@ -1832,7 +1832,7 @@ stdout:
               "count": 10106,
               "raw": " 19 files changed, 10106 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "3.9.1"
           }
         },
@@ -1847,7 +1847,7 @@ stdout:
               "count": 10957,
               "raw": " 34 files changed, 10957 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.33"
           }
         },
@@ -1862,7 +1862,7 @@ stdout:
               "count": 11882,
               "raw": " 65 files changed, 11882 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.8.2"
           }
         },
@@ -1877,7 +1877,7 @@ stdout:
               "count": 12875,
               "raw": " 63 files changed, 12875 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.57"
           }
         },
@@ -1892,7 +1892,7 @@ stdout:
               "count": 13877,
               "raw": " 67 files changed, 13877 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.7.1"
           }
         },
@@ -1907,7 +1907,7 @@ stdout:
               "count": 14609,
               "raw": " 33 files changed, 14609 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.11.2"
           }
         },
@@ -1922,7 +1922,7 @@ stdout:
               "count": 16148,
               "raw": " 29 files changed, 16148 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.136"
           }
         },
@@ -1937,7 +1937,7 @@ stdout:
               "count": 16350,
               "raw": " 17 files changed, 16350 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "2.2.2"
           }
         },
@@ -1952,7 +1952,7 @@ stdout:
               "count": 16758,
               "raw": " 27 files changed, 16758 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.5.1"
           }
         },
@@ -1967,7 +1967,7 @@ stdout:
               "count": 16826,
               "raw": " 41 files changed, 16826 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.6"
           }
         },
@@ -1982,7 +1982,7 @@ stdout:
               "count": 20978,
               "raw": " 243 files changed, 20978 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.80"
           }
         },
@@ -1997,7 +1997,7 @@ stdout:
               "count": 21234,
               "raw": " 44 files changed, 21234 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.7"
           }
         },
@@ -2012,7 +2012,7 @@ stdout:
               "count": 25074,
               "raw": " 187 files changed, 25074 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.21"
           }
         },
@@ -2027,7 +2027,7 @@ stdout:
               "count": 25617,
               "raw": " 72 files changed, 25617 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.14.18"
           }
         },
@@ -2042,7 +2042,7 @@ stdout:
               "count": 26066,
               "raw": " 66 files changed, 26066 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.13"
           }
         },
@@ -2072,7 +2072,7 @@ stdout:
               "count": 28628,
               "raw": " 26 files changed, 28628 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.19"
           }
         },
@@ -2087,7 +2087,7 @@ stdout:
               "count": 28634,
               "raw": " 85 files changed, 28634 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.10.38"
           }
         },
@@ -2102,7 +2102,7 @@ stdout:
               "count": 32538,
               "raw": " 19 files changed, 32538 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.3"
           }
         },
@@ -2117,7 +2117,7 @@ stdout:
               "count": 42648,
               "raw": " 834 files changed, 42648 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.15"
           }
         },
@@ -2132,7 +2132,7 @@ stdout:
               "count": 197014,
               "raw": " 2203 files changed, 197014 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.57"
           }
         },
@@ -2147,7 +2147,7 @@ stdout:
               "count": 507252,
               "raw": " 104 files changed, 507252 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.8.31"
           }
         }
@@ -2164,7 +2164,7 @@ stdout:
               "count": 938,
               "raw": " 11 files changed, 938 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.19"
           }
         }
@@ -2182,7 +2182,7 @@ stdout:
             "count": 938,
             "raw": " 11 files changed, 938 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.19"
         }
       },
@@ -2197,7 +2197,7 @@ stdout:
             "count": 2585,
             "raw": " 12 files changed, 2585 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.1.3"
         }
       },
@@ -2212,7 +2212,7 @@ stdout:
             "count": 2918,
             "raw": " 23 files changed, 2918 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "6.0.0"
         }
       },
@@ -2227,7 +2227,7 @@ stdout:
             "count": 6165,
             "raw": " 18 files changed, 6165 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.15.0"
         }
       },
@@ -2242,7 +2242,7 @@ stdout:
             "count": 9452,
             "raw": " 33 files changed, 9452 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.8.1"
         }
       },
@@ -2257,7 +2257,7 @@ stdout:
             "count": 21663,
             "raw": " 63 files changed, 21663 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.11.10"
         }
       },
@@ -2272,7 +2272,7 @@ stdout:
             "count": 22855,
             "raw": " 88 files changed, 22855 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.79"
         }
       },
@@ -2287,7 +2287,7 @@ stdout:
             "count": 91278,
             "raw": " 405 files changed, 91278 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.17.0"
         }
       },
@@ -2302,7 +2302,7 @@ stdout:
             "count": 94067,
             "raw": " 217 files changed, 94067 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.123"
         }
       },
@@ -2317,7 +2317,7 @@ stdout:
             "count": 181329,
             "raw": " 412 files changed, 181329 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.9"
         }
       },
@@ -2332,7 +2332,7 @@ stdout:
             "count": 87,
             "raw": " 7 files changed, 87 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.0"
         }
       },
@@ -2347,7 +2347,7 @@ stdout:
             "count": 211,
             "raw": " 7 files changed, 211 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.9"
         }
       },
@@ -2362,7 +2362,7 @@ stdout:
             "count": 303,
             "raw": " 6 files changed, 303 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.1"
         }
       },
@@ -2377,7 +2377,7 @@ stdout:
             "count": 386,
             "raw": " 8 files changed, 386 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.3"
         }
       },
@@ -2392,7 +2392,7 @@ stdout:
             "count": 456,
             "raw": " 12 files changed, 456 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.5"
         }
       },
@@ -2407,7 +2407,7 @@ stdout:
             "count": 507,
             "raw": " 8 files changed, 507 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.1"
         }
       },
@@ -2422,7 +2422,7 @@ stdout:
             "count": 516,
             "raw": " 8 files changed, 516 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.80"
         }
       },
@@ -2437,7 +2437,7 @@ stdout:
             "count": 544,
             "raw": " 15 files changed, 544 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.0"
         }
       },
@@ -2452,7 +2452,7 @@ stdout:
             "count": 551,
             "raw": " 8 files changed, 551 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.21"
         }
       },
@@ -2467,7 +2467,7 @@ stdout:
             "count": 584,
             "raw": " 7 files changed, 584 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.2"
         }
       },
@@ -2482,7 +2482,7 @@ stdout:
             "count": 588,
             "raw": " 11 files changed, 588 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.0"
         }
       },
@@ -2497,7 +2497,7 @@ stdout:
             "count": 598,
             "raw": " 9 files changed, 598 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.5.3"
         }
       },
@@ -2512,7 +2512,7 @@ stdout:
             "count": 678,
             "raw": " 14 files changed, 678 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.12"
         }
       },
@@ -2527,7 +2527,7 @@ stdout:
             "count": 695,
             "raw": " 7 files changed, 695 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.1"
         }
       },
@@ -2542,7 +2542,7 @@ stdout:
             "count": 703,
             "raw": " 9 files changed, 703 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.0"
         }
       },
@@ -2557,7 +2557,7 @@ stdout:
             "count": 708,
             "raw": " 7 files changed, 708 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.1.0"
         }
       },
@@ -2572,7 +2572,7 @@ stdout:
             "count": 736,
             "raw": " 10 files changed, 736 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.7"
         }
       },
@@ -2587,7 +2587,7 @@ stdout:
             "count": 796,
             "raw": " 15 files changed, 796 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.1"
         }
       },
@@ -2602,7 +2602,7 @@ stdout:
             "count": 882,
             "raw": " 13 files changed, 882 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.4.0"
         }
       },
@@ -2617,7 +2617,7 @@ stdout:
             "count": 1001,
             "raw": " 12 files changed, 1001 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.2"
         }
       },
@@ -2632,7 +2632,7 @@ stdout:
             "count": 1101,
             "raw": " 15 files changed, 1101 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.5"
         }
       },
@@ -2647,7 +2647,7 @@ stdout:
             "count": 1133,
             "raw": " 1392 files changed, 1133 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.0"
         }
       },
@@ -2662,7 +2662,7 @@ stdout:
             "count": 1168,
             "raw": " 1421 files changed, 1168 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.0"
         }
       },
@@ -2677,7 +2677,7 @@ stdout:
             "count": 1182,
             "raw": " 16 files changed, 1182 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.21"
         }
       },
@@ -2692,7 +2692,7 @@ stdout:
             "count": 1187,
             "raw": " 16 files changed, 1187 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.21"
         }
       },
@@ -2707,7 +2707,7 @@ stdout:
             "count": 1262,
             "raw": " 19 files changed, 1262 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.4"
         }
       },
@@ -2722,7 +2722,7 @@ stdout:
             "count": 1275,
             "raw": " 46 files changed, 1275 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.80"
         }
       },
@@ -2737,7 +2737,7 @@ stdout:
             "count": 1301,
             "raw": " 14 files changed, 1301 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.5.0"
         }
       },
@@ -2752,7 +2752,7 @@ stdout:
             "count": 1304,
             "raw": " 13 files changed, 1304 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.30"
         }
       },
@@ -2767,7 +2767,7 @@ stdout:
             "count": 1375,
             "raw": " 12 files changed, 1375 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.7.0"
         }
       },
@@ -2782,7 +2782,7 @@ stdout:
             "count": 1721,
             "raw": " 15 files changed, 1721 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.16"
         }
       },
@@ -2797,7 +2797,7 @@ stdout:
             "count": 1754,
             "raw": " 16 files changed, 1754 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.25"
         }
       },
@@ -2812,7 +2812,7 @@ stdout:
             "count": 1804,
             "raw": " 19 files changed, 1804 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.0"
         }
       },
@@ -2827,7 +2827,7 @@ stdout:
             "count": 1966,
             "raw": " 7 files changed, 1966 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.80"
         }
       },
@@ -2842,7 +2842,7 @@ stdout:
             "count": 1971,
             "raw": " 28 files changed, 1971 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.8.3"
         }
       },
@@ -2857,7 +2857,7 @@ stdout:
             "count": 2023,
             "raw": " 29 files changed, 2023 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.6.1"
         }
       },
@@ -2872,7 +2872,7 @@ stdout:
             "count": 2050,
             "raw": " 14 files changed, 2050 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.2"
         }
       },
@@ -2887,7 +2887,7 @@ stdout:
             "count": 2127,
             "raw": " 19 files changed, 2127 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.7.1"
         }
       },
@@ -2902,7 +2902,7 @@ stdout:
             "count": 2622,
             "raw": " 11 files changed, 2622 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.6"
         }
       },
@@ -2917,7 +2917,7 @@ stdout:
             "count": 3019,
             "raw": " 11 files changed, 3019 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.80"
         }
       },
@@ -2932,7 +2932,7 @@ stdout:
             "count": 3135,
             "raw": " 16 files changed, 3135 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.7"
         }
       },
@@ -2947,7 +2947,7 @@ stdout:
             "count": 3309,
             "raw": " 17 files changed, 3309 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.11.0+wasi-snapshot-preview1"
         }
       },
@@ -2962,7 +2962,7 @@ stdout:
             "count": 3398,
             "raw": " 23 files changed, 3398 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.7"
         }
       },
@@ -2977,7 +2977,7 @@ stdout:
             "count": 3845,
             "raw": " 35 files changed, 3845 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.18"
         }
       },
@@ -2992,7 +2992,7 @@ stdout:
             "count": 3897,
             "raw": " 32 files changed, 3897 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.13"
         }
       },
@@ -3007,7 +3007,7 @@ stdout:
             "count": 3960,
             "raw": " 28 files changed, 3960 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.9.3"
         }
       },
@@ -3022,7 +3022,7 @@ stdout:
             "count": 3964,
             "raw": " 20 files changed, 3964 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.20"
         }
       },
@@ -3037,7 +3037,7 @@ stdout:
             "count": 3980,
             "raw": " 15 files changed, 3980 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.4.0"
         }
       },
@@ -3052,7 +3052,7 @@ stdout:
             "count": 3999,
             "raw": " 20 files changed, 3999 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.21"
         }
       },
@@ -3067,7 +3067,7 @@ stdout:
             "count": 4066,
             "raw": " 24 files changed, 4066 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "3.3.0"
         }
       },
@@ -3082,7 +3082,7 @@ stdout:
             "count": 4089,
             "raw": " 21 files changed, 4089 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.10"
         }
       },
@@ -3097,7 +3097,7 @@ stdout:
             "count": 4140,
             "raw": " 24 files changed, 4140 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.10.0"
         }
       },
@@ -3112,7 +3112,7 @@ stdout:
             "count": 4276,
             "raw": " 29 files changed, 4276 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.10.1"
         }
       },
@@ -3127,7 +3127,7 @@ stdout:
             "count": 4531,
             "raw": " 37 files changed, 4531 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.9"
         }
       },
@@ -3142,7 +3142,7 @@ stdout:
             "count": 4607,
             "raw": " 34 files changed, 4607 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.19"
         }
       },
@@ -3157,7 +3157,7 @@ stdout:
             "count": 5632,
             "raw": " 21 files changed, 5632 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.16"
         }
       },
@@ -3172,7 +3172,7 @@ stdout:
             "count": 5702,
             "raw": " 22 files changed, 5702 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.37"
         }
       },
@@ -3187,7 +3187,7 @@ stdout:
             "count": 6018,
             "raw": " 13 files changed, 6018 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.4.4"
         }
       },
@@ -3202,7 +3202,7 @@ stdout:
             "count": 6107,
             "raw": " 72 files changed, 6107 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.8"
         }
       },
@@ -3217,7 +3217,7 @@ stdout:
             "count": 6163,
             "raw": " 28 files changed, 6163 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.25"
         }
       },
@@ -3232,7 +3232,7 @@ stdout:
             "count": 6671,
             "raw": " 22 files changed, 6671 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.73"
         }
       },
@@ -3247,7 +3247,7 @@ stdout:
             "count": 7265,
             "raw": " 20 files changed, 7265 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.7.0"
         }
       },
@@ -3262,7 +3262,7 @@ stdout:
             "count": 8718,
             "raw": " 48 files changed, 8718 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.4.1"
         }
       },
@@ -3277,7 +3277,7 @@ stdout:
             "count": 9213,
             "raw": " 45 files changed, 9213 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.1.0"
         }
       },
@@ -3292,7 +3292,7 @@ stdout:
             "count": 9484,
             "raw": " 48 files changed, 9484 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.9.72"
         }
       },
@@ -3307,7 +3307,7 @@ stdout:
             "count": 9776,
             "raw": " 45 files changed, 9776 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.6.1"
         }
       },
@@ -3322,7 +3322,7 @@ stdout:
             "count": 10106,
             "raw": " 19 files changed, 10106 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "3.9.1"
         }
       },
@@ -3337,7 +3337,7 @@ stdout:
             "count": 10957,
             "raw": " 34 files changed, 10957 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.33"
         }
       },
@@ -3352,7 +3352,7 @@ stdout:
             "count": 11882,
             "raw": " 65 files changed, 11882 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.8.2"
         }
       },
@@ -3367,7 +3367,7 @@ stdout:
             "count": 12875,
             "raw": " 63 files changed, 12875 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.57"
         }
       },
@@ -3382,7 +3382,7 @@ stdout:
             "count": 13877,
             "raw": " 67 files changed, 13877 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.7.1"
         }
       },
@@ -3397,7 +3397,7 @@ stdout:
             "count": 14609,
             "raw": " 33 files changed, 14609 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.11.2"
         }
       },
@@ -3412,7 +3412,7 @@ stdout:
             "count": 16148,
             "raw": " 29 files changed, 16148 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.136"
         }
       },
@@ -3427,7 +3427,7 @@ stdout:
             "count": 16350,
             "raw": " 17 files changed, 16350 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "2.2.2"
         }
       },
@@ -3442,7 +3442,7 @@ stdout:
             "count": 16758,
             "raw": " 27 files changed, 16758 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.5.1"
         }
       },
@@ -3457,7 +3457,7 @@ stdout:
             "count": 16826,
             "raw": " 41 files changed, 16826 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.6"
         }
       },
@@ -3472,7 +3472,7 @@ stdout:
             "count": 20978,
             "raw": " 243 files changed, 20978 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.80"
         }
       },
@@ -3487,7 +3487,7 @@ stdout:
             "count": 21234,
             "raw": " 44 files changed, 21234 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.7"
         }
       },
@@ -3502,7 +3502,7 @@ stdout:
             "count": 25074,
             "raw": " 187 files changed, 25074 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.21"
         }
       },
@@ -3517,7 +3517,7 @@ stdout:
             "count": 25617,
             "raw": " 72 files changed, 25617 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.14.18"
         }
       },
@@ -3532,7 +3532,7 @@ stdout:
             "count": 26066,
             "raw": " 66 files changed, 26066 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.13"
         }
       },
@@ -3562,7 +3562,7 @@ stdout:
             "count": 28628,
             "raw": " 26 files changed, 28628 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.19"
         }
       },
@@ -3577,7 +3577,7 @@ stdout:
             "count": 28634,
             "raw": " 85 files changed, 28634 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.10.38"
         }
       },
@@ -3592,7 +3592,7 @@ stdout:
             "count": 32538,
             "raw": " 19 files changed, 32538 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.3"
         }
       },
@@ -3607,7 +3607,7 @@ stdout:
             "count": 42648,
             "raw": " 834 files changed, 42648 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.15"
         }
       },
@@ -3622,7 +3622,7 @@ stdout:
             "count": 197014,
             "raw": " 2203 files changed, 197014 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.57"
         }
       },
@@ -3637,7 +3637,7 @@ stdout:
             "count": 507252,
             "raw": " 104 files changed, 507252 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.8.31"
         }
       }

--- a/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-shallow-json.snap
@@ -91,7 +91,7 @@ stdout:
               "count": 2585,
               "raw": " 12 files changed, 2585 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.1.3"
           }
         },
@@ -106,7 +106,7 @@ stdout:
               "count": 2918,
               "raw": " 23 files changed, 2918 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "6.0.0"
           }
         },
@@ -121,7 +121,7 @@ stdout:
               "count": 6165,
               "raw": " 18 files changed, 6165 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.15.0"
           }
         },
@@ -136,7 +136,7 @@ stdout:
               "count": 9452,
               "raw": " 33 files changed, 9452 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.8.1"
           }
         },
@@ -151,7 +151,7 @@ stdout:
               "count": 21663,
               "raw": " 63 files changed, 21663 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.11.10"
           }
         },
@@ -166,7 +166,7 @@ stdout:
               "count": 22855,
               "raw": " 88 files changed, 22855 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.0.79"
           }
         },
@@ -181,7 +181,7 @@ stdout:
               "count": 91278,
               "raw": " 405 files changed, 91278 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "1.17.0"
           }
         }
@@ -198,7 +198,7 @@ stdout:
               "count": 938,
               "raw": " 11 files changed, 938 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.1.19"
           }
         },
@@ -213,7 +213,7 @@ stdout:
               "count": 94067,
               "raw": " 217 files changed, 94067 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.2.123"
           }
         },
@@ -228,7 +228,7 @@ stdout:
               "count": 181329,
               "raw": " 412 files changed, 181329 insertions(+)\n"
             },
-            "from": "0.0.0",
+            "from": null,
             "to": "0.3.9"
           }
         }
@@ -246,7 +246,7 @@ stdout:
             "count": 938,
             "raw": " 11 files changed, 938 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.1.19"
         }
       },
@@ -261,7 +261,7 @@ stdout:
             "count": 2585,
             "raw": " 12 files changed, 2585 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.1.3"
         }
       },
@@ -276,7 +276,7 @@ stdout:
             "count": 2918,
             "raw": " 23 files changed, 2918 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "6.0.0"
         }
       },
@@ -291,7 +291,7 @@ stdout:
             "count": 6165,
             "raw": " 18 files changed, 6165 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.15.0"
         }
       },
@@ -306,7 +306,7 @@ stdout:
             "count": 9452,
             "raw": " 33 files changed, 9452 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.8.1"
         }
       },
@@ -321,7 +321,7 @@ stdout:
             "count": 21663,
             "raw": " 63 files changed, 21663 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.11.10"
         }
       },
@@ -336,7 +336,7 @@ stdout:
             "count": 22855,
             "raw": " 88 files changed, 22855 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.0.79"
         }
       },
@@ -351,7 +351,7 @@ stdout:
             "count": 91278,
             "raw": " 405 files changed, 91278 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "1.17.0"
         }
       },
@@ -366,7 +366,7 @@ stdout:
             "count": 94067,
             "raw": " 217 files changed, 94067 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.2.123"
         }
       },
@@ -381,7 +381,7 @@ stdout:
             "count": 181329,
             "raw": " 412 files changed, 181329 insertions(+)\n"
           },
-          "from": "0.0.0",
+          "from": null,
           "to": "0.3.9"
         }
       }


### PR DESCRIPTION
The logic in the resolver previously treated the version 0.0.0 as the
"root version" (i.e. equivalent to no version at all). Unfortunatley,
this version can be published, meaning that we'll misbehave when trying
to interact with an actually published version 0.0.0 of a crate, and
will always consider it fully-audited as the "root version".

This patch updates the logic in the resolver to operate on
`Option<Version>` instead of `Version` in places where the root version
is valid.

Because this encoding of 0.0.0 as the root version is saved on disk in
the diff-cache, this patch changes the diff-cache format in an
incompatible way to force it to be re-built. It also adds a mechanism to
make forcing the diff-cache to be re-built easier in the future.

Unfortunately, these changes lead to a large number of JSON output test
failures, as we exposed the old internal desugaring of '0.0.0' as a diff
source in the JSON output, which has now changed to null. We may want to
look into changing this part of the output to avoid talking about full
audits as "diffs from null" in the future.

Fixes #307