### PR TITLE
Validate git hashes more aggressively.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,6 +84,8 @@ pub enum VersionParseError {
     Semver(#[from] semver::Error),
     #[error("unrecognized revision type, expected 'git:' prefix")]
     UnknownRevision,
+    #[error("unrecognized git hash, expected 40 hex digits")]
+    InvalidGitHash,
 }
 
 ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Require git hashes are 40 characters (SHA1) and hex digits.

Closes #385.