### PR TITLE
Avoid unrelated imports during certify and vet

### DIFF
--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -29,7 +29,13 @@ fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", exemptions);
@@ -55,7 +61,13 @@ fn builtin_simple_deps_exemptions_overbroad_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", exemptions);
@@ -84,7 +96,13 @@ fn builtin_complex_exemptions_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", exemptions);
@@ -113,7 +131,13 @@ fn builtin_complex_exemptions_partial_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -149,7 +173,13 @@ fn builtin_simple_exemptions_in_delta_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", exemptions);
@@ -182,7 +212,13 @@ fn builtin_simple_exemptions_in_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", exemptions);
@@ -213,7 +249,13 @@ fn builtin_simple_deps_exemptions_adds_uneeded_criteria_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -249,7 +291,13 @@ fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect_regenerate() 
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -281,7 +329,13 @@ fn builtin_simple_exemptions_extra_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", exemptions);
@@ -310,7 +364,13 @@ fn builtin_simple_exemptions_in_direct_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -361,7 +421,13 @@ fn builtin_simple_exemptions_nested_weaker_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -417,7 +483,13 @@ fn builtin_simple_exemptions_nested_stronger_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -446,7 +518,13 @@ fn builtin_simple_audit_as_default_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -478,7 +556,13 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", exemptions);
@@ -506,7 +590,13 @@ fn builtin_simple_exemptions_larger_diff_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -566,7 +656,13 @@ fn builtin_simple_exemptions_broaden_basic() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-broaden-basic", exemptions);
@@ -619,7 +715,13 @@ fn builtin_simple_exemptions_regenerate_merge() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        true,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-regenerate-merge", exemptions);
@@ -672,7 +774,13 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        false,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -683,8 +791,8 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
 #[test]
 fn builtin_simple_exemptions_regenerate_nonew_failed() {
-    // (Pass) minimize_exemptions will be a no-op if no new exemptions are
-    // allowed, and vet is failing.
+    // (Pass) minimize_exemptions will only remove unknown packages if no new
+    // exemptions are allowed, and vet is failing.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -712,7 +820,13 @@ fn builtin_simple_exemptions_regenerate_nonew_failed() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
+    crate::resolver::regenerate_exemptions(
+        &cfg,
+        &mut store,
+        crate::resolver::PreferFreshImports::All,
+        false,
+    )
+    .unwrap();
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(

--- a/src/tests/snapshots/cargo_vet__tests__import__import_multiple_versions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_multiple_versions.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/import.rs
+expression: output
+---
++
++[[audits.peer-company.audits.third-core]]
++criteria = "safe-to-deploy"
++version = "5.0.0"
++
++[[audits.peer-company.audits.third-core]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_all.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_all.snap
@@ -1,0 +1,38 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+audits.toml: (unchanged)
+config.toml:
+ 
+ # cargo-vet config file
+ 
+ [imports.peer-company]
+ url = "https://peercompany.co.uk"
+-
+-[[exemptions.third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+-
+-[[exemptions.third-party2]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+-
+-[[exemptions.transitive-third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+
+imports.lock:
+ 
+ # cargo-vet imports lock
+ 
+-[audits.peer-company.audits]
++[[audits.peer-company.audits.third-party1]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
++
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
+
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_none.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_none.snap
@@ -1,0 +1,26 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+audits.toml: (unchanged)
+config.toml:
+ 
+ # cargo-vet config file
+ 
+ [imports.peer-company]
+ url = "https://peercompany.co.uk"
+ 
+ [[exemptions.third-party1]]
+ version = "10.0.0"
+ criteria = "safe-to-deploy"
+ 
+ [[exemptions.third-party2]]
+ version = "10.0.0"
+ criteria = "safe-to-deploy"
+-
+-[[exemptions.transitive-third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+
+imports.lock: (unchanged)
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_only.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_only.snap
@@ -13,14 +13,14 @@ config.toml:
  [[exemptions.third-party1]]
  version = "10.0.0"
  criteria = "safe-to-deploy"
- 
+-
 -[[exemptions.third-party2]]
 -version = "10.0.0"
 -criteria = "safe-to-deploy"
 -
- [[exemptions.transitive-third-party1]]
- version = "10.0.0"
- criteria = "safe-to-deploy"
+-[[exemptions.transitive-third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
 
 imports.lock:
  

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-nonew-failed.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin-simple-exemptions-regenerate-nonew-failed.snap
@@ -2,10 +2,6 @@
 source: src/tests/regenerate_unaudited.rs
 expression: exemptions
 ---
-[[random-crate]]
-version = "300.0.0"
-criteria = "safe-to-deploy"
-
 [[third-party1]]
 version = "300.0.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This is done by making whether imports or exemptions are preferred configurable on a per-package basis when running `regenerate_exemptions`.

This combines the existing iterative approach, which prefers imports, with an approach based on used edges when auditing, which prefers local audits. After the change, it is still possible for `vet` to cause imports to occur if they are necessary to vet successfully, however it will not cause unrelated exemptions to be removed.

Fixes #391