### PR TITLE
When running --locked, check formatting of store files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nom = "7.1.1"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.136"
 serde_json = "1.0.82"
+similar = "2.2.0"
 tar = { version = "0.4.26", default-features = false }
 tempfile = "3.3.0"
 textwrap = { version = "0.15", default-features = false }
@@ -58,4 +59,3 @@ features = [
 
 [dev-dependencies]
 insta = "1.16.0"
-similar = "2.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use format::{CriteriaName, CriteriaStr, PackageName, PolicyEntry};
 use futures_util::future::{join_all, try_join_all};
 use indicatif::ProgressDrawTarget;
 use lazy_static::lazy_static;
-use miette::{miette, Context, Diagnostic, IntoDiagnostic, NamedSource, SourceOffset};
+use miette::{miette, Context, Diagnostic, IntoDiagnostic, SourceOffset};
 use network::Network;
 use out::{progress_bar, IncProgressOnDrop};
 use reqwest::Url;
@@ -30,7 +30,7 @@ use thiserror::Error;
 use tracing::{error, info, trace, warn};
 
 use crate::cli::*;
-use crate::errors::{CommandError, DownloadError, RegenerateExemptionsError};
+use crate::errors::{CommandError, DownloadError, RegenerateExemptionsError, SourceFile};
 use crate::format::{
     AuditEntry, AuditKind, AuditsFile, ConfigFile, CriteriaEntry, DependencyCriteria,
     ExemptedDependency, FetchCommand, ImportsFile, MetaConfig, MetaConfigInstance, PackageStr,
@@ -1610,7 +1610,7 @@ fn cmd_aggregate(
             let url_string = url.to_string();
             let audit_bytes = network.download(url).await?;
             let audit_string = String::from_utf8(audit_bytes).map_err(LoadTomlError::from)?;
-            let audit_source = Arc::new(NamedSource::new(url_string.clone(), audit_string.clone()));
+            let audit_source = SourceFile::new(&url_string, audit_string.clone());
             let audit_file: AuditsFile = toml::de::from_str(&audit_string)
                 .map_err(|error| {
                     let (line, col) = error.line_col().unwrap_or((0, 0));

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_updated_description.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_updated_description.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/import.rs
+expression: "format!(\"{:?}\", error)"
+---
+
+  × Some of your imported audits changed their criteria descriptions
+
+Error: 
+  × peer-company's 'example' criteria changed:
+  │ 
+  │ @@ -1,4 +1,4 @@
+  │  Example criteria description
+  │ -First line
+  │ -Second line
+  │ +First new line
+  │  Third line
+  │ +Fourth line
+  │ 
+  help: Run `cargo vet regenerate imports` to accept this new definition
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize.snap
@@ -21,7 +21,6 @@ config.toml:
  [[exemptions.transitive-third-party1]]
  version = "10.0.0"
  criteria = "safe-to-deploy"
- 
 
 imports.lock:
  
@@ -31,6 +30,5 @@ imports.lock:
 +[[audits.peer-company.audits.third-party2]]
 +criteria = "safe-to-deploy"
 +version = "10.0.0"
- 
 
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
@@ -1,0 +1,58 @@
+---
+source: src/tests/store_parsing.rs
+expression: acquire_errors
+---
+
+  × Your cargo-vet store (supply-chain) has consistency errors
+
+Error: 
+  × A file in the store is not correctly formatted:
+  │ 
+  │ --- old/config.toml
+  │ +++ new/config.toml
+  │ @@ -8,14 +8,14 @@
+  │  [imports.peer2]
+  │  url = "https://peer1.com"
+  │ 
+  │ -[[exemptions.zzz]]
+  │ +[[exemptions.aaa]]
+  │  version = "1.0.0"
+  │  criteria = "safe-to-deploy"
+  │ 
+  │  [[exemptions.bbb]]
+  │ +version = "1.0.0"
+  │  criteria = "safe-to-deploy"
+  │ -version = "1.0.0"
+  │ 
+  │ -[[exemptions.aaa]]
+  │ +[[exemptions.zzz]]
+  │  version = "1.0.0"
+  │  criteria = "safe-to-deploy"
+  │ 
+  help: run `cargo vet` without --locked to reformat files in the store
+Error: 
+  × A file in the store is not correctly formatted:
+  │ 
+  │ --- old/audits.toml
+  │ +++ new/audits.toml
+  │ @@ -4,14 +4,12 @@
+  │  [criteria.good]
+  │  description = "great"
+  │  implies = "safe-to-deploy"
+  │ -unrecognized-field = "hey there!"
+  │ 
+  │  [[audits.serde]]
+  │  criteria = ["safe-to-deploy", "good"]
+  │ -version = "2.0.0"
+  │ -note = "invalid field"
+  │ +version = "1.0.0"
+  │ +notes = "valid field"
+  │ 
+  │  [[audits.serde]]
+  │  criteria = ["safe-to-deploy", "good"]
+  │ -version = "1.0.0"
+  │ -notes = "valid field"
+  │ +version = "2.0.0"
+  │ 
+  help: run `cargo vet` without --locked to reformat files in the store
+

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_audits.snap
@@ -7,100 +7,101 @@ expression: acquire_errors
 
 Error: 
   × 'bad-imply' is not a valid criteria name
-   ╭─[audits.toml:3:1]
- 3 │ description = "great"
- 4 │ implies = ["safe-to-deploy", "bad-imply"]
+   ╭─[audits.toml:5:1]
+ 5 │ description = "great"
+ 6 │ implies = ["safe-to-deploy", "bad-imply"]
    ·                              ───────────
- 5 │ 
+ 7 │ 
    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad' is not a valid criteria name
-   ╭─[audits.toml:7:1]
- 7 │ version = "1.0.0"
- 8 │ criteria = "bad"
-   ·            ─────
- 9 │ dependency-criteria = { toml = "bad-dep", serde_derive = ["bad1", "good", "bad2"] }
-   ╰────
+    ╭─[audits.toml:8:1]
+  8 │ [[audits.serde]]
+  9 │ criteria = "bad"
+    ·            ─────
+ 10 │ version = "1.0.0"
+    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad1' is not a valid criteria name
-    ╭─[audits.toml:8:1]
-  8 │ criteria = "bad"
-  9 │ dependency-criteria = { toml = "bad-dep", serde_derive = ["bad1", "good", "bad2"] }
-    ·                                                           ──────
- 10 │ 
+    ╭─[audits.toml:10:1]
+ 10 │ version = "1.0.0"
+ 11 │ dependency-criteria = { serde_derive = ["bad1", "good", "bad2"], toml = "bad-dep" }
+    ·                                         ──────
+ 12 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad2' is not a valid criteria name
-    ╭─[audits.toml:8:1]
-  8 │ criteria = "bad"
-  9 │ dependency-criteria = { toml = "bad-dep", serde_derive = ["bad1", "good", "bad2"] }
-    ·                                                                           ──────
- 10 │ 
+    ╭─[audits.toml:10:1]
+ 10 │ version = "1.0.0"
+ 11 │ dependency-criteria = { serde_derive = ["bad1", "good", "bad2"], toml = "bad-dep" }
+    ·                                                         ──────
+ 12 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad-dep' is not a valid criteria name
-    ╭─[audits.toml:8:1]
-  8 │ criteria = "bad"
-  9 │ dependency-criteria = { toml = "bad-dep", serde_derive = ["bad1", "good", "bad2"] }
-    ·                                ─────────
- 10 │ 
-    ╰────
-  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
-Error: 
-  × 'dang' is not a valid criteria name
-    ╭─[audits.toml:12:1]
- 12 │ delta = "1.0.0 -> 1.1.0"
- 13 │ criteria = ["safe-to-run", "dang"]
-    ·                            ──────
- 14 │ dependency-criteria = {}
-    ╰────
-  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
-Error: 
-  × 'oops' is not a valid criteria name
-    ╭─[audits.toml:17:1]
- 17 │ delta = "1.0.0 -> 1.1.0"
- 18 │ criteria = "oops"
-    ·            ──────
- 19 │ dependency-criteria = { "nope" = "nah" }
-    ╰────
-  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
-Error: 
-  × 'nah' is not a valid criteria name
-    ╭─[audits.toml:18:1]
- 18 │ criteria = "oops"
- 19 │ dependency-criteria = { "nope" = "nah" }
-    ·                                  ─────
- 20 │ 
+    ╭─[audits.toml:10:1]
+ 10 │ version = "1.0.0"
+ 11 │ dependency-criteria = { serde_derive = ["bad1", "good", "bad2"], toml = "bad-dep" }
+    ·                                                                         ─────────
+ 12 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'safe-to-jog' is not a valid criteria name
-    ╭─[audits.toml:22:1]
- 22 │ version = "2.0.0"
- 23 │ criteria = "safe-to-jog"
+    ╭─[audits.toml:13:1]
+ 13 │ [[audits.serde]]
+ 14 │ criteria = "safe-to-jog"
     ·            ─────────────
- 24 │ dependency-criteria = { toml = ["unsafe-to-destroy"] }
+ 15 │ version = "2.0.0"
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'unsafe-to-destroy' is not a valid criteria name
-    ╭─[audits.toml:23:1]
- 23 │ criteria = "safe-to-jog"
- 24 │ dependency-criteria = { toml = ["unsafe-to-destroy"] }
-    ·                                ─────────────────────
- 25 │ 
+    ╭─[audits.toml:15:1]
+ 15 │ version = "2.0.0"
+ 16 │ dependency-criteria = { toml = "unsafe-to-destroy" }
+    ·                                ───────────────────
+ 17 │ 
+    ╰────
+  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
+Error: 
+  × 'dang' is not a valid criteria name
+    ╭─[audits.toml:18:1]
+ 18 │ [[audits.serde]]
+ 19 │ criteria = ["safe-to-run", "dang"]
+    ·                            ──────
+ 20 │ delta = "1.0.0 -> 1.1.0"
+    ╰────
+  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
+Error: 
+  × 'oops' is not a valid criteria name
+    ╭─[audits.toml:22:1]
+ 22 │ [[audits.serde]]
+ 23 │ criteria = "oops"
+    ·            ──────
+ 24 │ delta = "1.0.0 -> 1.1.0"
+    ╰────
+  help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
+Error: 
+  × 'nah' is not a valid criteria name
+    ╭─[audits.toml:24:1]
+ 24 │ delta = "1.0.0 -> 1.1.0"
+ 25 │ dependency-criteria = { nope = "nah" }
+    ·                                ─────
+ 26 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'no-good-bad-bad' is not a valid criteria name
     ╭─[audits.toml:27:1]
- 27 │ violation = "5.0.0 "
+ 27 │ [[audits.serde]]
  28 │ criteria = "no-good-bad-bad"
     ·            ─────────────────
+ 29 │ violation = "^5.0.0"
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_config.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_config.snap
@@ -7,65 +7,65 @@ expression: acquire_errors
 
 Error: 
   × 'oops' is not a valid criteria name
-    ╭─[config.toml:16:1]
- 16 │ version = "1.0.0"
- 17 │ criteria = "oops"
+    ╭─[config.toml:18:1]
+ 18 │ version = "1.0.0"
+ 19 │ criteria = "oops"
     ·            ──────
- 18 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
+ 20 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'nah' is not a valid criteria name
-    ╭─[config.toml:17:1]
- 17 │ criteria = "oops"
- 18 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
+    ╭─[config.toml:19:1]
+ 19 │ criteria = "oops"
+ 20 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
     ·                                       ─────
- 19 │ 
+ 21 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'no' is not a valid criteria name
-    ╭─[config.toml:17:1]
- 17 │ criteria = "oops"
- 18 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
+    ╭─[config.toml:19:1]
+ 19 │ criteria = "oops"
+ 20 │ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
     ·                                                      ────
- 19 │ 
+ 21 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad' is not a valid criteria name
-   ╭─[config.toml:2:1]
- 2 │ [policy.serde]
- 3 │ criteria = "bad"
-   ·            ─────
- 4 │ dev-criteria = "nope"
-   ╰────
+    ╭─[config.toml:12:1]
+ 12 │ [policy.serde]
+ 13 │ criteria = "bad"
+    ·            ─────
+ 14 │ dev-criteria = "nope"
+    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'nope' is not a valid criteria name
-   ╭─[config.toml:3:1]
- 3 │ criteria = "bad"
- 4 │ dev-criteria = "nope"
-   ·                ──────
- 5 │ dependency-criteria = { serde_derive = "nada", clap = ["safe-to-run", "unsafe-for-all", "good"] }
-   ╰────
+    ╭─[config.toml:13:1]
+ 13 │ criteria = "bad"
+ 14 │ dev-criteria = "nope"
+    ·                ──────
+ 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'unsafe-for-all' is not a valid criteria name
-   ╭─[config.toml:4:1]
- 4 │ dev-criteria = "nope"
- 5 │ dependency-criteria = { serde_derive = "nada", clap = ["safe-to-run", "unsafe-for-all", "good"] }
-   ·                                                                       ────────────────
- 6 │ 
-   ╰────
+    ╭─[config.toml:14:1]
+ 14 │ dev-criteria = "nope"
+ 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+    ·                                                ────────────────
+ 16 │ 
+    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'nada' is not a valid criteria name
-   ╭─[config.toml:4:1]
- 4 │ dev-criteria = "nope"
- 5 │ dependency-criteria = { serde_derive = "nada", clap = ["safe-to-run", "unsafe-for-all", "good"] }
-   ·                                        ──────
- 6 │ 
-   ╰────
+    ╭─[config.toml:14:1]
+ 14 │ dev-criteria = "nope"
+ 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+    ·                                                                                          ──────
+ 16 │ 
+    ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__simple_bad_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__simple_bad_audit.snap
@@ -7,10 +7,11 @@ expression: acquire_errors
 
 Error: 
   × 'bad' is not a valid criteria name
-   ╭─[audits.toml:3:1]
- 3 │ version = "1.0.0"
- 4 │ criteria = "bad"
+   ╭─[audits.toml:4:1]
+ 4 │ [[audits.serde]]
+ 5 │ criteria = "bad"
    ·            ─────
+ 6 │ version = "1.0.0"
    ╰────
   help: the possible criteria are ["safe-to-run", "safe-to-deploy"]
 

--- a/src/tests/store_parsing.rs
+++ b/src/tests/store_parsing.rs
@@ -1,9 +1,19 @@
-const EMPTY_CONFIG: &str = "\n";
-const EMPTY_AUDITS: &str = "[audits]\n";
-const EMPTY_IMPORTS: &str = "[audits]\n";
+const EMPTY_CONFIG: &str = r##"
+# cargo-vet config file
+"##;
+const EMPTY_AUDITS: &str = r##"
+# cargo-vet audits file
+
+[audits]
+"##;
+const EMPTY_IMPORTS: &str = r##"
+# cargo-vet imports lock
+
+[audits]
+"##;
 
 fn get_valid_store(config: &str, audits: &str, imports: &str) -> String {
-    let res = crate::Store::mock_acquire(config, audits, imports);
+    let res = crate::Store::mock_acquire(config, audits, imports, true);
     match res {
         Ok(_) => String::new(),
         Err(e) => format!("{:?}", miette::Report::new(e)),
@@ -25,9 +35,11 @@ fn test_all_min() {
 #[test]
 fn test_simple_bad_audit() {
     let audits = r##"
+# cargo-vet audits file
+
 [[audits.serde]]
-version = "1.0.0"
 criteria = "bad"
+version = "1.0.0"
 "##;
 
     let acquire_errors = get_valid_store(EMPTY_CONFIG, audits, EMPTY_IMPORTS);
@@ -37,33 +49,34 @@ criteria = "bad"
 #[test]
 fn test_many_bad_audits() {
     let audits = r##"
+# cargo-vet audits file
+
 [criteria.good]
 description = "great"
 implies = ["safe-to-deploy", "bad-imply"]
 
 [[audits.serde]]
-version = "1.0.0"
 criteria = "bad"
-dependency-criteria = { toml = "bad-dep", serde_derive = ["bad1", "good", "bad2"] }
+version = "1.0.0"
+dependency-criteria = { serde_derive = ["bad1", "good", "bad2"], toml = "bad-dep" }
 
 [[audits.serde]]
-delta = "1.0.0 -> 1.1.0"
-criteria = ["safe-to-run", "dang"]
-dependency-criteria = {}
-
-[[audits.serde]]
-delta = "1.0.0 -> 1.1.0"
-criteria = "oops"
-dependency-criteria = { "nope" = "nah" }
-
-[[audits.serde]]
-version = "2.0.0"
 criteria = "safe-to-jog"
-dependency-criteria = { toml = ["unsafe-to-destroy"] }
+version = "2.0.0"
+dependency-criteria = { toml = "unsafe-to-destroy" }
 
 [[audits.serde]]
-violation = "5.0.0 "
+criteria = ["safe-to-run", "dang"]
+delta = "1.0.0 -> 1.1.0"
+
+[[audits.serde]]
+criteria = "oops"
+delta = "1.0.0 -> 1.1.0"
+dependency-criteria = { nope = "nah" }
+
+[[audits.serde]]
 criteria = "no-good-bad-bad"
+violation = "^5.0.0"
 "##;
 
     let acquire_errors = get_valid_store(EMPTY_CONFIG, audits, EMPTY_IMPORTS);
@@ -73,18 +86,20 @@ criteria = "no-good-bad-bad"
 #[test]
 fn test_many_bad_config() {
     let config = r##"
-[policy.serde]
-criteria = "bad"
-dev-criteria = "nope"
-dependency-criteria = { serde_derive = "nada", clap = ["safe-to-run", "unsafe-for-all", "good"] }
+# cargo-vet config file
+
+[policy.boring]
+audit-as-crates-io = true
 
 [policy.clap]
 criteria = "safe-to-deploy"
 dev-criteria = "safe-to-run"
 dependency-criteria = { clap_derive = "good" }
 
-[policy.boring]
-audit-as-crates-io = true
+[policy.serde]
+criteria = "bad"
+dev-criteria = "nope"
+dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
 
 [[exemptions.clap]]
 version = "1.0.0"
@@ -94,13 +109,14 @@ dependency-criteria = { clap_derive = "nah", oops = ["no", "safe-to-run"] }
 [[exemptions.clap_derive]]
 version = "1.0.0"
 criteria = "safe-to-run"
-
 "##;
 
     let audits = r##"
+# cargo-vet audits file
+
 [criteria.good]
 description = "great"
-implies = ["safe-to-deploy"]
+implies = "safe-to-deploy"
 
 [audits]
 "##;
@@ -112,13 +128,15 @@ implies = ["safe-to-deploy"]
 #[test]
 fn test_outdated_imports_lock_extra_peer() {
     let config = r##"
+# cargo-vet config file
+
 [imports.peer1]
 url = "https://peer1.com"
-criteria-map = []
-
 "##;
 
     let imports = r##"
+# cargo-vet imports lock
+
 [[audits.peer1.audits.third-party1]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
@@ -126,7 +144,6 @@ version = "10.0.0"
 [[audits.peer2.audits.third-party2]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
-
 "##;
 
     let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
@@ -136,21 +153,21 @@ version = "10.0.0"
 #[test]
 fn test_outdated_imports_lock_missing_peer() {
     let config = r##"
+# cargo-vet config file
+
 [imports.peer1]
 url = "https://peer1.com"
-criteria-map = []
 
 [imports.peer2]
 url = "https://peer2.com"
-criteria-map = []
-
 "##;
 
     let imports = r##"
+# cargo-vet imports lock
+
 [[audits.peer1.audits.third-party1]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
-
 "##;
 
     let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
@@ -160,14 +177,16 @@ version = "10.0.0"
 #[test]
 fn test_outdated_imports_lock_excluded_crate() {
     let config = r##"
+# cargo-vet config file
+
 [imports.peer1]
 url = "https://peer1.com"
 exclude = ["third-party1"]
-criteria-map = []
-
 "##;
 
     let imports = r##"
+# cargo-vet imports lock
+
 [[audits.peer1.audits.third-party1]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
@@ -175,8 +194,6 @@ version = "10.0.0"
 [[audits.peer1.audits.third-party2]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
-
-
 "##;
 
     let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
@@ -186,18 +203,19 @@ version = "10.0.0"
 #[test]
 fn test_outdated_imports_lock_ok() {
     let config = r##"
+# cargo-vet config file
+
 [imports.peer1]
 url = "https://peer1.com"
 exclude = ["third-party2"]
-criteria-map = []
 
 [imports.peer2]
 url = "https://peer1.com"
-criteria-map = []
-
 "##;
 
     let imports = r##"
+# cargo-vet imports lock
+
 [[audits.peer1.audits.third-party1]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
@@ -205,9 +223,68 @@ version = "10.0.0"
 [[audits.peer2.audits.third-party2]]
 criteria = "safe-to-deploy"
 version = "10.0.0"
-
 "##;
 
     let acquire_errors = get_valid_store(config, EMPTY_AUDITS, imports);
+    insta::assert_snapshot!(acquire_errors);
+}
+
+#[test]
+fn test_invalid_formatting() {
+    let config = r##"
+# cargo-vet config file
+
+[imports.peer1]
+url = "https://peer1.com"
+exclude = ["zzz", "aaa"]
+
+[imports.peer2]
+url = "https://peer1.com"
+
+[[exemptions.zzz]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bbb]]
+criteria = "safe-to-deploy"
+version = "1.0.0"
+
+[[exemptions.aaa]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+"##;
+
+    let audits = r##"
+# cargo-vet audits file
+
+[criteria.good]
+description = "great"
+implies = "safe-to-deploy"
+unrecognized-field = "hey there!"
+
+[[audits.serde]]
+criteria = ["safe-to-deploy", "good"]
+version = "2.0.0"
+note = "invalid field"
+
+[[audits.serde]]
+criteria = ["safe-to-deploy", "good"]
+version = "1.0.0"
+notes = "valid field"
+"##;
+
+    let imports = r##"
+# cargo-vet imports lock
+
+[[audits.peer1.audits.third-party1]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+
+[[audits.peer2.audits.third-party2]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+"##;
+
+    let acquire_errors = get_valid_store(config, audits, imports);
     insta::assert_snapshot!(acquire_errors);
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -47,3 +47,12 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 
+[[audits.similar]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+notes = """
+Algorithm crate implemented entirely in safe rust. Does no platform-specific
+logic, only implementing diffing and string manipulation algorithms.
+"""
+

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -161,10 +161,6 @@ criteria = "safe-to-deploy"
 version = "0.1.19"
 criteria = "safe-to-deploy"
 
-[[exemptions.hex]]
-version = "0.4.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.http]]
 version = "0.2.8"
 criteria = "safe-to-deploy"
@@ -404,10 +400,6 @@ criteria = "safe-to-deploy"
 [[exemptions.signal-hook-registry]]
 version = "1.4.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.similar]]
-version = "2.1.0"
-criteria = "safe-to-run"
 
 [[exemptions.slab]]
 version = "0.4.6"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -163,6 +163,11 @@ criteria = "safe-to-deploy"
 version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
 
+[[audits.firefox.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+
 [[audits.firefox.audits.hyper]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-run"

--- a/tests/diff-cache.toml
+++ b/tests/diff-cache.toml
@@ -1757,4 +1757,3 @@ raw = """
  27 files changed, 2704 insertions(+)
 """
 count = 2704
-

--- a/tests/test-project/supply-chain/audits.toml
+++ b/tests/test-project/supply-chain/audits.toml
@@ -84,4 +84,3 @@ notes = "test for partial delta criteria"
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.3.7"
 notes = "test for delta to unaudited"
-

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -401,4 +401,3 @@ criteria = "safe-to-deploy"
 [[exemptions.winreg]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
-

--- a/tests/test-project/supply-chain/imports.lock
+++ b/tests/test-project/supply-chain/imports.lock
@@ -2,4 +2,3 @@
 # cargo-vet imports lock
 
 [audits]
-


### PR DESCRIPTION
This will detect issues like audits being out of order and unrecognized fields in CI, and should help avoid simple executions of `cargo vet` causing formatting changes locally.

The implementation isn't particularly efficient for this, in that it immediately attempts to re-serialize the file after parsing it, and then compares the results (ignoring trailing newlines). As this checks formatting, it is a string-based check, and not structural.

The `similar` library, which we already used for our tests, is used to allow including diffs in the output to make any issues more clear. This also required some changes to the way we read/write files from disk to keep information around.

As a side-effect of these changes, we no longer emit an extra unnecessary newline at the end of store files. This won't be detected as an error by the checker, but will be a change when run locally.

Fixes #341