### PR TITLE
Update installation instructions to pass --locked to cargo install

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -3,7 +3,7 @@
 Installing `cargo vet` can be done through Cargo:
 
 ```
-$ cargo install cargo-vet
+$ cargo install --locked cargo-vet
 ```
 
 Afterwards you can confirm that it's installed via:


### PR DESCRIPTION
Without this, installation will pick up any new semantically-compatible dependencies available at the time of compilation. We haven't been entirely rigorous with audits for the tool itself, but we should in principle aim to move in that direction, and therefore should be encouraging people to build with the same Cargo.lock as us.