### PR TITLE
Display progress bars for long-running operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "home",
+ "indicatif",
  "insta",
  "lazy_static",
  "libc",
@@ -592,6 +593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
+]
+
+[[package]]
 name = "insta"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +817,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ filetime = "0.2.16"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 futures-util = { version = "0.3.21", default-features = false, features = ["std"] }
 home = "0.5.3"
+indicatif = "0.17.0"
 lazy_static = "1.4.0"
 libc = "0.2"
 nom = "7.1.1"

--- a/src/flock.rs
+++ b/src/flock.rs
@@ -13,6 +13,7 @@ use std::path::{Display, Path, PathBuf};
 use sys::*;
 
 use crate::errors::FlockError;
+use crate::out::indeterminate_spinner;
 
 #[derive(Debug)]
 pub struct FileLock {
@@ -278,7 +279,8 @@ fn acquire(
             }
         }
     }
-    eprintln!("Blocking: waiting for file lock on {}", msg);
+
+    let _spinner = indeterminate_spinner("Blocking", format!("waiting for file lock on {}", msg));
 
     lock_block()?;
     return Ok(());

--- a/src/out.rs
+++ b/src/out.rs
@@ -6,7 +6,9 @@
 
 use crate::editor::Editor;
 use console::{Style, Term};
-use std::{fmt, fs::File, io};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use lazy_static::lazy_static;
+use std::{borrow::Cow, fmt, fs::File, io, mem, time::Duration};
 
 /// Object-safe extension of `std::io::Write` with extra features for
 /// interacting with the terminal. Can be mocked in tests to allow them to test
@@ -65,6 +67,8 @@ pub trait Out: Send + Sync + 'static {
 // "Real" user-facing terminal on stdout
 impl Out for Term {
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        // XXX: Consider suspending the MultiProgress when writing if we ever
+        // want to write to `Out` while a progress bar is rendering.
         io::Write::write(&mut &*self, buf)
     }
 
@@ -105,5 +109,93 @@ impl io::Write for &'_ dyn Out {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+lazy_static! {
+    /// The global `MultiProgress` which can be used to write out progress reports.
+    ///
+    /// By default, this is invisible so that it isn't shown during tests, but
+    /// it will be configured to be visible early during main.
+    pub static ref MULTIPROGRESS: MultiProgress =
+        MultiProgress::with_draw_target(ProgressDrawTarget::hidden());
+}
+
+/// Helper for bracketing some region with an indeterminate spinner which shows
+/// no meaningful progress.
+pub fn indeterminate_spinner(
+    prefix: impl Into<Cow<'static, str>>,
+    message: impl Into<Cow<'static, str>>,
+) -> ProgressBar {
+    let progress_bar = MULTIPROGRESS.add(
+        ProgressBar::new_spinner()
+            .with_style(
+                ProgressStyle::with_template("{prefix:>12.cyan.bold} {msg} {spinner}").unwrap(),
+            )
+            .with_prefix(prefix)
+            .with_message(message),
+    );
+    progress_bar.enable_steady_tick(Duration::from_millis(100));
+    progress_bar
+}
+
+/// Create a new progress bar with a cargo-inspired style.
+pub fn progress_bar(
+    prefix: impl Into<Cow<'static, str>>,
+    message: impl Into<Cow<'static, str>>,
+    len: u64,
+) -> ProgressBar {
+    let progress_bar = MULTIPROGRESS.add(
+        ProgressBar::new(len)
+            .with_style(
+                ProgressStyle::with_template("{prefix:>12.cyan.bold} {msg} [{bar:57}] {pos}/{len}")
+                    .unwrap()
+                    .progress_chars("=> "),
+            )
+            .with_prefix(prefix)
+            .with_message(message),
+    );
+    progress_bar.tick();
+    progress_bar
+}
+
+/// Helper guard object to increment progress for the given progress bar by the
+/// given amount when this object is destroyed.
+pub struct IncProgressOnDrop<'a>(pub &'a ProgressBar, pub u64);
+impl Drop for IncProgressOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.inc(self.1);
+    }
+}
+
+/// A helper type which implements `io::Write`, and will buffer up input, then
+/// suspend the MultiProgress and write it all out when dropped to avoid
+/// tearing.
+///
+/// This is used for tracing logs when no log file is specified.
+pub struct StderrLogWriter {
+    buffer: Vec<u8>,
+}
+
+impl StderrLogWriter {
+    pub fn new() -> Self {
+        StderrLogWriter { buffer: Vec::new() }
+    }
+}
+
+impl io::Write for StderrLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        io::Write::write(&mut self.buffer, buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let buffer = mem::take(&mut self.buffer);
+        MULTIPROGRESS.suspend(|| io::stderr().write_all(&buffer))
+    }
+}
+
+impl Drop for StderrLogWriter {
+    fn drop(&mut self) {
+        let _ = io::Write::flush(self);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -33,6 +33,7 @@ use crate::{
         SortedMap, SAFE_TO_DEPLOY, SAFE_TO_RUN,
     },
     network::Network,
+    out::{progress_bar, IncProgressOnDrop},
     resolver::{self, Conclusion},
     serialization::{spanned::Spanned, to_formatted_toml},
     Config, PartialConfig,
@@ -737,7 +738,9 @@ async fn fetch_imported_audits(
     network: &Network,
     config: &ConfigFile,
 ) -> Result<Vec<(ImportName, AuditsFile)>, FetchAuditError> {
+    let progress_bar = progress_bar("Fetching", "imported audits", config.imports.len() as u64);
     try_join_all(config.imports.iter().map(|(name, import)| async {
+        let _guard = IncProgressOnDrop(&progress_bar, 1);
         let audit_file = fetch_imported_audit(network, name, &import.url).await?;
         Ok::<_, FetchAuditError>((name.clone(), audit_file))
     }))


### PR DESCRIPTION
This adds progress bars for most long-running operations using indicatif. It
also adds some support for avoiding tearing when these progress bars are used
in-tandem with tracing logging.

Progress bars or spinners will be shown for running `cargo metadata`, fetching
imported audits, acquiring contended lockfiles, and computing suggested audits.

Fixes #209