### PR TITLE
Add support (and requirements) for crate policies to have associated versions

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@ use cargo_metadata::semver;
 use miette::{Diagnostic, MietteSpanContents, SourceCode, SourceOffset, SourceSpan};
 use thiserror::Error;
 
-use crate::format::{CriteriaName, ForeignCriteriaName, ImportName, PackageName, PackageVersion};
+use crate::format::{CriteriaName, ForeignCriteriaName, ImportName, PackageName, VetVersion};
 use crate::network::PayloadEncoding;
 
 #[derive(Eq, PartialEq)]
@@ -167,7 +167,7 @@ impl Display for UnusedAuditAsErrors {
 #[error("{package}{}", .version.as_ref().map(|v| format!(":{v}")).unwrap_or_default())]
 pub struct PackageError {
     pub package: PackageName,
-    pub version: Option<PackageVersion>,
+    pub version: Option<VetVersion>,
 }
 
 ///////////////////////////////////////////////////////////
@@ -200,9 +200,7 @@ pub struct NeedsPolicyVersionErrors {
 
 impl Display for NeedsPolicyVersionErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(
-            "some third-party crates have policies that are missing an associated version",
-        )?;
+        f.write_str("some crates have policies that are missing an associated version")?;
         for e in &self.errors {
             f.write_fmt(format_args!("\n  {e}"))?
         }
@@ -218,7 +216,7 @@ pub struct UnusedPolicyVersionErrors {
 
 impl Display for UnusedPolicyVersionErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("some third-party crate policies don't correspond to crates being used")?;
+        f.write_str("some versioned policy entries don't correspond to crates being used")?;
         for e in &self.errors {
             f.write_fmt(format_args!("\n  {e}"))?
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -118,7 +118,7 @@ pub enum AuditAsError {
 #[derive(Debug, Error, Diagnostic)]
 #[diagnostic(help("Add a `policy.*.audit-as-crates-io` entry for them"))]
 pub struct NeedsAuditAsErrors {
-    pub errors: Vec<AuditAsPackageError>,
+    pub errors: Vec<PackageError>,
 }
 
 impl Display for NeedsAuditAsErrors {
@@ -134,7 +134,7 @@ impl Display for NeedsAuditAsErrors {
 #[derive(Debug, Error, Diagnostic)]
 #[diagnostic(help("Remove the audit-as-crates-io entries or make them `false`"))]
 pub struct ShouldntBeAuditAsErrors {
-    pub errors: Vec<AuditAsPackageError>,
+    pub errors: Vec<PackageError>,
 }
 
 impl Display for ShouldntBeAuditAsErrors {
@@ -150,7 +150,7 @@ impl Display for ShouldntBeAuditAsErrors {
 #[derive(Debug, Error, Diagnostic)]
 #[diagnostic(help("Remove the audit-as-crates-io entries"))]
 pub struct UnusedAuditAsErrors {
-    pub errors: Vec<UnusedAuditAsError>,
+    pub errors: Vec<PackageError>,
 }
 
 impl Display for UnusedAuditAsErrors {
@@ -163,16 +163,9 @@ impl Display for UnusedAuditAsErrors {
     }
 }
 
-#[derive(Debug, Error)]
-#[error("{package}:{version}")]
-pub struct AuditAsPackageError {
-    pub package: PackageName,
-    pub version: PackageVersion,
-}
-
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 #[error("{package}{}", .version.as_ref().map(|v| format!(":{v}")).unwrap_or_default())]
-pub struct UnusedAuditAsError {
+pub struct PackageError {
     pub package: PackageName,
     pub version: Option<PackageVersion>,
 }
@@ -180,7 +173,7 @@ pub struct UnusedAuditAsError {
 ///////////////////////////////////////////////////////////
 // CratePolicyErrors
 ///////////////////////////////////////////////////////////
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error, Diagnostic, PartialEq, Eq)]
 #[error("There are some issues with your third-party policy entries")]
 #[diagnostic()]
 pub struct CratePolicyErrors {
@@ -188,7 +181,7 @@ pub struct CratePolicyErrors {
     pub errors: Vec<CratePolicyError>,
 }
 
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error, Diagnostic, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CratePolicyError {
     #[error(transparent)]
@@ -199,10 +192,10 @@ pub enum CratePolicyError {
     UnusedVersion(UnusedPolicyVersionErrors),
 }
 
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error, Diagnostic, PartialEq, Eq)]
 #[diagnostic(help("Add a `policy.\"<crate>:<version>\"` entry for them"))]
 pub struct NeedsPolicyVersionErrors {
-    pub errors: Vec<NeedsPolicyVersionError>,
+    pub errors: Vec<PackageError>,
 }
 
 impl Display for NeedsPolicyVersionErrors {
@@ -217,17 +210,10 @@ impl Display for NeedsPolicyVersionErrors {
     }
 }
 
-#[derive(Debug, Error)]
-#[error("{package}:{version}")]
-pub struct NeedsPolicyVersionError {
-    pub package: PackageName,
-    pub version: PackageVersion,
-}
-
-#[derive(Debug, Error, Diagnostic)]
-#[diagnostic(help("Remove the `policy.\"<crate>:<version>\"` entries"))]
+#[derive(Debug, Error, Diagnostic, PartialEq, Eq)]
+#[diagnostic(help("Remove the `policy` entries"))]
 pub struct UnusedPolicyVersionErrors {
-    pub errors: Vec<UnusedPolicyVersionError>,
+    pub errors: Vec<PackageError>,
 }
 
 impl Display for UnusedPolicyVersionErrors {
@@ -238,13 +224,6 @@ impl Display for UnusedPolicyVersionErrors {
         }
         Ok(())
     }
-}
-
-#[derive(Debug, Error)]
-#[error("{package}:{version}")]
-pub struct UnusedPolicyVersionError {
-    pub package: PackageName,
-    pub version: PackageVersion,
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -200,7 +200,7 @@ pub enum CratePolicyError {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[diagnostic(help("Add a `policy.<crate>.version` entry for them"))]
+#[diagnostic(help("Add a `policy.\"<crate>:<version>\"` entry for them"))]
 pub struct NeedsPolicyVersionErrors {
     pub errors: Vec<NeedsPolicyVersionError>,
 }
@@ -225,7 +225,7 @@ pub struct NeedsPolicyVersionError {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[diagnostic(help("Remove the `policy.<crate>.version` entries"))]
+#[diagnostic(help("Remove the `policy.\"<crate>:<version>\"` entries"))]
 pub struct UnusedPolicyVersionErrors {
     pub errors: Vec<UnusedPolicyVersionError>,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -204,7 +204,7 @@ impl Display for NeedsPolicyVersionErrors {
             "some third-party crates have policies that are missing an associated version",
         )?;
         for e in &self.errors {
-            f.write_fmt(format_args!("\n  {}", e))?
+            f.write_fmt(format_args!("\n  {e}"))?
         }
         Ok(())
     }
@@ -220,7 +220,7 @@ impl Display for UnusedPolicyVersionErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("some third-party crate policies don't correspond to crates being used")?;
         for e in &self.errors {
-            f.write_fmt(format_args!("\n  {}", e))?
+            f.write_fmt(format_args!("\n  {e}"))?
         }
         Ok(())
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -535,7 +535,12 @@ impl<'a> IntoIterator for &'a Policy {
 /// _all_ and _only_ the versions present in the dependency tree must be provided to set policies.
 /// Otherwise, versions may be omitted.
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
-#[serde(untagged)]
+// We have to use a flattened struct rather than `serde(untagged)`, because toml only parses
+// `Spanned` elements (as contained in `PolicyEntry`) through `deserialize_any`, and
+// `serde(untagged)` deserializes everything into a buffer first to try different deserialization
+// branches (which will separate the `toml` Deserializer from being able to handle `Spanned`).
+#[serde(from = "serialization::policy::PackagePolicyEntryAll")]
+#[serde(into = "serialization::policy::PackagePolicyEntryAll")]
 pub enum PackagePolicyEntry {
     Versioned {
         version: SortedMap<PackageVersion, PolicyEntry>,

--- a/src/format.rs
+++ b/src/format.rs
@@ -481,7 +481,7 @@ impl Policy {
     /// Return an iterator over defined policies.
     pub fn iter(&self) -> PolicyIter {
         PolicyIter {
-            iter: (&self.package).into_iter(),
+            iter: self.package.iter(),
             versioned: None,
         }
     }
@@ -511,7 +511,7 @@ impl<'a> Iterator for PolicyIter<'a> {
                 let (name, ppe) = self.iter.next()?;
                 match ppe {
                     PackagePolicyEntry::Versioned { version } => {
-                        self.versioned = Some((name, version.into_iter()));
+                        self.versioned = Some((name, version.iter()));
                         self.next()
                     }
                     PackagePolicyEntry::Unversioned(p) => Some((name, None, p)),

--- a/src/format.rs
+++ b/src/format.rs
@@ -22,7 +22,6 @@ pub type CriteriaName = String;
 pub type CriteriaStr<'a> = &'a str;
 pub type ForeignCriteriaName = String;
 pub type PackageName = String;
-pub type PackageVersion = VetVersion;
 pub type PackageStr<'a> = &'a str;
 pub type ImportName = String;
 
@@ -405,7 +404,7 @@ pub struct Policy {
 
 impl Policy {
     /// Get the policy entry for the given crate, if any.
-    pub fn get(&self, name: PackageStr, version: &PackageVersion) -> Option<&PolicyEntry> {
+    pub fn get(&self, name: PackageStr, version: &VetVersion) -> Option<&PolicyEntry> {
         self.package
             .get(name)
             .and_then(|pkg_policy| match pkg_policy {
@@ -418,7 +417,7 @@ impl Policy {
     pub fn get_mut(
         &mut self,
         name: PackageStr,
-        version: Option<&PackageVersion>,
+        version: Option<&VetVersion>,
     ) -> Option<&mut PolicyEntry> {
         self.package
             .get_mut(name)
@@ -438,10 +437,10 @@ impl Policy {
     ///
     /// `all_versions` is required to maintain proper structure of the policy map if the entry is
     /// missing: if one policy version is provided, they all must be.
-    pub fn get_mut_or_default<F: FnOnce() -> Vec<PackageVersion>>(
+    pub fn get_mut_or_default<F: FnOnce() -> Vec<VetVersion>>(
         &mut self,
         name: PackageName,
-        version: Option<&PackageVersion>,
+        version: Option<&VetVersion>,
         all_versions: F,
     ) -> Option<&mut PolicyEntry> {
         let pkg_policy = self.package.entry(name).or_insert_with(|| {
@@ -491,12 +490,12 @@ pub struct PolicyIter<'a> {
     iter: <&'a SortedMap<PackageName, PackagePolicyEntry> as IntoIterator>::IntoIter,
     versioned: Option<(
         &'a PackageName,
-        <&'a SortedMap<PackageVersion, PolicyEntry> as IntoIterator>::IntoIter,
+        <&'a SortedMap<VetVersion, PolicyEntry> as IntoIterator>::IntoIter,
     )>,
 }
 
 impl<'a> Iterator for PolicyIter<'a> {
-    type Item = (&'a PackageName, Option<&'a PackageVersion>, &'a PolicyEntry);
+    type Item = (&'a PackageName, Option<&'a VetVersion>, &'a PolicyEntry);
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.versioned {
@@ -542,7 +541,7 @@ impl<'a> IntoIterator for &'a Policy {
 // branches (which will use an internal `serde` Deserializer rather than the `toml` Deserializer).
 pub enum PackagePolicyEntry {
     Versioned {
-        version: SortedMap<PackageVersion, PolicyEntry>,
+        version: SortedMap<VetVersion, PolicyEntry>,
     },
     Unversioned(PolicyEntry),
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -22,6 +22,7 @@ pub type CriteriaName = String;
 pub type CriteriaStr<'a> = &'a str;
 pub type ForeignCriteriaName = String;
 pub type PackageName = String;
+pub type PackageVersion = VetVersion;
 pub type PackageStr<'a> = &'a str;
 pub type ImportName = String;
 
@@ -355,7 +356,7 @@ impl Serialize for Delta {
 ////////////////////////////////////////////////////////////////////////////////////
 
 /// config.toml
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct ConfigFile {
     /// This top-level key specifies the default criteria that cargo vet certify will use
     /// when recording audits. If unspecified, this defaults to "safe-to-deploy".
@@ -369,10 +370,10 @@ pub struct ConfigFile {
     #[serde(default)]
     pub imports: SortedMap<ImportName, RemoteImport>,
 
-    /// A table of policies for first-party crates.
-    #[serde(skip_serializing_if = "SortedMap::is_empty")]
+    /// A table of policies for crates.
+    #[serde(skip_serializing_if = "Policy::is_empty")]
     #[serde(default)]
-    pub policy: SortedMap<PackageName, PolicyEntry>,
+    pub policy: Policy,
 
     /// All of the "foreign" dependencies that we rely on but haven't audited yet.
     /// Foreign dependencies are just "things on crates.io", everything else
@@ -394,21 +395,168 @@ fn is_default_criteria(val: &CriteriaName) -> bool {
     val == DEFAULT_CRITERIA
 }
 
-/// Policies that first-party (non-foreign) crates must pass.
+/// The table of crate policies.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
+#[serde(transparent)]
+pub struct Policy {
+    pub package: SortedMap<PackageName, PackagePolicyEntry>,
+}
+
+impl Policy {
+    /// Get the policy entry for the given crate, if any.
+    pub fn get(&self, name: PackageStr, version: &PackageVersion) -> Option<&PolicyEntry> {
+        self.package
+            .get(name)
+            .and_then(|pkg_policy| match pkg_policy {
+                PackagePolicyEntry::Unversioned(e) => Some(e),
+                PackagePolicyEntry::Versioned { version: v } => v.get(version),
+            })
+    }
+
+    /// Get the mutable policy entry for the given crate, if any.
+    pub fn get_mut(
+        &mut self,
+        name: PackageStr,
+        version: Option<&PackageVersion>,
+    ) -> Option<&mut PolicyEntry> {
+        self.package
+            .get_mut(name)
+            .and_then(|pkg_policy| match pkg_policy {
+                PackagePolicyEntry::Unversioned(e) => Some(e),
+                PackagePolicyEntry::Versioned { version: v } => {
+                    version.and_then(|version| v.get_mut(version))
+                }
+            })
+    }
+
+    /// Get the mutable policy entry for the given crate, creating a default if none exists.
+    ///
+    /// Unlike `get_mut`, this guarantees that the policy is represented as versioned or
+    /// unversioned based on the whether the `version` is provided. If the `version` passed is
+    /// incompatible with the current policy, None is returned.
+    ///
+    /// `all_versions` is required to maintain proper structure of the policy map if the entry is
+    /// missing: if one policy version is provided, they all must be.
+    pub fn get_mut_or_default<F: FnOnce() -> Vec<PackageVersion>>(
+        &mut self,
+        name: PackageName,
+        version: Option<&PackageVersion>,
+        all_versions: F,
+    ) -> Option<&mut PolicyEntry> {
+        let pkg_policy = self.package.entry(name).or_insert_with(|| {
+            if version.is_none() {
+                PackagePolicyEntry::Unversioned(Default::default())
+            } else {
+                PackagePolicyEntry::Versioned {
+                    version: all_versions()
+                        .into_iter()
+                        .map(|v| (v, Default::default()))
+                        .collect(),
+                }
+            }
+        });
+
+        match (pkg_policy, version) {
+            (PackagePolicyEntry::Unversioned(e), None) => Some(e),
+            (PackagePolicyEntry::Versioned { version }, Some(v)) => version.get_mut(v),
+            _ => None,
+        }
+    }
+
+    /// Insert a new package policy entry.
+    pub fn insert(
+        &mut self,
+        name: PackageName,
+        entry: PackagePolicyEntry,
+    ) -> Option<PackagePolicyEntry> {
+        self.package.insert(name, entry)
+    }
+
+    /// Return whether there are no policies defined.
+    pub fn is_empty(&self) -> bool {
+        self.package.is_empty()
+    }
+
+    /// Return an iterator over defined policies.
+    pub fn iter(&self) -> PolicyIter {
+        PolicyIter {
+            iter: (&self.package).into_iter(),
+            versioned: None,
+        }
+    }
+}
+
+pub struct PolicyIter<'a> {
+    iter: <&'a SortedMap<PackageName, PackagePolicyEntry> as IntoIterator>::IntoIter,
+    versioned: Option<(
+        &'a PackageName,
+        <&'a SortedMap<PackageVersion, PolicyEntry> as IntoIterator>::IntoIter,
+    )>,
+}
+
+impl<'a> Iterator for PolicyIter<'a> {
+    type Item = (&'a PackageName, Option<&'a PackageVersion>, &'a PolicyEntry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.versioned {
+            Some((name, versioned)) => match versioned.next() {
+                Some((v, p)) => Some((name, Some(v), p)),
+                None => {
+                    self.versioned = None;
+                    self.next()
+                }
+            },
+            None => {
+                let (name, ppe) = self.iter.next()?;
+                match ppe {
+                    PackagePolicyEntry::Versioned { version } => {
+                        self.versioned = Some((name, version.into_iter()));
+                        self.next()
+                    }
+                    PackagePolicyEntry::Unversioned(p) => Some((name, None, p)),
+                }
+            }
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Policy {
+    type IntoIter = PolicyIter<'a>;
+    type Item = <PolicyIter<'a> as Iterator>::Item;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Policies for a particular package (crate).
 ///
-/// This is basically the first-party equivalent of audits.toml, which is separated out
-/// because it's not supposed to be shared (or, doesn't really make sense to share,
-/// since first-party crates are defined by "not on crates.io").
+/// If the crate exists as a third-party crate anywhere in the dependency tree, crate versions for
+/// _all_ and _only_ the versions present in the dependency tree must be provided to set policies.
+/// Otherwise, versions may be omitted.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(untagged)]
+pub enum PackagePolicyEntry {
+    Versioned {
+        version: SortedMap<PackageVersion, PolicyEntry>,
+    },
+    Unversioned(PolicyEntry),
+}
+
+/// Policies that crates must pass.
 ///
-/// Because first-party crates are implicitly trusted, really the only purpose of this
-/// table is to define the boundary between a first-party crates and third-party ones.
-/// More specifically, the criteria of the dependency edges between a first-party crate
-/// and its direct third-party dependencies.
+/// Policy settings here are basically the equivalent of audits.toml, which is separated out
+/// because it's not supposed to be shared (or, doesn't really make sense to share, since
+/// first-party crates are defined by "not on crates.io").
+///
+/// Because first-party crates are implicitly trusted, the only purpose of this table is to define
+/// the boundary between first-party and third-party ones.  More specifically, the criteria of the
+/// dependency edges between a first-party crate and its direct third-party dependencies.
 ///
 /// If this sounds overwhelming, don't worry, everything defaults to "nothing special"
 /// and an empty PolicyTable basically just means "everything should satisfy the
 /// default criteria in audits.toml".
-#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct PolicyEntry {
     /// Whether this nominally-first-party crate should actually be subject to audits
     /// as-if it was third-party, based on matches to crates.io packages with the same
@@ -433,23 +581,21 @@ pub struct PolicyEntry {
     #[serde(rename = "audit-as-crates-io")]
     pub audit_as_crates_io: Option<bool>,
 
-    /// Default criteria that must be satisfied by all *direct* third-party (foreign)
-    /// dependencies of first-party crates. If satisfied, the first-party crate is
-    /// set to satisfying all criteria.
+    /// Default criteria that must be satisfied by all *direct* third-party (foreign) dependencies
+    /// of the crate. If satisfied, the crate is set to satisfying all criteria.
     ///
     /// If not present, this defaults to the default criteria in the audits table.
     #[serde(default)]
     #[serde(with = "serialization::string_or_vec_or_none")]
     pub criteria: Option<Vec<Spanned<CriteriaName>>>,
 
-    /// Same as `criteria`, but for first-party(?) crates/dependencies that are only
-    /// used as dev-dependencies.
+    /// Same as `criteria`, but for crates that are only used as dev-dependencies.
     #[serde(rename = "dev-criteria")]
     #[serde(default)]
     #[serde(with = "serialization::string_or_vec_or_none")]
     pub dev_criteria: Option<Vec<Spanned<CriteriaName>>>,
 
-    /// Custom criteria for a specific first-party crate's dependencies.
+    /// Custom criteria for a specific crate's dependencies.
     ///
     /// Any dependency edge that isn't explicitly specified defaults to `criteria`.
     #[serde(rename = "dependency-criteria")]
@@ -476,7 +622,7 @@ pub static DEFAULT_POLICY_CRITERIA: CriteriaStr = SAFE_TO_DEPLOY;
 pub static DEFAULT_POLICY_DEV_CRITERIA: CriteriaStr = SAFE_TO_RUN;
 
 /// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
-#[derive(serde::Serialize, serde::Deserialize, Clone, Default)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct RemoteImport {
     /// URL of the foreign audits.toml
     pub url: String,
@@ -492,7 +638,7 @@ pub struct RemoteImport {
 }
 
 /// Translations of foreign criteria to local criteria.
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct CriteriaMapping {
     /// This local criteria is implied...
     pub ours: CriteriaName,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2108,7 +2108,7 @@ fn check_audit_as_crates_io(
         // Remove both versioned and unversioned entries
         let vet_version = package.vet_version();
         unused_audit_as.remove(&(&package.name, Some(&vet_version)));
-        //unused_audit_as.remove(&(&package.name, None));
+        unused_audit_as.remove(&(&package.name, None));
 
         let audit_policy = package
             .policy_entry(&store.config.policy)
@@ -2219,12 +2219,12 @@ fn check_crate_policies(cfg: &Config, store: &Store) -> Result<(), CratePolicyEr
 
     let mut needs_policy_version_errors = Vec::new();
 
-    for package in cfg.metadata.packages.iter().filter(|p| p.is_third_party()) {
+    for package in &cfg.metadata.packages {
         let vet_version = package.vet_version();
         let versioned_policy_exists =
             versioned_policy_crates.remove(&(&package.name, &vet_version));
         let crate_policy_exists = store.config.policy.package.contains_key(&package.name);
-        if !versioned_policy_exists && crate_policy_exists {
+        if package.is_third_party() && !versioned_policy_exists && crate_policy_exists {
             // If a crate policy exists, a versioned policy for all used versions must exist.
             needs_policy_version_errors.push(NeedsPolicyVersionError {
                 package: package.name.clone(),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -713,7 +713,7 @@ impl<'a> DepGraph<'a> {
                 package_id: &resolve_node.id,
                 name: &package.name,
                 version: package.vet_version(),
-                is_third_party: package.is_considered_third_party(policy),
+                is_third_party: package.is_third_party(policy),
                 // These will get (re)computed later
                 normal_deps: vec![],
                 build_deps: vec![],

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -181,6 +181,49 @@ pub mod dependency_criteria {
     }
 }
 
+pub mod policy {
+    use super::*;
+    use crate::format::{PackagePolicyEntry, PackageVersion, PolicyEntry};
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct PackagePolicyEntryAll {
+        #[serde(default)]
+        version: SortedMap<PackageVersion, PolicyEntry>,
+        #[serde(flatten)]
+        unversioned: PolicyEntry,
+    }
+
+    impl From<PackagePolicyEntryAll> for PackagePolicyEntry {
+        fn from(
+            PackagePolicyEntryAll {
+                version,
+                unversioned,
+            }: PackagePolicyEntryAll,
+        ) -> Self {
+            if version.is_empty() {
+                PackagePolicyEntry::Unversioned(unversioned)
+            } else {
+                PackagePolicyEntry::Versioned { version }
+            }
+        }
+    }
+
+    impl From<PackagePolicyEntry> for PackagePolicyEntryAll {
+        fn from(e: PackagePolicyEntry) -> Self {
+            match e {
+                PackagePolicyEntry::Versioned { version } => PackagePolicyEntryAll {
+                    version,
+                    unversioned: Default::default(),
+                },
+                PackagePolicyEntry::Unversioned(unversioned) => PackagePolicyEntryAll {
+                    unversioned,
+                    version: Default::default(),
+                },
+            }
+        }
+    }
+}
+
 pub mod audit {
     use super::*;
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -625,26 +625,26 @@ mod test {
             vec!["criteria-one".to_owned().into()],
         );
 
-        let mut policy = SortedMap::new();
+        let mut policy = Policy::default();
         policy.insert(
             "long-criteria".to_owned(),
-            PolicyEntry {
+            PackagePolicyEntry::Unversioned(PolicyEntry {
                 audit_as_crates_io: None,
                 criteria: Some(vec!["long-criteria".to_owned().into()]),
                 dev_criteria: None,
                 dependency_criteria: dc_long,
                 notes: Some("notes go here!".to_owned()),
-            },
+            }),
         );
         policy.insert(
             "short-criteria".to_owned(),
-            PolicyEntry {
+            PackagePolicyEntry::Unversioned(PolicyEntry {
                 audit_as_crates_io: None,
                 criteria: Some(vec!["short-criteria".to_owned().into()]),
                 dev_criteria: None,
                 dependency_criteria: dc_short,
                 notes: Some("notes go here!".to_owned()),
-            },
+            }),
         );
 
         let formatted = super::to_formatted_toml(ConfigFile {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -188,7 +188,7 @@ pub mod policy {
     };
     use serde::de::value::Error as SerdeError;
 
-    const VERSION_SEPARATOR: &'static str = ":";
+    const VERSION_SEPARATOR: &str = ":";
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(transparent)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -161,7 +161,7 @@ impl Store {
             config: ConfigFile {
                 default_criteria: String::new(),
                 imports: SortedMap::new(),
-                policy: SortedMap::new(),
+                policy: Default::default(),
                 exemptions: SortedMap::new(),
             },
             imports: ImportsFile {
@@ -449,7 +449,7 @@ impl Store {
                 );
             }
         }
-        for (_package, policy) in &self.config.policy {
+        for (_name, _version, policy) in &self.config.policy {
             check_criteria(
                 &self.config_src,
                 &valid_criteria,

--- a/src/tests/crate_policies.rs
+++ b/src/tests/crate_policies.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+use crate::errors::{
+    CratePolicyError, CratePolicyErrors, NeedsPolicyVersionErrors, PackageError,
+    UnusedPolicyVersionErrors,
+};
+
+/// Checks that if a third-party crate is present, and an unversioned policy is used, an error
+/// occurs indicating that versions need to be specified.
+#[test]
+fn simple_crate_policies_third_party_crates_imply_versions() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let mock = MockMetadata::overlapping();
+    let metadata = mock.metadata();
+    let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
+    config.policy.insert(
+        "third-party".into(),
+        PackagePolicyEntry::Unversioned(Default::default()),
+    );
+    let store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+
+    let result = crate::check_crate_policies(&cfg, &store);
+    assert_eq!(
+        result,
+        Err(CratePolicyErrors {
+            errors: vec![CratePolicyError::NeedsVersion(NeedsPolicyVersionErrors {
+                errors: vec![
+                    PackageError {
+                        package: "third-party".into(),
+                        version: Some(ver(1))
+                    },
+                    PackageError {
+                        package: "third-party".into(),
+                        version: Some(ver(2))
+                    }
+                ]
+            })]
+        })
+    );
+}
+
+/// Checks that if a third-party crate is present and a versioned policy is used for one version,
+/// an error occurs indicating that versions are needed for other versions (regardless of whether
+/// they are considered first- or third-party).
+#[test]
+fn simple_crate_policies_third_party_crates_need_all_versions() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let mock = MockMetadata::overlapping();
+    let metadata = mock.metadata();
+
+    for (a, b) in [(1, 2), (2, 1)] {
+        let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
+        config.policy.insert(
+            "third-party".into(),
+            PackagePolicyEntry::Versioned {
+                version: [(ver(a), Default::default())].into(),
+            },
+        );
+        let store = Store::mock(config, audits, imports);
+        let cfg = mock_cfg(&metadata);
+
+        let result = crate::check_crate_policies(&cfg, &store);
+        assert_eq!(
+            result,
+            Err(CratePolicyErrors {
+                errors: vec![CratePolicyError::NeedsVersion(NeedsPolicyVersionErrors {
+                    errors: vec![PackageError {
+                        package: "third-party".into(),
+                        version: Some(ver(b))
+                    }]
+                })]
+            })
+        );
+    }
+}
+
+/// If crate policies are provided for versions which aren't present in the graph, an error should
+/// occur.
+#[test]
+fn simple_crate_policies_extraneous_crate_versions() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let mock = MockMetadata::overlapping();
+    let metadata = mock.metadata();
+    let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
+    config.policy.insert(
+        "third-party".into(),
+        PackagePolicyEntry::Versioned {
+            version: [
+                (ver(1), Default::default()),
+                (ver(2), Default::default()),
+                (ver(3), Default::default()),
+            ]
+            .into(),
+        },
+    );
+    let store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+
+    let result = crate::check_crate_policies(&cfg, &store);
+    assert_eq!(
+        result,
+        Err(CratePolicyErrors {
+            errors: vec![CratePolicyError::UnusedVersion(UnusedPolicyVersionErrors {
+                errors: vec![PackageError {
+                    package: "third-party".into(),
+                    version: Some(ver(3))
+                },]
+            })]
+        })
+    );
+}
+
+/// If crate policies are provided for crates which aren't present in the graph, an error should
+/// occur.
+#[test]
+fn simple_crate_policies_extraneous_crates() {
+    let _enter = TEST_RUNTIME.enter();
+
+    let mock = MockMetadata::overlapping();
+    let metadata = mock.metadata();
+    let (mut config, audits, imports) = builtin_files_full_audited(&metadata);
+    config.policy.insert(
+        "non-existent".into(),
+        PackagePolicyEntry::Unversioned(Default::default()),
+    );
+    let store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+
+    let result = crate::check_crate_policies(&cfg, &store);
+    assert_eq!(
+        result,
+        Err(CratePolicyErrors {
+            errors: vec![CratePolicyError::UnusedVersion(UnusedPolicyVersionErrors {
+                errors: vec![PackageError {
+                    package: "non-existent".into(),
+                    version: None
+                }]
+            })]
+        })
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -965,7 +965,7 @@ fn files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFi
 
     let mut audited = SortedMap::<PackageName, Vec<AuditEntry>>::new();
     for package in &metadata.packages {
-        if package.is_considered_third_party(&config.policy) {
+        if package.is_third_party(&config.policy) {
             audited
                 .entry(package.name.clone())
                 .or_default()
@@ -994,7 +994,7 @@ fn builtin_files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, I
 
     let mut audited = SortedMap::<PackageName, Vec<AuditEntry>>::new();
     for package in &metadata.packages {
-        if package.is_considered_third_party(&config.policy) {
+        if package.is_third_party(&config.policy) {
             audited
                 .entry(package.name.clone())
                 .or_default()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ macro_rules! assert_report_snapshot {
 mod aggregate;
 mod audit_as_crates_io;
 mod certify;
+mod crate_policies;
 mod import;
 mod regenerate_unaudited;
 mod store_parsing;
@@ -574,6 +575,37 @@ impl MockMetadata {
             MockPackage {
                 name: "third-core",
                 version: ver(5),
+                ..Default::default()
+            },
+        ])
+    }
+
+    /// The `third-party` crate is used as both a first- and third-party crate (with different
+    /// versions).
+    fn overlapping() -> Self {
+        MockMetadata::new(vec![
+            MockPackage {
+                name: "root-package",
+                is_workspace: true,
+                is_first_party: true,
+                deps: vec![dep("first-party"), dep_ver("third-party", 1)],
+                ..Default::default()
+            },
+            MockPackage {
+                name: "first-party",
+                is_first_party: true,
+                deps: vec![dep_ver("third-party", 2)],
+                ..Default::default()
+            },
+            MockPackage {
+                name: "third-party",
+                is_first_party: true,
+                version: ver(1),
+                ..Default::default()
+            },
+            MockPackage {
+                name: "third-party",
+                version: ver(2),
                 ..Default::default()
             },
         ])

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -467,10 +467,9 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
 
     config.policy.insert(
         "root-package".to_string(),
-        PolicyEntry {
-            criteria: Some(vec![SAFE_TO_RUN.to_string().into()]),
-            ..audit_as_policy(Some(true))
-        },
+        audit_as_policy_with(Some(true), |policy| {
+            policy.criteria = Some(vec![SAFE_TO_RUN.to_string().into()]);
+        }),
     );
     config.exemptions.insert(
         "root-package".to_string(),

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__extraneous_crate_versions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__extraneous_crate_versions.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/crate_policies.rs
+expression: "format!(\"{:?}\", miette :: Report :: new(e))"
+---
+
+  × There are some issues with your third-party policy entries
+
+Error: 
+  × some versioned policy entries don't correspond to crates being used
+  │   third-party:3.0.0
+  help: Remove the `policy` entries
+

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__extraneous_crates.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__extraneous_crates.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/crate_policies.rs
+expression: "format!(\"{:?}\", miette :: Report :: new(e))"
+---
+
+  × There are some issues with your third-party policy entries
+
+Error: 
+  × some versioned policy entries don't correspond to crates being used
+  │   non-existent
+  help: Remove the `policy` entries
+

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_imply_versions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_imply_versions.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/crate_policies.rs
+expression: "format!(\"{:?}\", miette :: Report :: new(e))"
+---
+
+  × There are some issues with your third-party policy entries
+
+Error: 
+  × some crates have policies that are missing an associated version
+  │   third-party:1.0.0
+  │   third-party:2.0.0
+  help: Add a `policy."<crate>:<version>"` entry for them
+

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_1.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_1.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/crate_policies.rs
+expression: "format!(\"{:?}\", miette :: Report :: new(e))"
+---
+
+  × There are some issues with your third-party policy entries
+
+Error: 
+  × some crates have policies that are missing an associated version
+  │   third-party:2.0.0
+  help: Add a `policy."<crate>:<version>"` entry for them
+

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_2.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_2.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/crate_policies.rs
+expression: "format!(\"{:?}\", miette :: Report :: new(e))"
+---
+
+  × There are some issues with your third-party policy entries
+
+Error: 
+  × some crates have policies that are missing an associated version
+  │   third-party:1.0.0
+  help: Add a `policy."<crate>:<version>"` entry for them
+

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -2392,10 +2392,9 @@ fn builtin_simple_audit_as_weaker_root() {
 
     config.policy.insert(
         "root-package".to_string(),
-        PolicyEntry {
-            criteria: Some(vec![SAFE_TO_RUN.to_string().into()]),
-            ..audit_as_policy(Some(true))
-        },
+        audit_as_policy_with(Some(true), |policy| {
+            policy.criteria = Some(vec![SAFE_TO_RUN.to_string().into()]);
+        }),
     );
     config.exemptions.insert(
         "root-package".to_string(),

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -1,10 +1,12 @@
 
 # cargo-vet config file
 
-[policy.clap]
+[policy."clap:3.1.8"]
 dependency-criteria = { atty = "safe-to-run", bitflags = ["audited", "fuzzed"] }
 
-[policy.proc-macro2]
+[policy."proc-macro2:1.0.37"]
+
+[policy."proc-macro2:1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9"]
 audit-as-crates-io = true
 
 [policy.test-project]


### PR DESCRIPTION
Adds serialization support and runtime checks to guarantee desired properties of crate policies:
* If a package name has at least one version present as a third-party crate, and any policy is provided associated with that package name, all versions (and only those versions) present in the dependency graph must have explicit versioned policies provided.

Closes #379.