### PR TITLE
Avoid removing unnecessary imports and exemptions unless explicitly requested

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -315,12 +315,12 @@ pub enum Commands {
     #[clap(disable_version_flag = true)]
     Fmt(FmtArgs),
 
-    /// Explicitly fetch the imports (foreign audit files)
+    /// Prune unnecessary imports and exemptions
     ///
-    /// `cargo vet check` will implicitly do this, so this mostly exists as "plumbing"
-    /// for building tools on top of vet.
+    /// This will fetch the updated state of imports, and attempt to remove any
+    /// now-unnecessary imports or exemptions from the supply-chain.
     #[clap(disable_version_flag = true)]
-    FetchImports(FetchImportsArgs),
+    Prune(PruneArgs),
 
     /// Fetch and merge audits from multiple sources into a single `audits.toml`
     /// file.
@@ -561,7 +561,14 @@ pub struct SuggestArgs {}
 pub struct FmtArgs {}
 
 #[derive(clap::Args)]
-pub struct FetchImportsArgs {}
+pub struct PruneArgs {
+    /// Don't prune unused imports
+    #[clap(long, action)]
+    pub no_imports: bool,
+    /// Don't prune unused exemptions
+    #[clap(long, action)]
+    pub no_exemptions: bool,
+}
 
 #[derive(clap::Args)]
 pub struct RegenerateExemptionsArgs {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -290,19 +290,6 @@ pub enum InitError {
     StoreCommit(#[source] StoreCommitError),
 }
 
-//////////////////////////////////////////////////////////
-// RegenerateExemptionsError
-//////////////////////////////////////////////////////////
-
-#[derive(Debug, Error, Diagnostic)]
-#[non_exhaustive]
-pub enum RegenerateExemptionsError {
-    #[error(
-        "Regenerating exemptions failed due to violation conflicts. Run 'cargo vet' for details"
-    )]
-    ViolationConflict,
-}
-
 ///////////////////////////////////////////////////////////
 // StoreErrors
 ///////////////////////////////////////////////////////////

--- a/src/format.rs
+++ b/src/format.rs
@@ -208,7 +208,7 @@ pub type WildcardAudits = SortedMap<PackageName, Vec<WildcardEntry>>;
 pub type AuditedDependencies = SortedMap<PackageName, Vec<AuditEntry>>;
 
 /// audits.toml
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AuditsFile {
     /// A map of criteria_name to details on that criteria.
     #[serde(skip_serializing_if = "SortedMap::is_empty")]
@@ -237,7 +237,7 @@ pub struct ForeignAuditsFile {
 }
 
 /// Information on a Criteria
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct CriteriaEntry {
     /// Summary of how you evaluate something by this criteria.
@@ -371,7 +371,7 @@ impl Serialize for Delta {
 /// publication time and user-id.
 ///
 /// These audits will be reified in the imports.lock file when unlocked.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WildcardEntry {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -751,7 +751,7 @@ fn is_default_exemptions_suggest(val: &bool) -> bool {
 //                                                                                //
 ////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ImportsFile {
     #[serde(default)]
     #[serde(skip_serializing_if = "SortedMap::is_empty")]
@@ -763,7 +763,7 @@ pub struct ImportsFile {
 
 /// Information about who published a specific version of a crate to be cached
 /// in imports.lock.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CratesPublisher {
     // NOTE: This will only ever be a `semver::Version`, however the resolver
     // code works on borrowed `VetVersion` instances, so we use one here so it

--- a/src/tests/regenerate_unaudited.rs
+++ b/src/tests/regenerate_unaudited.rs
@@ -11,6 +11,22 @@ fn get_exemptions(store: &Store) -> String {
     toml_edit::ser::to_string_pretty(&store.config.exemptions).unwrap()
 }
 
+fn basic_regenerate(cfg: &Config, store: &mut Store) {
+    crate::resolver::update_store(cfg, store, |_| crate::resolver::UpdateMode {
+        search_mode: crate::resolver::SearchMode::RegenerateExemptions,
+        prune_exemptions: true,
+        prune_imports: true,
+    });
+}
+
+fn basic_minimize(cfg: &Config, store: &mut Store) {
+    crate::resolver::update_store(cfg, store, |_| crate::resolver::UpdateMode {
+        search_mode: crate::resolver::SearchMode::PreferFreshImports,
+        prune_exemptions: true,
+        prune_imports: true,
+    });
+}
+
 #[test]
 fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
     // (Pass) there's an exemptions entry for a package that isn't in our tree at all.
@@ -29,7 +45,7 @@ fn builtin_simple_exemptions_not_a_real_dep_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-not-a-real-dep-regenerate", exemptions);
@@ -55,7 +71,7 @@ fn builtin_simple_deps_exemptions_overbroad_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-overbroad-regenerate", exemptions);
@@ -84,7 +100,7 @@ fn builtin_complex_exemptions_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-twins-regenerate", exemptions);
@@ -113,7 +129,7 @@ fn builtin_complex_exemptions_partial_twins_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -149,7 +165,7 @@ fn builtin_simple_exemptions_in_delta_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-delta-regenerate", exemptions);
@@ -182,7 +198,7 @@ fn builtin_simple_exemptions_in_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-in-full-regenerate", exemptions);
@@ -213,7 +229,7 @@ fn builtin_simple_deps_exemptions_adds_uneeded_criteria_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -249,7 +265,7 @@ fn builtin_dev_detection_exemptions_adds_uneeded_criteria_indirect_regenerate() 
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -281,7 +297,7 @@ fn builtin_simple_exemptions_extra_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-unaudited-extra-regenerate", exemptions);
@@ -310,7 +326,7 @@ fn builtin_simple_exemptions_in_direct_full_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -361,7 +377,7 @@ fn builtin_simple_exemptions_nested_weaker_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -417,7 +433,7 @@ fn builtin_simple_exemptions_nested_stronger_req_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -446,7 +462,7 @@ fn builtin_simple_audit_as_default_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -478,7 +494,7 @@ fn builtin_simple_audit_as_weaker_root_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-audit-as-weaker-root-regenerate", exemptions);
@@ -506,7 +522,7 @@ fn builtin_simple_exemptions_larger_diff_regenerate() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -566,7 +582,7 @@ fn builtin_simple_exemptions_broaden_basic() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-broaden-basic", exemptions);
@@ -619,7 +635,7 @@ fn builtin_simple_exemptions_regenerate_merge() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, true).unwrap();
+    basic_regenerate(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!("builtin-simple-exemptions-regenerate-merge", exemptions);
@@ -672,7 +688,7 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
+    basic_minimize(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
@@ -683,8 +699,8 @@ fn builtin_simple_exemptions_regenerate_merge_nonew() {
 
 #[test]
 fn builtin_simple_exemptions_regenerate_nonew_failed() {
-    // (Pass) minimize_exemptions will be a no-op if no new exemptions are
-    // allowed, and vet is failing.
+    // (Pass) minimize_exemptions will only remove unknown packages if no new
+    // exemptions are allowed, and vet is failing.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();
@@ -712,11 +728,70 @@ fn builtin_simple_exemptions_regenerate_nonew_failed() {
 
     let mut store = Store::mock(config, audits, imports);
     let cfg = mock_cfg(&metadata);
-    crate::resolver::regenerate_exemptions(&cfg, &mut store, false).unwrap();
+    basic_minimize(&cfg, &mut store);
 
     let exemptions = get_exemptions(&store);
     insta::assert_snapshot!(
         "builtin-simple-exemptions-regenerate-nonew-failed",
         exemptions
     );
+}
+
+#[test]
+fn builtin_complex_exemptions_preferred_path() {
+    // (Pass) minimizing exemptions will remove a now-unnecessary full exemption
+    // of another exemption already exists for an earlier version, with a valid
+    // delta-audit.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::complex();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = builtin_files_inited(&metadata);
+
+    audits.audits.insert(
+        "third-core".to_owned(),
+        vec![delta_audit(ver(5), ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+    );
+
+    config.exemptions.insert(
+        "third-core".to_owned(),
+        vec![
+            exemptions(ver(5), SAFE_TO_DEPLOY),
+            exemptions(ver(DEFAULT_VER), SAFE_TO_DEPLOY),
+        ],
+    );
+
+    let mut store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+    basic_minimize(&cfg, &mut store);
+
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!(exemptions);
+}
+
+#[test]
+fn builtin_complex_exemptions_preferred_path_fresh() {
+    // (Pass) regenerating exemptions will choose to only add a full exemption
+    // to an earlier version if a delta audit exists.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::complex();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = builtin_files_inited(&metadata);
+
+    audits.audits.insert(
+        "third-core".to_owned(),
+        vec![delta_audit(ver(5), ver(DEFAULT_VER), SAFE_TO_DEPLOY)],
+    );
+
+    config.exemptions.remove("third-core");
+
+    let mut store = Store::mock(config, audits, imports);
+    let cfg = mock_cfg(&metadata);
+    basic_regenerate(&cfg, &mut store);
+
+    let exemptions = get_exemptions(&store);
+    insta::assert_snapshot!(exemptions);
 }

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
@@ -8,16 +8,16 @@ expression: output
  version = "5.0.0"
  
  [[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-run"
+-version = "10.0.0"
+-
+-[[audits.peer-company.audits.third-party2]]
  criteria = "safe-to-deploy"
  delta = "5.0.0 -> 10.0.0"
 -
 -[[audits.peer-company.audits.third-party2]]
 -criteria = "safe-to-deploy"
 -delta = "100.0.0 -> 200.0.0"
--
--[[audits.peer-company.audits.third-party2]]
--criteria = "safe-to-run"
--version = "10.0.0"
 -
 -[[audits.peer-company.audits.unused-package]]
 -criteria = "safe-to-deploy"

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused_noprune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused_noprune.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "5.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-run"
+ version = "10.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "5.0.0 -> 10.0.0"
+ 
+ [[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ delta = "100.0.0 -> 200.0.0"
+ 
+ [[audits.peer-company.audits.unused-package]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit_noprune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_revoked_audit_noprune.snap
@@ -1,0 +1,10 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+ 
+-[[audits.peer-company.audits.third-party2]]
+-criteria = "safe-to-deploy"
+-version = "10.0.0"
++[audits.peer-company.audits]
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_certify.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_certify.snap
@@ -26,9 +26,16 @@ imports.lock:
  
  # cargo-vet imports lock
  
--[audits.peer-company.audits]
+ [[audits.peer-company.audits.third-party1]]
+ criteria = "safe-to-deploy"
+ delta = "10.0.0 -> 100.0.0"
+ 
 +[[audits.peer-company.audits.third-party2]]
 +criteria = "safe-to-deploy"
 +version = "10.0.0"
++
+ [[audits.peer-company.audits.unused-crate]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
 
 

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_prune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_prune.snap
@@ -1,0 +1,39 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+audits.toml: (unchanged)
+config.toml:
+ 
+ # cargo-vet config file
+ 
+ [imports.peer-company]
+ url = "https://peercompany.co.uk"
+-
+-[[exemptions.third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+-
+-[[exemptions.third-party2]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+-
+-[[exemptions.transitive-third-party1]]
+-version = "10.0.0"
+-criteria = "safe-to-deploy"
+
+imports.lock:
+ 
+ # cargo-vet imports lock
+ 
+ [[audits.peer-company.audits.third-party1]]
+ criteria = "safe-to-deploy"
+-delta = "10.0.0 -> 100.0.0"
++version = "10.0.0"
+ 
+-[[audits.peer-company.audits.unused-crate]]
++[[audits.peer-company.audits.third-party2]]
+ criteria = "safe-to-deploy"
+ version = "10.0.0"
+
+

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_vet.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_vet.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+audits.toml: (unchanged)
+config.toml: (unchanged)
+imports.lock: (unchanged)
+

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin_complex_exemptions_preferred_path.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin_complex_exemptions_preferred_path.snap
@@ -2,15 +2,15 @@
 source: src/tests/regenerate_unaudited.rs
 expression: exemptions
 ---
-[[third-party1]]
-version = "300.0.0"
+[[third-core]]
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
-[[transitive-third-party1]]
-version = "300.0.0"
+[[thirdA]]
+version = "10.0.0"
 criteria = "safe-to-deploy"
 
-[[transitive-third-party1]]
-version = "400.0.0"
+[[thirdAB]]
+version = "10.0.0"
 criteria = "safe-to-deploy"
 

--- a/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin_complex_exemptions_preferred_path_fresh.snap
+++ b/src/tests/snapshots/cargo_vet__tests__regenerate_unaudited__builtin_complex_exemptions_preferred_path_fresh.snap
@@ -2,15 +2,15 @@
 source: src/tests/regenerate_unaudited.rs
 expression: exemptions
 ---
-[[third-party1]]
-version = "300.0.0"
+[[third-core]]
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
-[[transitive-third-party1]]
-version = "300.0.0"
+[[thirdA]]
+version = "10.0.0"
 criteria = "safe-to-deploy"
 
-[[transitive-third-party1]]
-version = "400.0.0"
+[[thirdAB]]
+version = "10.0.0"
 criteria = "safe-to-deploy"
 

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -140,8 +140,8 @@ SUBCOMMANDS:
             Declare that some versions of a package violate certain audit criteria
     fmt
             Reformat all of vet's files (in case you hand-edited them)
-    fetch-imports
-            Explicitly fetch the imports (foreign audit files)
+    prune
+            Prune unnecessary imports and exemptions
     aggregate
             Fetch and merge audits from multiple sources into a single `audits.toml` file
     dump-graph

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -139,7 +139,7 @@ graph
 * [add-exemption](#cargo-vet-add-exemption): Mark a package as exempted from review
 * [record-violation](#cargo-vet-record-violation): Declare that some versions of a package violate certain audit criteria
 * [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
-* [fetch-imports](#cargo-vet-fetch-imports): Explicitly fetch the imports (foreign audit files)
+* [prune](#cargo-vet-prune): Prune unnecessary imports and exemptions
 * [aggregate](#cargo-vet-aggregate): Fetch and merge audits from multiple sources into a single `audits.toml` file
 * [dump-graph](#cargo-vet-dump-graph): Print the cargo build graph as understood by `cargo vet`
 * [gc](#cargo-vet-gc): Clean up old packages from the vet cache
@@ -626,18 +626,24 @@ Print help information
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet fetch-imports
-Explicitly fetch the imports (foreign audit files)
+## cargo vet prune
+Prune unnecessary imports and exemptions
 
-`cargo vet check` will implicitly do this, so this mostly exists as "plumbing" for building tools on
-top of vet.
+This will fetch the updated state of imports, and attempt to remove any now-unnecessary imports or
+exemptions from the supply-chain.
 
 ### USAGE
 ```
-cargo vet fetch-imports [OPTIONS]
+cargo vet prune [OPTIONS]
 ```
 
 ### OPTIONS
+#### `--no-imports`
+Don't prune unused imports
+
+#### `--no-exemptions`
+Don't prune unused exemptions
+
 #### `-h, --help`
 Print help information
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -68,7 +68,7 @@ SUBCOMMANDS:
     add-exemption       Mark a package as exempted from review
     record-violation    Declare that some versions of a package violate certain audit criteria
     fmt                 Reformat all of vet's files (in case you hand-edited them)
-    fetch-imports       Explicitly fetch the imports (foreign audit files)
+    prune               Prune unnecessary imports and exemptions
     aggregate           Fetch and merge audits from multiple sources into a single `audits.toml`
                             file
     dump-graph          Print the cargo build graph as understood by `cargo vet`


### PR DESCRIPTION
This patch changes the import and exemption minimization behaviour to be much more conservative than before, only performing full pruning of unnecessary audits and exemptions when running the new `cargo vet prune` subcommand (which replaces `cargo vet fetch-imports`), or when running `cargo vet regenerate {exemptions,imports}`.

When running other subcommands, the behaviour now avoids churn more.

* When running `cargo vet`, the command will only import new audits which are necessary to vet, but will not prune unused imported audits or unnecessary exemptions. This should reduce unintentional churn and avoid unrelated ride-along exemption removals with other changes.

* When running `cargo vet certify`, we will prune exemptions for only the newly certified crate, but not for any other crate. This takes advantage of the dependency-criteria removal which allows us to vet each crate fully independently.

In order to do this, the regenerate_exemptions backend has been fully rewritten. It now builds on top of the minimal imports backend, to avoid unnecessary churn, and uses flags passed to `search_for_path` to control audit traversal behaviour. Handling of exemption criteria expansion/minimization is done using extra ride-along CriteriaSet information on RequiredEdge nodes.

As these updates are no longer handled implicitly, we now emit a warning from `cargo vet` if a `cargo vet prune` command could allow unused exemptions or imports to be pruned. This is currently done somewhat sloppily by running both updates and comparing the outputs, but could be potentially refined in the future.

Fixes #411,#391