### PR TITLE
Add an option to create wildcard audits with certify

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -445,6 +445,12 @@ pub struct CertifyArgs {
     /// If present, instead certify a diff from version1->version2
     #[clap(action)]
     pub version2: Option<VetVersion>,
+    /// If present, certify a wildcard audit for the user with the given username.
+    ///
+    /// Use the --start-date and --end-date options to specify the date range to
+    /// certify for.
+    #[clap(long, action, conflicts_with("version1"), requires("package"))]
+    pub wildcard: Option<String>,
     /// The criteria to certify for this audit
     ///
     /// If not provided, we will prompt you for this information.
@@ -460,6 +466,21 @@ pub struct CertifyArgs {
     /// If not provided, there will be no notes.
     #[clap(long, action)]
     pub notes: Option<String>,
+    /// Start date to create a wildcard audit from.
+    ///
+    /// Only valid with `--wildcard`.
+    ///
+    /// If not provided, will be the publication date of the first version
+    /// published by the given user.
+    #[clap(long, action, requires("wildcard"))]
+    pub start_date: Option<chrono::NaiveDate>,
+    /// End date to create a wildcard audit from. May be at most 1 year in the future.
+    ///
+    /// Only valid with `--wildcard`.
+    ///
+    /// If not provided, will be 1 year from the current date.
+    #[clap(long, action, requires("wildcard"))]
+    pub end_date: Option<chrono::NaiveDate>,
     /// Accept all criteria without an interactive prompt
     #[clap(long, action)]
     pub accept_all: bool,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -245,12 +245,22 @@ pub enum CertifyError {
     #[error("'{0}' isn't one of your foreign packages")]
     #[diagnostic(help("use --force to ignore this error"))]
     NotAPackage(PackageName),
+    #[error("'{0}' has not published any relevant version of '{1}'")]
+    #[diagnostic(help("please specify a user who has published a version of '{1}'"))]
+    NotAPublisher(String, PackageName),
+    #[error("end date of {0} is too far in the future")]
+    #[diagnostic(help("wildcard audit end dates may be at most 1 year in the future"))]
+    BadWildcardEndDate(chrono::NaiveDate),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     EditError(#[from] EditError),
     #[error(transparent)]
     UserInfoError(#[from] UserInfoError),
+    #[error(transparent)]
+    FetchAuditError(#[from] FetchAuditError),
+    #[error(transparent)]
+    CacheAcquire(#[from] CacheAcquireError),
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
@@ -1,0 +1,92 @@
+---
+source: src/tests/certify.rs
+expression: result
+---
+OUTPUT:
+<<<CLEAR SCREEN>>>
+choose criteria to certify for third-party1:*
+  0. <clear selections>
+  1. safe-to-run
+  2. safe-to-deploy
+  3. fuzzed
+  4. reviewed
+  5. strong-reviewed
+  6. weak-reviewed
+
+current selection: ["safe-to-deploy"]
+(press ENTER to accept the current criteria)
+> 
+
+<<<EDITING VET_CERTIFY>>>
+# Please read the following criteria and then follow the instructions below:
+
+# === BEGIN CRITERIA "safe-to-deploy" ===
+#
+# This crate will not introduce a serious security vulnerability to production
+# software exposed to untrusted input.
+#
+# Auditors are not required to perform a full logic review of the entire crate.
+# Rather, they must review enough to fully reason about the behavior of all unsafe
+# blocks and usage of powerful imports. For any reasonable usage of the crate in
+# real-world software, an attacker must not be able to manipulate the runtime
+# behavior of these sections in an exploitable or surprising way.
+#
+# Ideally, all unsafe code is fully sound, and ambient capabilities (e.g.
+# filesystem access) are hardened against manipulation and consistent with the
+# advertised behavior of the crate. However, some discretion is permitted. In such
+# cases, the nature of the discretion should be recorded in the `notes` field of
+# the audit record.
+#
+# For crates which generate deployed code (e.g. build dependencies or procedural
+# macros), reasonable usage of the crate should output code which meets the above
+# criteria.
+#
+# === END CRITERIA ===
+#
+# Uncomment the following statement:
+
+# I, testing, certify that I have audited all versions published by user 'testuser' between 2022-12-12 and 2024-01-01 of third-party1 in accordance with the above criteria.
+
+# Add any notes about your audit below this line:
+
+
+<<<EDIT OK>>>
+I, testing, certify that I have audited all versions published by user 'testuser' between 2022-12-12 and 2024-01-01 of third-party1 in accordance with the above criteria.
+
+These are testing notes. They contain some
+newlines. Trailing whitespace        
+    and leading whitespace
+
+
+<<<END EDIT>>>
+
+AUDITS:
+
+[criteria.fuzzed]
+description = "fuzzed"
+
+[criteria.reviewed]
+description = "reviewed"
+implies = "weak-reviewed"
+
+[criteria.strong-reviewed]
+description = "strongly reviewed"
+implies = "reviewed"
+
+[criteria.weak-reviewed]
+description = "weakly reviewed"
+
+[[wildcard-audits.third-party1]]
+who = "testing"
+criteria = "safe-to-deploy"
+user-id = 2
+start = "2022-12-12"
+end = "2024-01-01"
+notes = """
+These are testing notes. They contain some
+newlines. Trailing whitespace
+    and leading whitespace
+"""
+
+[audits]
+

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -337,6 +337,11 @@ The version to certify as audited
 If present, instead certify a diff from version1->version2
 
 ### OPTIONS
+#### `--wildcard <WILDCARD>`
+If present, certify a wildcard audit for the user with the given username.
+
+Use the --start-date and --end-date options to specify the date range to certify for.
+
 #### `--criteria <CRITERIA>`
 The criteria to certify for this audit
 
@@ -351,6 +356,21 @@ If not provided, we will collect this information from the local git.
 A free-form string to include with the new audit entry
 
 If not provided, there will be no notes.
+
+#### `--start-date <START_DATE>`
+Start date to create a wildcard audit from.
+
+Only valid with `--wildcard`.
+
+If not provided, will be the publication date of the first version published by the
+given user.
+
+#### `--end-date <END_DATE>`
+End date to create a wildcard audit from. May be at most 1 year in the future.
+
+Only valid with `--wildcard`.
+
+If not provided, will be 1 year from the current date.
 
 #### `--accept-all`
 Accept all criteria without an interactive prompt


### PR DESCRIPTION
This adds a --wildcard flag to the certify subcommand which can be used to create wildcard audits. Start and end dates must be specified with --start-date and --end-date, though they have fallback values.

This is a first-draft of the UX, and we may improve it in the future. We expect creating wildcard audits to be less frequent than other types, so the experience is a bit less polished.

Fixes #402