### PR TITLE
Allow policy dependency_criteria for crates-io crates

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -116,10 +116,10 @@ of a given crate.
 
 ### the `policy` Table
 
-This table maps first-party crates to the audit requirements that `cargo vet`
-should enforce on their dependencies. When unspecified, non-top-level
-first-party crates inherit most policy attributes from their parents, whereas
-top-level first-party crates get the defaults described below.
+This table maps crates to extra audit requirements that `cargo vet` should
+enforce on their dependencies. When unspecified, non-top-level first-party
+crates inherit most policy attributes from their parents, whereas top-level
+first-party crates get the defaults described below.
 
 In this context, "top-level" generally refers to crates with no
 reverse-dependencies — except when evaluating dev-dependencies, in which case
@@ -129,6 +129,9 @@ every workspace member is considered a root.
 
 A string or array of strings specifying the criteria that should be enforced for
 this crate and its dependency tree.
+
+If specified, no other audits or dependency edges can enforce additional or
+fewer criteria.
 
 For top-level crates, defaults to `safe-to-deploy`.
 
@@ -140,9 +143,15 @@ For top-level crates, defaults to `safe-to-run`.
 
 #### `dependency-criteria`
 
-Allows overriding the above values on a per-dependency basis. Similar in format
-to the [equivalent field](audit-entries.md#dependency-criteria) in audit
-entries.
+Allows overriding dependency criteria requirements on a per-dependency basis.
+
+Similar in format to the [equivalent field](audit-entries.md#dependency-criteria)
+in audit entries.
+
+This policy override takes priority over all other places where
+`dependency-criteria` is specified, and can be specified for any crate,
+including third-party crates, in order to modify how audits on that crate treat
+dependencies.
 
 Defaults to the empty set and is not inherited.
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1595,6 +1595,22 @@ fn resolve_third_party<'a>(
 
     let all_audits = own_audits.chain(foreign_audits);
 
+    // Get custom policies for our dependencies
+    let policy_dep_criteria = store
+        .config
+        .policy
+        .get(package.name)
+        .map(|policy| {
+            policy
+                .dependency_criteria
+                .iter()
+                .map(|(dep_name, criteria)| {
+                    (&**dep_name, criteria_mapper.criteria_from_list(criteria))
+                })
+                .collect::<FastMap<_, _>>()
+        })
+        .unwrap_or_default();
+
     // See AuditGraph's docs for details on the lowering we do here
     let mut forward_audits = AuditGraph::new();
     let mut backward_audits = AuditGraph::new();
@@ -1619,17 +1635,17 @@ fn resolve_third_party<'a>(
             }
         };
 
-        let criteria = criteria_mapper.criteria_from_namespaced_entry(namespace, entry);
         // Convert all the custom criteria to CriteriaSets
-        let dependency_criteria: FastMap<_, _> = dependency_criteria
-            .iter()
-            .map(|(pkg_name, criteria)| {
-                (
-                    &**pkg_name,
-                    criteria_mapper.criteria_from_namespaced_list(namespace, criteria),
-                )
-            })
-            .collect();
+        let criteria = criteria_mapper.criteria_from_namespaced_entry(namespace, entry);
+
+        // Build the dependency_criteria for this edge, by combining the
+        // explicitly specified criteria with ones from the policy.
+        let mut dep_criteria = policy_dep_criteria.clone();
+        for (pkg_name, criteria) in dependency_criteria {
+            dep_criteria.entry(&**pkg_name).or_insert_with(|| {
+                criteria_mapper.criteria_from_namespaced_list(namespace, criteria)
+            });
+        }
 
         let origin = if entry.is_fresh_import {
             DeltaEdgeOrigin::FreshImportedAudit
@@ -1640,7 +1656,7 @@ fn resolve_third_party<'a>(
         forward_audits.entry(from_ver).or_default().push(DeltaEdge {
             version: Some(to_ver),
             criteria: criteria.clone(),
-            dependency_criteria: dependency_criteria.clone(),
+            dependency_criteria: dep_criteria.clone(),
             origin,
         });
         backward_audits
@@ -1649,7 +1665,7 @@ fn resolve_third_party<'a>(
             .push(DeltaEdge {
                 version: from_ver,
                 criteria,
-                dependency_criteria,
+                dependency_criteria: dep_criteria,
                 origin,
             });
     }
@@ -1782,25 +1798,27 @@ fn resolve_third_party<'a>(
             let from_ver = None;
             let to_ver = Some(&allowed.version);
             let criteria = criteria_mapper.criteria_from_list(&allowed.criteria);
-            let dependency_criteria: FastMap<_, _> = allowed
-                .dependency_criteria
-                .iter()
-                .map(|(pkg_name, criteria)| {
-                    (&**pkg_name, criteria_mapper.criteria_from_list(criteria))
-                })
-                .collect();
+
+            // Build the dependency_criteria for this edge, by combining the
+            // explicitly specified criteria with ones from the policy.
+            let mut dep_criteria = policy_dep_criteria.clone();
+            for (pkg_name, criteria) in &allowed.dependency_criteria {
+                dep_criteria
+                    .entry(&**pkg_name)
+                    .or_insert_with(|| criteria_mapper.criteria_from_list(criteria));
+            }
 
             // For simplicity, turn 'exemptions' entries into deltas from None.
             forward_audits.entry(from_ver).or_default().push(DeltaEdge {
                 version: to_ver,
                 criteria: criteria.clone(),
-                dependency_criteria: dependency_criteria.clone(),
+                dependency_criteria: dep_criteria.clone(),
                 origin: DeltaEdgeOrigin::Exemption,
             });
             backward_audits.entry(to_ver).or_default().push(DeltaEdge {
                 version: from_ver,
                 criteria,
-                dependency_criteria,
+                dependency_criteria: dep_criteria,
                 origin: DeltaEdgeOrigin::Exemption,
             });
         }


### PR DESCRIPTION
Previously this wouldn't be allowed, as the dependency-criteria would be
pulled from the audit edges, rather than from the policy. With these
changes, it will be pulled from both places, with policy
dependency-criteria overriding the criteria specified by all audit and
exemption edges.