### PR TITLE
Ensure cargo-vet builds on rustc 1.61

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,18 @@ jobs:
         run: |
           cargo test --workspace --all-targets
 
+  msrv-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.61.0
+          override: true
+      - name: Run cargo check
+        run: |
+          cargo check
+
   vet:
     runs-on: ubuntu-latest
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1439,7 +1439,11 @@ fn fix_audit_as(cfg: &Config, store: &mut Store) -> Result<(), CacheAcquireError
                         };
                         let policy_entry = store.config.policy.get_mut_or_default(
                             err.package.clone(),
-                            is_third_party.then_some(err.version.as_ref()).flatten(),
+                            if is_third_party {
+                                err.version.as_ref()
+                            } else {
+                                None
+                            },
                             all_versions,
                         );
 
@@ -2314,7 +2318,13 @@ fn check_crate_policies(cfg: &Config, store: &Store) -> Result<(), CratePolicyEr
         .config
         .policy
         .iter()
-        .filter_map(|(name, _, entry)| (!entry.dependency_criteria.is_empty()).then_some(name))
+        .filter_map(|(name, _, entry)| {
+            if entry.dependency_criteria.is_empty() {
+                None
+            } else {
+                Some(name)
+            }
+        })
         .collect::<SortedSet<_>>();
 
     let mut needs_policy_version_errors = Vec::new();

--- a/src/network.rs
+++ b/src/network.rs
@@ -211,7 +211,7 @@ impl Network {
 
     /// Internal core implementation of network fetching which is shared between
     /// `download` and `download_and_persist`.
-    async fn fetch_core(&self, url: Url) -> Result<Response, DownloadError> {
+    async fn fetch_core(&self, url: Url) -> Result<Response<'_>, DownloadError> {
         #[cfg(test)]
         if let Some(mock_network) = &self.mock_network {
             let chunk = mock_network

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1956,12 +1956,12 @@ impl Cache {
         // time, and we don't want to do multiple crates.io API calls at
         // the same time, so we'll do the network fetch sync for now.
         let response = tokio::runtime::Handle::current().block_on(network.download(url))?;
-        let result = load_json::<CratesAPICrate>(&response[..])?.versions;
+        let CratesAPICrate { versions } = load_json(&response[..])?;
 
         // Update the users cache and individual crates caches, and return our
         // set of versions.
         let mut guard = self.state.lock().unwrap();
-        let versions: Vec<_> = result
+        let versions: Vec<_> = versions
             .into_iter()
             .map(|api_version| PublisherCacheVersion {
                 num: api_version.num,


### PR DESCRIPTION
This is the current version used for macOS and windows toolchain builds in mozilla-central.