### PR TITLE
Add Embark and Bytecode Alliance to the registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1,3 +1,9 @@
+[registry.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[registry.embark-studios]
+url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
+
 [registry.firefox]
 url = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
We haven't implemented the code to fetch the registry from the tool, but it's still a useful place for discoverability.