### PR TITLE
Diff each file separately, combining outputs with a pager

### DIFF
--- a/src/out.rs
+++ b/src/out.rs
@@ -4,7 +4,7 @@
 //! In general, this type should be preferred over directly writing to stdout or
 //! stderr.
 
-use crate::editor::Editor;
+use crate::git_tool::Editor;
 use console::{Style, Term};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use lazy_static::lazy_static;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,11 +11,11 @@ use clap::Parser;
 use serde_json::{json, Value};
 
 use crate::{
-    editor::Editor,
     format::{
         AuditKind, CriteriaName, CriteriaStr, DependencyCriteria, FastMap, MetaConfig, PackageName,
         PackageStr, PolicyEntry, SortedSet, VersionReq, SAFE_TO_DEPLOY, SAFE_TO_RUN,
     },
+    git_tool::Editor,
     init_files,
     out::Out,
     resolver::{ResolveDepth, ResolveReport},


### PR DESCRIPTION
This greatly improves on the filtering capabilities which I built in https://github.com/mozilla/cargo-vet/pull/371, making them much more reliable. Without this change, a poor interaction between between orderfiles and --skip-to for diffs with --no-index in git diff would cause some files to occasionally not be ignored when they were supposed to be (such as Cargo.lock files) which could lead to issues when used with some git revisions.

The new approach means that we always generate diffs for only the files we intend to, in a more reliable manner. Like the GIT_EDITOR setup, this required some work to integrate with the git-provided pager, however most of the work could be re-used from GIT_EDITOR.

This will also make the `cargo vet diff` command interact better with the --out-file command line option, as previously the output would always be written to stdout.