### PR TITLE
Implement cargo vet aggregate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -322,6 +322,15 @@ pub enum Commands {
     #[clap(disable_version_flag = true)]
     FetchImports(FetchImportsArgs),
 
+    /// Fetch and merge audits from multiple sources into a single `audits.toml`
+    /// file.
+    ///
+    /// Will fetch the audits from each URL in the provided file, combining them
+    /// into a single file. Custom criteria will be merged by-name, and must
+    /// have identical descriptions in each source audit file.
+    #[clap(disable_version_flag = true)]
+    Aggregate(AggregateArgs),
+
     /// Print the cargo build graph as understood by `cargo vet`
     ///
     /// This is a debugging command, the output's format is not guaranteed.
@@ -569,6 +578,13 @@ pub struct RegenerateImportsArgs {}
 
 #[derive(clap::Args)]
 pub struct RegenerateAuditAsCratesIoArgs {}
+
+#[derive(clap::Args)]
+pub struct AggregateArgs {
+    /// Path to a file containing a list of URLs to aggregate the audits from.
+    #[clap(action)]
+    pub sources: PathBuf,
+}
 
 #[derive(clap::Args)]
 pub struct HelpMarkdownArgs {}

--- a/src/format.rs
+++ b/src/format.rs
@@ -148,6 +148,12 @@ pub struct CriteriaEntry {
     #[serde(default)]
     #[serde(with = "serialization::string_or_vec")]
     pub implies: Vec<Spanned<CriteriaName>>,
+    /// Chain of sources this criteria was aggregated from, most recent last.
+    #[serde(rename = "aggregated-from")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(with = "serialization::string_or_vec")]
+    pub aggregated_from: Vec<Spanned<String>>,
 }
 
 /// This is conceptually an enum
@@ -159,6 +165,8 @@ pub struct AuditEntry {
     pub criteria: Vec<Spanned<CriteriaName>>,
     pub kind: AuditKind,
     pub notes: Option<String>,
+    /// Chain of sources this audit was aggregated from, most recent last.
+    pub aggregated_from: Vec<Spanned<String>>,
     /// A non-serialized member which indicates whether this audit is a "fresh"
     /// audit. This will be set for all audits imported found in the remote
     /// audits file which aren't also found in the local `imports.lock` cache.

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3142,7 +3142,7 @@ impl FailForViolationConflict {
                 }
             }
             if !entry.who.is_empty() {
-                writeln!(out, "");
+                writeln!(out);
             }
             if let Some(notes) = &entry.notes {
                 writeln!(out, "      notes: {notes}");

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -206,6 +206,11 @@ pub mod audit {
         #[serde(default)]
         dependency_criteria: DependencyCriteria,
         notes: Option<String>,
+        #[serde(rename = "aggregated-from")]
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(with = "string_or_vec")]
+        #[serde(default)]
+        pub aggregated_from: Vec<Spanned<String>>,
     }
 
     impl TryFrom<AuditEntryAll> for AuditEntry {
@@ -244,6 +249,7 @@ pub mod audit {
                 notes: val.notes,
                 criteria: val.criteria,
                 kind: kind?,
+                aggregated_from: val.aggregated_from,
                 // By default, always read entries as non-fresh. The import code
                 // will set this flag to true for imported entries.
                 is_fresh_import: false,
@@ -283,6 +289,7 @@ pub mod audit {
                 delta,
                 violation,
                 dependency_criteria,
+                aggregated_from: val.aggregated_from,
             }
         }
     }
@@ -627,6 +634,7 @@ mod test {
                         dependency_criteria: dc_long,
                     },
                     notes: Some("notes go here!".to_owned()),
+                    aggregated_from: vec![],
                     is_fresh_import: false, // ignored
                 },
                 AuditEntry {
@@ -637,6 +645,7 @@ mod test {
                         dependency_criteria: dc_short,
                     },
                     notes: Some("notes go here!".to_owned()),
+                    aggregated_from: vec![],
                     is_fresh_import: true, // ignored
                 },
             ],

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -1,0 +1,231 @@
+use insta::assert_snapshot;
+
+use super::*;
+
+fn mock_aggregate(sources: Vec<(String, AuditsFile)>) -> String {
+    match crate::do_aggregate_audits(sources) {
+        Ok(merged) => crate::serialization::to_formatted_toml(merged)
+            .unwrap()
+            .to_string(),
+        Err(error) => format!("{:?}", miette::Report::new(error)),
+    }
+}
+
+#[test]
+fn test_merge_audits_files_basic() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let audits_files = vec![
+        (
+            "https://source1.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [].into_iter().collect(),
+                audits: [(
+                    "package1".to_owned(),
+                    vec![full_audit(ver(DEFAULT_VER), "safe-to-deploy")],
+                )]
+                .into_iter()
+                .collect(),
+            },
+        ),
+        (
+            "https://source2.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [].into_iter().collect(),
+                audits: [
+                    (
+                        "package1".to_owned(),
+                        vec![
+                            full_audit(ver(5), "safe-to-deploy"),
+                            full_audit(ver(DEFAULT_VER), "safe-to-deploy"),
+                        ],
+                    ),
+                    (
+                        "package2".to_owned(),
+                        vec![full_audit(ver(DEFAULT_VER), "safe-to-deploy")],
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            },
+        ),
+    ];
+
+    let output = mock_aggregate(audits_files);
+    assert_snapshot!(output);
+}
+
+#[test]
+fn test_merge_audits_files_custom_criteria() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let audits_files = vec![
+        (
+            "https://source1.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [
+                    (
+                        "criteria1".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 1".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec!["https://elsewhere.example.com/audits.toml"
+                                .to_owned()
+                                .into()],
+                        },
+                    ),
+                    (
+                        "criteria2".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 2".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec![],
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                audits: [(
+                    "package1".to_owned(),
+                    vec![
+                        full_audit(ver(DEFAULT_VER), "criteria1"),
+                        full_audit(ver(DEFAULT_VER), "criteria2"),
+                    ],
+                )]
+                .into_iter()
+                .collect(),
+            },
+        ),
+        (
+            "https://source2.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [
+                    (
+                        "criteria1".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 1".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec!["https://beyond.example.com/audits.toml"
+                                .to_owned()
+                                .into()],
+                        },
+                    ),
+                    (
+                        "criteria3".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 3".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec![],
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                audits: [
+                    (
+                        "package1".to_owned(),
+                        vec![full_audit(ver(DEFAULT_VER), "criteria3")],
+                    ),
+                    (
+                        "package2".to_owned(),
+                        vec![full_audit(ver(DEFAULT_VER), "criteria1")],
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            },
+        ),
+    ];
+
+    let output = mock_aggregate(audits_files);
+    assert_snapshot!(output);
+}
+
+#[test]
+fn test_merge_audits_files_custom_criteria_conflict() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let audits_files = vec![
+        (
+            "https://source1.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [
+                    (
+                        "criteria1".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 1".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec![],
+                        },
+                    ),
+                    (
+                        "criteria2".to_owned(),
+                        CriteriaEntry {
+                            implies: vec!["criteria1".to_owned().into()],
+                            description: Some("Criteria 2".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec![],
+                        },
+                    ),
+                    (
+                        "criteria3".to_owned(),
+                        CriteriaEntry {
+                            implies: vec!["criteria2".to_owned().into()],
+                            description: None,
+                            description_url: Some("https://criteria3".to_owned()),
+                            aggregated_from: vec![],
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                audits: [].into_iter().collect(),
+            },
+        ),
+        (
+            "https://source2.example.com/supply_chain/audits.toml".to_owned(),
+            AuditsFile {
+                criteria: [
+                    (
+                        "criteria1".to_owned(),
+                        CriteriaEntry {
+                            implies: vec![],
+                            description: Some("Criteria 1 (alt)".to_owned()),
+                            description_url: None,
+                            aggregated_from: vec![],
+                        },
+                    ),
+                    (
+                        "criteria2".to_owned(),
+                        CriteriaEntry {
+                            implies: vec!["criteria1".to_owned().into()],
+                            description: None,
+                            description_url: Some("https://criteria2".to_owned()),
+                            aggregated_from: vec![],
+                        },
+                    ),
+                    (
+                        "criteria3".to_owned(),
+                        CriteriaEntry {
+                            implies: vec!["criteria1".to_owned().into()],
+                            description: None,
+                            description_url: Some("https://criteria3.alt".to_owned()),
+                            aggregated_from: vec![],
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                audits: [].into_iter().collect(),
+            },
+        ),
+    ];
+
+    let output = mock_aggregate(audits_files);
+    assert_snapshot!(output);
+}

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -337,16 +337,9 @@ fn existing_peer_import_custom_criteria() {
     };
 
     let new_foreign_audits = AuditsFile {
-        criteria: [(
-            "fuzzed".to_string(),
-            CriteriaEntry {
-                implies: vec![],
-                description: Some("fuzzed".to_string()),
-                description_url: None,
-            },
-        )]
-        .into_iter()
-        .collect(),
+        criteria: [("fuzzed".to_string(), criteria("fuzzed"))]
+            .into_iter()
+            .collect(),
         audits: [(
             "third-party2".to_owned(),
             vec![
@@ -395,16 +388,9 @@ fn new_audit_for_unused_criteria_basic() {
     let metadata = mock.metadata();
     let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
     let old_foreign_audits = AuditsFile {
-        criteria: [(
-            "fuzzed".to_string(),
-            CriteriaEntry {
-                implies: vec![],
-                description: Some("fuzzed".to_string()),
-                description_url: None,
-            },
-        )]
-        .into_iter()
-        .collect(),
+        criteria: [("fuzzed".to_string(), criteria("fuzzed"))]
+            .into_iter()
+            .collect(),
         audits: [(
             "third-party2".to_owned(),
             vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
@@ -457,16 +443,9 @@ fn new_audit_for_unused_criteria_transitive() {
     let metadata = mock.metadata();
     let (mut config, audits, mut imports) = builtin_files_full_audited(&metadata);
     let old_foreign_audits = AuditsFile {
-        criteria: [(
-            "fuzzed".to_string(),
-            CriteriaEntry {
-                implies: vec![],
-                description: Some("fuzzed".to_string()),
-                description_url: None,
-            },
-        )]
-        .into_iter()
-        .collect(),
+        criteria: [("fuzzed".to_string(), criteria("fuzzed"))]
+            .into_iter()
+            .collect(),
         audits: [(
             "third-party1".to_owned(),
             vec![full_audit(ver(DEFAULT_VER), SAFE_TO_DEPLOY)],

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -600,19 +600,11 @@ fn builtin_simple_exemptions_regenerate_merge() {
 
     audits.criteria.insert(
         "criteria1".to_owned(),
-        CriteriaEntry {
-            description: Some(String::new()),
-            description_url: None,
-            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
-        },
+        criteria_implies("", [SAFE_TO_DEPLOY]),
     );
     audits.criteria.insert(
         "criteria2".to_owned(),
-        CriteriaEntry {
-            description: Some(String::new()),
-            description_url: None,
-            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
-        },
+        criteria_implies("", [SAFE_TO_DEPLOY]),
     );
 
     audits.audits.insert(
@@ -659,19 +651,11 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
     audits.criteria.insert(
         "criteria1".to_owned(),
-        CriteriaEntry {
-            description: Some(String::new()),
-            description_url: None,
-            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
-        },
+        criteria_implies("", [SAFE_TO_DEPLOY]),
     );
     audits.criteria.insert(
         "criteria2".to_owned(),
-        CriteriaEntry {
-            description: Some(String::new()),
-            description_url: None,
-            implies: vec![SAFE_TO_DEPLOY.to_owned().into()],
-        },
+        criteria_implies("", [SAFE_TO_DEPLOY]),
     );
 
     audits.audits.insert(

--- a/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_basic.snap
+++ b/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_basic.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/aggregate.rs
+expression: output
+---
+
+[[audits.package1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
+
+[[audits.package1]]
+criteria = "safe-to-deploy"
+version = "5.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+
+[[audits.package1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+
+[[audits.package2]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+

--- a/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_custom_criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_custom_criteria.snap
@@ -1,0 +1,40 @@
+---
+source: src/tests/aggregate.rs
+expression: output
+---
+
+[criteria.criteria1]
+description = "Criteria 1"
+aggregated-from = [
+    "https://elsewhere.example.com/audits.toml",
+    "https://source1.example.com/supply_chain/audits.toml",
+]
+
+[criteria.criteria2]
+description = "Criteria 2"
+aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
+
+[criteria.criteria3]
+description = "Criteria 3"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+
+[[audits.package1]]
+criteria = "criteria1"
+version = "10.0.0"
+aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
+
+[[audits.package1]]
+criteria = "criteria2"
+version = "10.0.0"
+aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
+
+[[audits.package1]]
+criteria = "criteria3"
+version = "10.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+
+[[audits.package2]]
+criteria = "criteria1"
+version = "10.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+

--- a/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_custom_criteria_conflict.snap
+++ b/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_custom_criteria_conflict.snap
@@ -1,0 +1,32 @@
+---
+source: src/tests/aggregate.rs
+expression: output
+---
+
+  × there were errors aggregating source audit files
+
+Error: 
+  × criteria description mismatch for criteria1
+  │ https://source1.example.com/supply_chain/audits.toml:
+  │ Criteria 1
+  │ https://source2.example.com/supply_chain/audits.toml:
+  │ Criteria 1 (alt)
+Error: 
+  × criteria description mismatch for criteria2
+  │ https://source1.example.com/supply_chain/audits.toml:
+  │ Criteria 2
+  │ https://source2.example.com/supply_chain/audits.toml:
+  │ (URL) https://criteria2
+Error: 
+  × criteria description mismatch for criteria3
+  │ https://source1.example.com/supply_chain/audits.toml:
+  │ (URL) https://criteria3
+  │ https://source2.example.com/supply_chain/audits.toml:
+  │ (URL) https://criteria3.alt
+Error: 
+  × implied criteria mismatch for criteria3
+  │ https://source1.example.com/supply_chain/audits.toml:
+  │  - criteria2
+  │ https://source2.example.com/supply_chain/audits.toml:
+  │  - criteria1
+

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -2703,16 +2703,9 @@ fn builtin_simple_foreign_dep_criteria_fail() {
     imports.audits.insert(
         FOREIGN.to_owned(),
         AuditsFile {
-            criteria: [(
-                DEFAULT_CRIT.to_owned(),
-                CriteriaEntry {
-                    description: Some("nice".to_owned()),
-                    description_url: None,
-                    implies: Vec::new(),
-                },
-            )]
-            .into_iter()
-            .collect(),
+            criteria: [(DEFAULT_CRIT.to_owned(), criteria("nice"))]
+                .into_iter()
+                .collect(),
             audits: [(
                 "third-party1".to_owned(),
                 vec![full_audit_dep(
@@ -2757,16 +2750,9 @@ fn builtin_simple_foreign_dep_criteria_pass() {
     imports.audits.insert(
         FOREIGN.to_owned(),
         AuditsFile {
-            criteria: [(
-                DEFAULT_CRIT.to_owned(),
-                CriteriaEntry {
-                    description: Some("nice".to_owned()),
-                    description_url: None,
-                    implies: Vec::new(),
-                },
-            )]
-            .into_iter()
-            .collect(),
+            criteria: [(DEFAULT_CRIT.to_owned(), criteria("nice"))]
+                .into_iter()
+                .collect(),
             audits: [
                 (
                     "third-party1".to_owned(),


### PR DESCRIPTION
This feature allows specifying multiple sources in a `sources.list` file which will be processed to generate a new source file, containing all of the audits from each listed source. Criteria are merged from these sources by-name, with the descriptions and implies sets requried to be identical between criteria with the same name from different sources.

The chain of what imports were used for a given criteria or audit is now tracked in the .toml file as well, using an aggregated-from field on the relevant entries.

Fixes #83