### PR TITLE
Update crates.io index when necessary to avoid errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,10 +29,6 @@ pub enum AuditAsError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     ShouldntBeAuditAs(ShouldntBeAuditAsErrors),
-    // FIXME: we should probably just make the caller pass this in?
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    CacheAcquire(CacheAcquireError),
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__audit-as-crates-io-need-update.snap
+++ b/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__audit-as-crates-io-need-update.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/audit_as_crates_io.rs
+expression: output
+---
+
+  × There are some issues with your policy.audit-as-crates-io entries
+
+Error: 
+  × Some non-crates.io-fetched packages match published crates.io versions
+  │   root:10.0.0
+  help: Add a `policy.*.audit-as-crates-io` entry for them
+


### PR DESCRIPTION
If we would generate an error due to an `audit-as-crates-io` policy being specified for a crate which doesn't appear to be in the index, it may be because the local copy of the index is out-of-date.

With these changes, if we notice the index is out of date in this way, we'll update our local copy of the index and re-run our checks. This should avoid potential issues with new audits being added for `audit-as-crates-io = true` crates reporting errors on machines which have an out-of-date copy of the index.

In the future, we may want to switch to instead using the sparse http API for crates.io, rather than using `crates-index`, in order to handle running on machines using the new sparse crates.io registry support which may be stabilized soon (https://github.com/rust-lang/cargo/pull/11224). Alternatively it may be worth asking `cargo` to add a new subcommand to check if a specific crate exists in the index, which could take advantage of whatever representation is currently being used as well as any caching cargo performs under the hood.

The bulk of this patch involves changing how the mock index is handled in tests to make it possible to test this updating behaviour. 