### PR TITLE
CI Fixups

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -247,7 +247,7 @@ pub enum StoreAcquireError {
     Validate(#[from] StoreValidateErrors),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    FetchAuditError(#[from] FetchAuditError),
+    FetchAuditError(#[from] Box<FetchAuditError>),
     #[diagnostic(transparent)]
     #[error(transparent)]
     CriteriaChange(#[from] CriteriaChangeErrors),
@@ -561,7 +561,7 @@ pub enum FetchAuditError {
 pub enum DownloadError {
     #[error("failed to start download of {url}")]
     FailedToStartDownload {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         #[source]
         error: reqwest::Error,
     },
@@ -573,7 +573,7 @@ pub enum DownloadError {
     },
     #[error("failed to read download from {url}")]
     FailedToReadDownload {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         #[source]
         error: reqwest::Error,
     },
@@ -591,7 +591,7 @@ pub enum DownloadError {
     },
     #[error("Download wasn't valid utf8: {url}")]
     InvalidText {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         #[source]
         error: FromUtf8Error,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,7 +490,7 @@ pub fn init_files(
 
     // This is the hard one
     let config = {
-        let mut dependencies = SortedMap::new();
+        let mut dependencies = SortedMap::<PackageName, Vec<ExemptedDependency>>::new();
         let graph = DepGraph::new(metadata, filter_graph, None);
         for package in &graph.nodes {
             if !package.is_third_party {
@@ -512,7 +512,7 @@ pub fn init_files(
             };
             dependencies
                 .entry(package.name.to_string())
-                .or_insert(vec![])
+                .or_default()
                 .push(item);
         }
         ConfigFile {
@@ -944,7 +944,7 @@ fn do_cmd_certify(
         .audits
         .audits
         .entry(package.clone())
-        .or_insert(vec![])
+        .or_default()
         .push(new_entry);
 
     // If we're submitting a full audit, look for a matching exemption entry to remove
@@ -1173,7 +1173,7 @@ fn cmd_record_violation(
         .audits
         .audits
         .entry(sub_args.package.clone())
-        .or_insert(vec![])
+        .or_default()
         .push(new_entry);
 
     store.commit()?;
@@ -1247,7 +1247,7 @@ fn cmd_add_exemption(
         .config
         .exemptions
         .entry(sub_args.package.clone())
-        .or_insert(vec![])
+        .or_default()
         .push(new_entry);
 
     store.commit()?;
@@ -2054,7 +2054,7 @@ fn check_audit_as_crates_io(
         if let Some(index_entry) = cache.query_package_from_index(&package.name) {
             if storage::exact_version(&index_entry, &package.version).is_some() {
                 // We found a version of this package in the registry!
-                if audit_policy == None {
+                if audit_policy.is_none() {
                     // At this point, having no policy is an error
                     needs_audit_as_entry.push(NeedsAuditAsError {
                         package: package.name.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1989,7 +1989,7 @@ async fn eula_for_criteria(
     if let Some(network) = network {
         if let Ok(eula) = network.download(url.clone()).await.and_then(|bytes| {
             String::from_utf8(bytes).map_err(|error| DownloadError::InvalidText {
-                url: url.clone(),
+                url: Box::new(url.clone()),
                 error,
             })
         }) {

--- a/src/network.rs
+++ b/src/network.rs
@@ -76,7 +76,7 @@ impl Network {
                 .await
                 .and_then(|res| res.error_for_status())
                 .map_err(|error| DownloadError::FailedToStartDownload {
-                    url: url.clone(),
+                    url: Box::new(url.clone()),
                     error,
                 })?;
 
@@ -91,7 +91,7 @@ impl Network {
                 res.chunk()
                     .await
                     .map_err(|error| DownloadError::FailedToReadDownload {
-                        url: url.clone(),
+                        url: Box::new(url.clone()),
                         error,
                     })?
             {
@@ -136,7 +136,7 @@ impl Network {
             .await
             .and_then(|res| res.error_for_status())
             .map_err(|error| DownloadError::FailedToStartDownload {
-                url: url.clone(),
+                url: Box::new(url.clone()),
                 error,
             })?;
 
@@ -145,7 +145,7 @@ impl Network {
             res.chunk()
                 .await
                 .map_err(|error| DownloadError::FailedToReadDownload {
-                    url: url.clone(),
+                    url: Box::new(url.clone()),
                     error,
                 })?
         {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -558,9 +558,11 @@ impl Store {
 
         // If we're locked, and therefore not fetching new live imports,
         // validate that our imports.lock is in sync with config.toml.
-        let imports_lock_outdated = self
-            .imports_lock_outdated()
-            .then_some(StoreValidateError::ImportsLockOutdated);
+        let imports_lock_outdated = if self.imports_lock_outdated() {
+            Some(StoreValidateError::ImportsLockOutdated)
+        } else {
+            None
+        };
 
         let errors = invalid_criteria_errors
             .into_iter()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1363,7 +1363,7 @@ impl Cache {
                     let DiffCache::V1 { diffs } = &mut guard.diff_cache;
                     diffs
                         .entry(package.to_string())
-                        .or_insert(SortedMap::new())
+                        .or_default()
                         .insert(delta.clone(), diffstat.clone());
                 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1026,7 +1026,7 @@ fn files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFi
         if package.is_third_party(&config.policy) {
             audited
                 .entry(package.name.clone())
-                .or_insert(vec![])
+                .or_default()
                 .push(full_audit(package.version.clone(), DEFAULT_CRIT));
         }
     }
@@ -1055,7 +1055,7 @@ fn builtin_files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, I
         if package.is_third_party(&config.policy) {
             audited
                 .entry(package.name.clone())
-                .or_insert(vec![])
+                .or_default()
                 .push(full_audit(package.version.clone(), SAFE_TO_DEPLOY));
         }
     }
@@ -1069,13 +1069,10 @@ fn builtin_files_minimal_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile
     let mut audited = SortedMap::<PackageName, Vec<AuditEntry>>::new();
     for (name, entries) in std::mem::take(&mut config.exemptions) {
         for entry in entries {
-            audited
-                .entry(name.clone())
-                .or_insert(vec![])
-                .push(full_audit_m(
-                    entry.version,
-                    entry.criteria.iter().map(|s| &**s).collect::<Vec<_>>(),
-                ));
+            audited.entry(name.clone()).or_default().push(full_audit_m(
+                entry.version,
+                entry.criteria.iter().map(|s| &**s).collect::<Vec<_>>(),
+            ));
         }
     }
     audits.audits = audited;

--- a/src/tests/violations.rs
+++ b/src/tests/violations.rs
@@ -14,7 +14,7 @@ fn mock_simple_violation_cur_exemptions() {
     audits
         .audits
         .entry("third-party1".to_string())
-        .or_insert(vec![])
+        .or_default()
         .push(violation(violation_ver, "weak-reviewed"));
 
     let store = Store::mock(config, audits, imports);


### PR DESCRIPTION
- Box some things to avoid super-large error types.
- Appease clippy.
- Remove then_some usage, which is too new for the m-c tooltool builder.
