### PR TITLE
Import only the minimal number of audits required for vet to pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ name = "cargo-vet"
 version = "0.3.0"
 dependencies = [
  "base64-stream",
+ "bytes",
  "cargo_metadata",
  "clap",
  "clap-cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 
 [dependencies]
 base64-stream = "1.2.7"
+bytes = "1.1.0"
 cargo_metadata = "0.15.2"
 clap = { version = "3.2.6", features = ["derive"] }
 clap-cargo = "0.9.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -661,7 +661,7 @@ fn cmd_certify(
     // potentially update imports, and remove now-unnecessary exemptions.
     // Explicitly disallow new exemptions so that exemptions are only updated
     // once we start passing vet.
-    match resolver::regenerate_exemptions(cfg, &mut store, false, false) {
+    match resolver::regenerate_exemptions(cfg, &mut store, false) {
         Ok(()) | Err(RegenerateExemptionsError::ViolationConflict) => {}
     }
 
@@ -1284,7 +1284,7 @@ fn cmd_regenerate_imports(
 
     // NOTE: Explicitly ignore the `ViolationConflict` error, as we still want
     // to update imports in that case.
-    match resolver::regenerate_exemptions(cfg, &mut store, false, true) {
+    match resolver::regenerate_exemptions(cfg, &mut store, false) {
         Ok(()) | Err(RegenerateExemptionsError::ViolationConflict) => {}
     }
 
@@ -1365,7 +1365,7 @@ fn cmd_regenerate_exemptions(
     let network = Network::acquire(cfg);
     let mut store = Store::acquire(cfg, network.as_ref(), false)?;
 
-    resolver::regenerate_exemptions(cfg, &mut store, true, false)?;
+    resolver::regenerate_exemptions(cfg, &mut store, true)?;
 
     // We were successful, commit the store
     store.commit()?;
@@ -1531,7 +1531,7 @@ fn cmd_check(
     } else {
         if !cfg.cli.locked {
             #[allow(clippy::single_match)]
-            match resolver::regenerate_exemptions(cfg, &mut store, false, false) {
+            match resolver::regenerate_exemptions(cfg, &mut store, false) {
                 Err(RegenerateExemptionsError::ViolationConflict) => {
                     unreachable!("unexpeced violation conflict regenerating exemptions?")
                 }
@@ -1568,7 +1568,7 @@ fn cmd_fetch_imports(
 
     // NOTE: Explicitly ignore the `ViolationConflict` error, as we still want
     // to update imports in that case.
-    match resolver::regenerate_exemptions(cfg, &mut store, false, true) {
+    match resolver::regenerate_exemptions(cfg, &mut store, false) {
         Ok(()) | Err(RegenerateExemptionsError::ViolationConflict) => {}
     }
 

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -1,3 +1,5 @@
+use crate::network::Network;
+
 use super::*;
 
 // Helper function for imports tests. Performs a vet and updates imports based
@@ -83,17 +85,11 @@ fn new_peer_import() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![
-            (FOREIGN.to_owned(), new_foreign_audits),
-            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
-        ],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -143,14 +139,10 @@ fn existing_peer_skip_import() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -204,14 +196,10 @@ fn existing_peer_remove_unused() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -304,17 +292,11 @@ fn existing_peer_import_delta_audit() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![
-            (FOREIGN.to_owned(), new_foreign_audits),
-            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
-        ],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -371,14 +353,10 @@ fn existing_peer_import_custom_criteria() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
 
@@ -429,14 +407,10 @@ fn new_audit_for_unused_criteria_basic() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
 
@@ -491,14 +465,10 @@ fn new_audit_for_unused_criteria_transitive() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
 
@@ -545,14 +515,10 @@ fn existing_peer_revoked_audit() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -608,14 +574,10 @@ fn existing_peer_add_violation() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -659,14 +621,10 @@ fn peer_audits_exemption_no_minimize() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -710,14 +668,10 @@ fn peer_audits_exemption_minimize() {
         },
     );
 
-    let mut store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let mut store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     // Capture the old imports before minimizing exemptions
     let old = store.mock_commit();
@@ -780,14 +734,10 @@ fn peer_audits_import_exclusion() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let imported = store
         .imported_audits()
@@ -864,13 +814,10 @@ fn existing_peer_updated_description() {
         },
     );
 
-    let error = match Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        false,
-    ) {
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let error = match Store::mock_online(config, audits, imports, &network, false) {
         Ok(_) => panic!("expected store creation to fail due to updated criteria"),
         Err(err) => miette::Report::from(err),
     };
@@ -928,17 +875,11 @@ fn fresh_import_preferred_audits() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![
-            (FOREIGN.to_owned(), new_foreign_audits),
-            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
-        ],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -1001,17 +942,11 @@ fn old_import_preferred_audits() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![
-            (FOREIGN.to_owned(), new_foreign_audits),
-            (OTHER_FOREIGN.to_owned(), new_other_foreign_audits),
-        ],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);
@@ -1054,14 +989,10 @@ fn equal_length_preferred_audits() {
         },
     );
 
-    let store = Store::mock_online(
-        config,
-        audits,
-        imports,
-        vec![(FOREIGN.to_owned(), new_foreign_audits)],
-        true,
-    )
-    .unwrap();
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+
+    let store = Store::mock_online(config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes(&metadata, &store);
     insta::assert_snapshot!(output);

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -29,7 +29,7 @@ fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", exemptions);
@@ -55,7 +55,7 @@ fn builtin_simple_deps_exemptions_overbroad_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", exemptions);
@@ -84,7 +84,7 @@ fn builtin_complex_exemptions_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", exemptions);
@@ -113,7 +113,7 @@ fn builtin_complex_exemptions_partial_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -149,7 +149,7 @@ fn builtin_simple_exemptions_in_delta_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", exemptions);
@@ -182,7 +182,7 @@ fn builtin_simple_exemptions_in_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", exemptions);
@@ -213,7 +213,7 @@ fn builtin_simple_deps_exemptions_adds_uneeded_criteria_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -249,7 +249,7 @@ fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect_regenerate() 
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -281,7 +281,7 @@ fn builtin_simple_exemptions_extra_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", exemptions);
@@ -310,7 +310,7 @@ fn builtin_simple_exemptions_in_direct_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -361,7 +361,7 @@ fn builtin_simple_exemptions_nested_weaker_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -417,7 +417,7 @@ fn builtin_simple_exemptions_nested_stronger_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -446,7 +446,7 @@ fn builtin_simple_audit_as_default_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -479,7 +479,7 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", exemptions);
@@ -507,7 +507,7 @@ fn builtin_simple_exemptions_larger_diff_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -567,7 +567,7 @@ fn builtin_simple_exemptions_broaden_basic() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-broaden-basic", exemptions);
@@ -620,7 +620,7 @@ fn builtin_simple_exemptions_regenerate_merge() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-regenerate-merge", exemptions);
@@ -673,7 +673,7 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -713,7 +713,7 @@ fn builtin_simple_exemptions_regenerate_nonew_failed() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false, false).unwrap();
+    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(

--- a/src/tests/snapshots/cargo_vet__tests__import__equal_length_preferred_audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__equal_length_preferred_audits.snap
@@ -3,11 +3,12 @@ source: src/tests/import.rs
 expression: output
 ---
  
- [[audits.peer-company.audits.third-party2]]
- criteria = "safe-to-deploy"
- version = "10.0.0"
+-[audits]
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++version = "2.0.0"
 +
 +[[audits.peer-company.audits.third-party2]]
 +criteria = "safe-to-deploy"
-+violation = "99.*"
++delta = "2.0.0 -> 10.0.0"
 

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_delta_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_import_delta_audit.snap
@@ -7,16 +7,9 @@ expression: output
  criteria = "safe-to-deploy"
  version = "9.0.0"
  
--[audits.rival-company.audits]
 +[[audits.peer-company.audits.third-party2]]
 +criteria = "safe-to-deploy"
 +delta = "9.0.0 -> 10.0.0"
 +
-+[[audits.peer-company.audits.third-party2]]
-+criteria = "safe-to-deploy"
-+delta = "100.0.0 -> 200.0.0"
-+
-+[[audits.rival-company.audits.third-party2]]
-+criteria = "safe-to-deploy"
-+delta = "200.0.0 -> 300.0.0"
+ [audits.rival-company.audits]
 

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
@@ -5,7 +5,19 @@ expression: output
  
  [[audits.peer-company.audits.third-party2]]
  criteria = "safe-to-deploy"
- delta = "100.0.0 -> 200.0.0"
+ version = "5.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "5.0.0 -> 10.0.0"
+-
+-[[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-deploy"
+-delta = "100.0.0 -> 200.0.0"
+-
+-[[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-run"
+-version = "10.0.0"
 -
 -[[audits.peer-company.audits.unused-package]]
 -criteria = "safe-to-deploy"

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit.snap
@@ -5,6 +5,6 @@ expression: output
  
 -[[audits.peer-company.audits.third-party2]]
 -criteria = "safe-to-deploy"
--delta = "100.0.0 -> 200.0.0"
+-version = "10.0.0"
 +[audits.peer-company.audits]
 

--- a/src/tests/snapshots/cargo_vet__tests__import__fresh_import_preferred_audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__fresh_import_preferred_audits.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+-[audits]
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++version = "5.0.0"
++
++[[audits.rival-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++delta = "5.0.0 -> 10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__new_peer_import.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_peer_import.snap
@@ -3,9 +3,7 @@ source: src/tests/import.rs
 expression: output
 ---
  
-+[[audits.peer-company.audits.third-party2]]
-+criteria = "safe-to-deploy"
-+delta = "100.0.0 -> 200.0.0"
++[audits.peer-company.audits]
 +
  [audits.rival-company.audits]
 

--- a/src/tests/snapshots/cargo_vet__tests__import__old_import_preferred_audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__old_import_preferred_audits.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "5.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "5.0.0 -> 6.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "6.0.0 -> 10.0.0"
++
++[audits.rival-company.audits]
+

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,12 +17,6 @@ criteria = "safe-to-deploy"
 version = "0.3.66"
 notes = "I am the author of this crate."
 
-[[audits.bytecodealliance.audits.bumpalo]]
-who = "Nick Fitzgerald <fitzgen@gmail.com>"
-criteria = "safe-to-deploy"
-version = "3.9.1"
-notes = "I am the author of this crate."
-
 [[audits.bytecodealliance.audits.cc]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -84,37 +78,11 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "Inspected it and is a tiny crate with single safe macro"
 
-[[audits.embark.audits.webpki-roots]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.22.4"
-notes = "Inspected it to confirm that it only contains data definitions and no runtime code"
-
 [[audits.firefox.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "All code written or reviewed by Josh Stone."
-
-[[audits.firefox.audits.bumpalo]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-run"
-delta = "3.9.1 -> 3.10.0"
-notes = """
-Some nontrivial functional changes but certainly meets the no-malware bar of
-safe-to-run. If we needed safe-to-deploy for this in m-c I'd ask Nick to re-
-certify this version, but we don't, so this is fine for now.
-"""
-
-[[audits.firefox.audits.bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.1.0 -> 1.2.1"
-
-[[audits.firefox.audits.camino]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.9 -> 1.1.1"
 
 [[audits.firefox.audits.cargo_metadata]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
@@ -122,36 +90,11 @@ criteria = "safe-to-deploy"
 version = "0.15.2"
 notes = "I reviewed the whole code base. Parser for the output of cargo-metadata, relying mostly on serde. No unsafe code used."
 
-[[audits.firefox.audits.clap_lex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.0 -> 0.2.2"
-
-[[audits.firefox.audits.clap_lex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.2 -> 0.2.4"
-
-[[audits.firefox.audits.either]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.6.1 -> 1.7.0"
-
-[[audits.firefox.audits.either]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 1.8.0"
-
 [[audits.firefox.audits.encoding_rs]]
 who = "Henri Sivonen <hsivonen@hsivonen.fi>"
 criteria = "safe-to-deploy"
 version = "0.8.31"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
-
-[[audits.firefox.audits.fastrand]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 1.8.0"
 
 [[audits.firefox.audits.fnv]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -159,82 +102,16 @@ criteria = "safe-to-deploy"
 version = "1.0.7"
 notes = "Simple hasher implementation with no unsafe code."
 
-[[audits.firefox.audits.futures-channel]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.21 -> 0.3.23"
-
-[[audits.firefox.audits.futures-core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.21 -> 0.3.23"
-
-[[audits.firefox.audits.futures-sink]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.21 -> 0.3.23"
-
-[[audits.firefox.audits.futures-task]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.21 -> 0.3.23"
-
-[[audits.firefox.audits.futures-util]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.21 -> 0.3.23"
-
-[[audits.firefox.audits.getrandom]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.6 -> 0.2.7"
-
-[[audits.firefox.audits.h2]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.3.13 -> 0.3.14"
-
-[[audits.firefox.audits.hashbrown]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-version = "0.12.3"
-notes = "This version is used in rust's libstd, so effectively we're already trusting it"
-
 [[audits.firefox.audits.hex]]
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.4.3"
-
-[[audits.firefox.audits.hyper]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.14.19 -> 0.14.20"
-
-[[audits.firefox.audits.indexmap]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.8.2 -> 1.9.1"
-
-[[audits.firefox.audits.itoa]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.2 -> 1.0.3"
-
-[[audits.firefox.audits.libc]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.126 -> 0.2.132"
 
 [[audits.firefox.audits.linked-hash-map]]
 who = "Aria Beingessner <a.beingessner@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.5.4"
 notes = "I own this crate (I am contain-rs) and 0.5.4 passes miri. This code is very old and used by lots of people, so I'm pretty confident in it, even though it's in maintenance-mode and missing some nice-to-have APIs."
-
-[[audits.firefox.audits.linked-hash-map]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.5.4 -> 0.5.6"
 
 [[audits.firefox.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -246,12 +123,6 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.1.9"
 notes = "This is a trivial crate."
-
-[[audits.firefox.audits.num-bigint]]
-who = "Josh Stone <jistone@redhat.com>"
-criteria = "safe-to-deploy"
-version = "0.2.6"
-notes = "All code written or reviewed by Josh Stone."
 
 [[audits.firefox.audits.num-bigint]]
 who = "Josh Stone <jistone@redhat.com>"
@@ -270,16 +141,6 @@ who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"
 version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
-
-[[audits.firefox.audits.once_cell]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.12.0 -> 1.13.1"
-
-[[audits.firefox.audits.os_str_bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "6.1.0 -> 6.3.0"
 
 [[audits.firefox.audits.proc-macro2]]
 who = "Nika Layzell <nika@thelayzells.com>"
@@ -310,11 +171,6 @@ and is likely completely unused. Even when used, this API shouldn't be able to
 cause unsoundness.
 """
 
-[[audits.firefox.audits.proc-macro2]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.39 -> 1.0.43"
-
 [[audits.firefox.audits.quote]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -330,154 +186,13 @@ read, is generally straightforward. I have audited the the quote macros, ident
 formatter, and runtime logic.
 """
 
-[[audits.firefox.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
-
-[[audits.firefox.audits.redox_syscall]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.13 -> 0.2.16"
-
-[[audits.firefox.audits.regex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.5.6 -> 1.6.0"
-
-[[audits.firefox.audits.regex-syntax]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.26 -> 0.6.27"
-
 [[audits.firefox.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 
-[[audits.firefox.audits.ryu]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.10 -> 1.0.11"
-
-[[audits.firefox.audits.semver]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.9 -> 1.0.10"
-
-[[audits.firefox.audits.semver]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.10 -> 1.0.13"
-
-[[audits.firefox.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.137 -> 1.0.143"
-
-[[audits.firefox.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.firefox.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.137 -> 1.0.143"
-
-[[audits.firefox.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.firefox.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.81 -> 1.0.83"
-
-[[audits.firefox.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.83 -> 1.0.85"
-
-[[audits.firefox.audits.serde_yaml]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.8.24 -> 0.8.26"
-
-[[audits.firefox.audits.slab]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.6 -> 0.4.7"
-
-[[audits.firefox.audits.smallvec]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.8.0 -> 1.9.0"
-
-[[audits.firefox.audits.syn]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.96 -> 1.0.99"
-
-[[audits.firefox.audits.thiserror]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.31 -> 1.0.32"
-
-[[audits.firefox.audits.thiserror-impl]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.31 -> 1.0.32"
-
-[[audits.firefox.audits.tower-service]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.3.1 -> 0.3.2"
-
-[[audits.firefox.audits.tracing]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.35 -> 0.1.36"
-
-[[audits.firefox.audits.tracing-attributes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.21 -> 0.1.22"
-
-[[audits.firefox.audits.tracing-core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.27 -> 0.1.29"
-
 [[audits.firefox.audits.typenum]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.15.0 -> 1.16.0"
-
-[[audits.firefox.audits.unicode-ident]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.0 -> 1.0.1"
-
-[[audits.firefox.audits.unicode-ident]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.1 -> 1.0.3"
-
-[[audits.firefox.audits.unicode-normalization]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.19 -> 0.1.20"
-notes = "I am the author of most of these changes upstream, and prepared the release myself, at which point I looked at the other changes since 0.1.19."
-
-[[audits.firefox.audits.unicode-normalization]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.20 -> 0.1.21"
-
-[[audits.firefox.audits.unicode-normalization]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.21 -> 0.1.22"


### PR DESCRIPTION
This is the first part of #398, without any changes specifically pertaining to wildcard audits.

Doing minimal imports is a large change to how the import backend works. It takes advantage of the lack of per-audit `dependency-criteria` since #382 to dramatically simplify the set of audits which we import such that we always only import the
smallest number of audits possible.

While this impacts all imports, this is part of the work towards wildcard audits, as reifying all wildcard audits would be unnecessarily noisy, due to the number of releases of some crates.

In order to do this in a reliable fashion, we now sort audit edges more aggressively when traversing the tree, so as to give a more deterministic total order and ensure we're reliably selecting the same edges.

In addition, we now mock out the network layer completely when running unit tests in order to allow more flexibility when writing unit tests for wildcard audits in the future.