### PR TITLE
Add Zcash audit set to registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1,2 +1,5 @@
 [registry.firefox]
 url = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[registry.zcash]
+url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"


### PR DESCRIPTION
This audit set is automatically aggregated from all of our audit sources (currently only one, soon to be two).