### PR TITLE
Correctly handle importing audits for multiple versions

### DIFF
--- a/src/tests/snapshots/cargo_vet__tests__import__import_multiple_versions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_multiple_versions.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/import.rs
+expression: output
+---
++
++[[audits.peer-company.audits.third-core]]
++criteria = "safe-to-deploy"
++version = "5.0.0"
++
++[[audits.peer-company.audits.third-core]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
+


### PR DESCRIPTION
When we changed the way that imports were handled in #399, the new minimal imports logic didn't handle multiple versions of crates with the same name properly, meaning that we'd only import the required audits for one of the versions rather than all of them.

This patch adds a test to ensure that doesn't happen again, and fixes the underlying issue.