### PR TITLE
Relax parsing when importing remote audits

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -136,6 +136,15 @@ pub struct AuditsFile {
     pub audits: AuditedDependencies,
 }
 
+/// Foreign audits.toml with unparsed entries and audits. Should have the same
+/// structure as `AuditsFile`, but with individual audits and criteria unparsed.
+#[derive(serde::Deserialize, Clone)]
+pub struct ForeignAuditsFile {
+    #[serde(default)]
+    pub criteria: SortedMap<CriteriaName, toml::Value>,
+    pub audits: SortedMap<PackageName, Vec<toml::Value>>,
+}
+
 /// Information on a Criteria
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct CriteriaEntry {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -386,9 +386,24 @@ where
     Ok(toml_document)
 }
 
+/// Deserialize the given data structure from a toml::Value, without falling
+/// over due to Spanned failing to parse.
+pub fn parse_from_value<T>(value: toml::Value) -> Result<T, toml::de::Error>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    spanned::DISABLE_SPANNED_DESERIALIZATION.with(|disabled| {
+        let prev = disabled.replace(true);
+        let rv = T::deserialize(value);
+        disabled.set(prev);
+        rv
+    })
+}
+
 pub mod spanned {
     use std::{
         borrow::Borrow,
+        cell::Cell,
         cmp::Ordering,
         fmt::{self, Display},
         hash::{Hash, Hasher},
@@ -396,11 +411,16 @@ pub mod spanned {
     };
 
     use miette::SourceSpan;
-    use serde::{ser, Deserialize};
+    use serde::{de, ser};
+
+    thread_local! {
+        /// Hack to work around `toml::Spanned` failing to be deserialized when
+        /// used with the `toml::Value` deserializer.
+        pub(super) static DISABLE_SPANNED_DESERIALIZATION: Cell<bool> = Cell::new(false);
+    }
 
     /// A spanned value, indicating the range at which it is defined in the source.
-    #[derive(Clone, Default, Deserialize)]
-    #[serde(from = "toml::Spanned<T>")]
+    #[derive(Clone, Default)]
     pub struct Spanned<T> {
         start: usize,
         end: usize,
@@ -569,6 +589,19 @@ pub mod spanned {
                 end: value.end(),
                 value: value.into_inner(),
             }
+        }
+    }
+
+    impl<'de, T: de::Deserialize<'de>> de::Deserialize<'de> for Spanned<T> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            Ok(if DISABLE_SPANNED_DESERIALIZATION.with(|d| d.get()) {
+                T::deserialize(deserializer)?.into()
+            } else {
+                toml::Spanned::<T>::deserialize(deserializer)?.into()
+            })
         }
     }
 

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -859,6 +859,148 @@ fn existing_peer_updated_description() {
     insta::assert_snapshot!("existing_peer_updated_description", format!("{:?}", error));
 }
 
+#[test]
+fn foreign_audit_file_to_local() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let foreign_audit_file = crate::format::ForeignAuditsFile {
+        criteria: [
+            (
+                "example".to_string(),
+                toml::toml! {
+                    description = "Example criteria description"
+                },
+            ),
+            (
+                "example2".to_string(),
+                toml::toml! {
+                    implies = "unknown-criteria"
+                    description = "example2"
+                },
+            ),
+            (
+                "example3".to_string(),
+                toml::toml! {
+                    description = "example2"
+                    implies = ["safe-to-deploy", "will-not-parse"]
+                    unknown = "ignored unknown field"
+                },
+            ),
+            (
+                "will-not-parse".to_string(),
+                toml::toml! {
+                    implies = [{ not = "a string" }]
+                    description = "will be ignored"
+                },
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        audits: [
+            (
+                "crate-a".to_string(),
+                vec![
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        version = "10.0.0"
+                        notes = "should parse correctly"
+                    },
+                    toml::toml! {
+                        criteria = "unknown-criteria"
+                        version = "10.0.0"
+                        notes = "will be removed"
+                    },
+                    toml::toml! {
+                        criteria = "example"
+                        version = "invalid"
+                        notes = "will be removed"
+                    },
+                    toml::toml! {
+                        criteria = "will-not-parse"
+                        version = "10.0.0"
+                        notes = "will be removed"
+                    },
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        version = "10.0.0"
+                        dependency-criteria = { foo = "unknown-criteria" }
+                        notes = "will be removed"
+                    },
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        version = "10.0.0"
+                        dependency-criteria = { foo = ["example", "unknown-criteria"] }
+                        notes = "will be removed"
+                    },
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        version = "10.0.0"
+                        dependency-criteria = { foo = "example" }
+                        notes = "should parse correctly"
+                    },
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        violation = "invalid"
+                        notes = "will be removed"
+                    },
+                ],
+            ),
+            (
+                "crate-b".to_string(),
+                vec![toml::toml! {
+                    criteria = "example"
+                    version = "invalid"
+                    notes = "will be removed, along with the entire crate"
+                }],
+            ),
+            (
+                "crate-c".to_string(),
+                vec![
+                    toml::toml! {
+                        criteria = "example2"
+                        version = "10.0.0"
+                        notes = "will not be removed"
+                    },
+                    toml::toml! {
+                        criteria = ["example2", "example3"]
+                        version = "10.0.0"
+                        notes = "will not be removed"
+                    },
+                    toml::toml! {
+                        criteria = "example2"
+                        delta = "1.0.0 -> 10.0.0"
+                        notes = "will not be removed"
+                    },
+                    toml::toml! {
+                        criteria = "safe-to-deploy"
+                        violation = "=5.0.0"
+                        notes = "will not be removed"
+                    },
+                ],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    };
+
+    let mut result = crate::storage::foreign_audit_file_to_local(foreign_audit_file);
+    result.ignored_criteria.sort();
+    result.ignored_audits.sort();
+
+    assert_eq!(result.ignored_criteria, &["will-not-parse"]);
+    assert_eq!(
+        result.ignored_audits,
+        &["crate-a", "crate-a", "crate-a", "crate-a", "crate-a", "crate-a", "crate-b"]
+    );
+
+    insta::assert_snapshot!(
+        "foreign_audit_file_to_local",
+        crate::serialization::to_formatted_toml(&result.audit_file)
+            .unwrap()
+            .to_string()
+    );
+}
+
 // Other tests worth adding:
 //
 // - used edges with dependency-criteria should cause criteria to be imported

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -75,12 +75,10 @@ lazy_static::lazy_static! {
         })).expect("Failed to initialize error handler");
 
         tracing_subscriber::fmt::fmt()
-            .with_max_level(tracing::level_filters::LevelFilter::OFF)
-            // Toggle this on for tracing in tests
-            // .with_max_level(tracing::level_filters::LevelFilter::TRACE)
+            .with_max_level(tracing::level_filters::LevelFilter::TRACE)
             .with_target(false)
             .without_time()
-            .with_writer(std::io::stderr)
+            .with_writer(tracing_subscriber::fmt::writer::TestWriter::new())
             .init();
 
         tokio::runtime::Runtime::new().unwrap()

--- a/src/tests/snapshots/cargo_vet__tests__import__foreign_audit_file_to_local.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__foreign_audit_file_to_local.snap
@@ -1,0 +1,46 @@
+---
+source: src/tests/import.rs
+expression: "crate::serialization::to_formatted_toml(&result.audit_file).unwrap().to_string()"
+---
+
+[criteria.example]
+description = "Example criteria description"
+
+[criteria.example2]
+description = "example2"
+
+[criteria.example3]
+description = "example2"
+implies = "safe-to-deploy"
+
+[[audits.crate-a]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+notes = "should parse correctly"
+
+[[audits.crate-a]]
+criteria = "safe-to-deploy"
+version = "10.0.0"
+dependency-criteria = { foo = "example" }
+notes = "should parse correctly"
+
+[[audits.crate-c]]
+criteria = "example2"
+version = "10.0.0"
+notes = "will not be removed"
+
+[[audits.crate-c]]
+criteria = ["example2", "example3"]
+version = "10.0.0"
+notes = "will not be removed"
+
+[[audits.crate-c]]
+criteria = "example2"
+delta = "1.0.0 -> 10.0.0"
+notes = "will not be removed"
+
+[[audits.crate-c]]
+criteria = "safe-to-deploy"
+violation = "=5.0.0"
+notes = "will not be removed"
+


### PR DESCRIPTION
This will allow the audits files to still partially parse and provide audits when the cargo-vet version used upstream is newer than the local version in more cases. The goal is for this to avoid issues with organizations updating the version of cargo-vet they are using out-of-sync with one another.

This ended up requiring a few hacky things in order to avoid parsing issues around how `toml::Value` de-serialization works compared to normal toml string deserialization, and Spanned locations will be less accurate in remote code (however we don't need to report errors in that situation much, so I doubt it'll be an issue).

The rough approach taken is to perform basic de-serialization at the root level like normal, and deserialize each audit and criteria entry independently, so that a parsing or validation error only impacts that single audit/criteria entry, and the other entries can still be imported.