### PR TITLE
Relax crate policy checks to only require versions for all crates in the

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -193,7 +193,10 @@ pub enum CratePolicyError {
 }
 
 #[derive(Debug, Error, Diagnostic, PartialEq, Eq)]
-#[diagnostic(help("Add a `policy.\"<crate>:<version>\"` entry for them"))]
+#[diagnostic(help(
+    "Specifing `dependency-criteria` requires explicit policies for each version of \
+     a crate. Add a `policy.\"<crate>:<version>\"` entry for them."
+))]
 pub struct NeedsPolicyVersionErrors {
     pub errors: Vec<PackageError>,
 }

--- a/src/tests/crate_policies.rs
+++ b/src/tests/crate_policies.rs
@@ -1,9 +1,29 @@
+use crate::errors::CratePolicyErrors;
+
 use super::*;
 
 struct CratePolicyTest(pub MockMetadata);
 
 impl CratePolicyTest {
+    pub fn no_errors<F>(&self, alter_config: F)
+    where
+        F: FnOnce(&mut ConfigFile),
+    {
+        self.check_crate_policies(alter_config)
+            .expect("crate policy check should succeed");
+    }
+
     pub fn insta_crate_policy_errors<N: AsRef<str>, F>(&self, name: N, alter_config: F)
+    where
+        F: FnOnce(&mut ConfigFile),
+    {
+        let e = self
+            .check_crate_policies(alter_config)
+            .expect_err("crate policy check should have failed");
+        insta::assert_snapshot!(name.as_ref(), format!("{:?}", miette::Report::new(e)));
+    }
+
+    fn check_crate_policies<F>(&self, alter_config: F) -> Result<(), CratePolicyErrors>
     where
         F: FnOnce(&mut ConfigFile),
     {
@@ -13,14 +33,33 @@ impl CratePolicyTest {
         let store = Store::mock(config, audits, imports);
         let cfg = mock_cfg(&metadata);
 
-        let e = crate::check_crate_policies(&cfg, &store)
-            .expect_err("crate policy check should have failed");
-        insta::assert_snapshot!(name.as_ref(), format!("{:?}", miette::Report::new(e)));
+        crate::check_crate_policies(&cfg, &store)
     }
 }
 
-/// Checks that if a third-party crate is present, and an unversioned policy is used, an error
-/// occurs indicating that versions need to be specified.
+/// Checks that if a third-party crate is present, and an unversioned policy is used _without_
+/// `dependency-criteria`, no error occurs.
+#[test]
+fn simple_crate_policies_third_party_crates_dont_need_versions() {
+    let _enter = TEST_RUNTIME.enter();
+
+    CratePolicyTest(MockMetadata::overlapping()).no_errors(|config| {
+        config.policy.insert(
+            "third-party".into(),
+            PackagePolicyEntry::Unversioned(Default::default()),
+        );
+    });
+}
+
+fn dep_criteria_policy_entry() -> PolicyEntry {
+    PolicyEntry {
+        dependency_criteria: [("foo".to_owned(), vec!["bar".to_owned().into()])].into(),
+        ..Default::default()
+    }
+}
+
+/// Checks that if a third-party crate is present, and an unversioned policy is used with
+/// `dependency-criteria`, an error occurs indicating that versions need to be specified.
 #[test]
 fn simple_crate_policies_third_party_crates_imply_versions() {
     let _enter = TEST_RUNTIME.enter();
@@ -30,15 +69,15 @@ fn simple_crate_policies_third_party_crates_imply_versions() {
         |config| {
             config.policy.insert(
                 "third-party".into(),
-                PackagePolicyEntry::Unversioned(Default::default()),
+                PackagePolicyEntry::Unversioned(dep_criteria_policy_entry()),
             );
         },
     );
 }
 
-/// Checks that if a third-party crate is present and a versioned policy is used for one version,
-/// an error occurs indicating that versions are needed for other versions (regardless of whether
-/// they are considered first- or third-party).
+/// Checks that if a third-party crate is present and a versioned policy with `dependency-criteria`
+/// is used for one version, an error occurs indicating that versions are needed for other versions
+/// (regardless of whether they are considered first- or third-party).
 #[test]
 fn simple_crate_policies_third_party_crates_need_all_versions() {
     let _enter = TEST_RUNTIME.enter();
@@ -52,7 +91,7 @@ fn simple_crate_policies_third_party_crates_need_all_versions() {
                 config.policy.insert(
                     "third-party".into(),
                     PackagePolicyEntry::Versioned {
-                        version: [(ver(which), Default::default())].into(),
+                        version: [(ver(which), dep_criteria_policy_entry())].into(),
                     },
                 );
             },

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_imply_versions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_imply_versions.snap
@@ -9,5 +9,7 @@ Error:
   × some crates have policies that are missing an associated version
   │   third-party:1.0.0
   │   third-party:2.0.0
-  help: Add a `policy."<crate>:<version>"` entry for them
+  help: Specifing `dependency-criteria` requires explicit policies for each
+        version of a crate. Add a `policy."<crate>:<version>"` entry for
+        them.
 

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_1.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_1.snap
@@ -8,5 +8,7 @@ expression: "format!(\"{:?}\", miette :: Report :: new(e))"
 Error: 
   × some crates have policies that are missing an associated version
   │   third-party:2.0.0
-  help: Add a `policy."<crate>:<version>"` entry for them
+  help: Specifing `dependency-criteria` requires explicit policies for each
+        version of a crate. Add a `policy."<crate>:<version>"` entry for
+        them.
 

--- a/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_2.snap
+++ b/src/tests/snapshots/cargo_vet__tests__crate_policies__third_party_crates_need_all_versions_2.snap
@@ -8,5 +8,7 @@ expression: "format!(\"{:?}\", miette :: Report :: new(e))"
 Error: 
   × some crates have policies that are missing an associated version
   │   third-party:1.0.0
-  help: Add a `policy."<crate>:<version>"` entry for them
+  help: Specifing `dependency-criteria` requires explicit policies for each
+        version of a crate. Add a `policy."<crate>:<version>"` entry for
+        them.
 


### PR DESCRIPTION
graph for a particular package if `dependency-criteria` is used by any policy of that package.