### PR TITLE
Add a CI job to ensure cargo-vet builds on rust 1.65

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,18 @@ jobs:
         run: |
           cargo test --workspace --all-targets
 
+  msrv-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65.0
+          override: true
+      - name: Run cargo check
+        run: |
+          cargo check
+
   vet:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is the rust version used to build toolchain artifacts in mozilla-central, such as cargo-vet.

Supercedes #415