### PR TITLE
Tweak wildcard certify message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -919,12 +919,16 @@ fn do_cmd_certify(
         .criteria_names(&criteria_set)
         .collect::<Vec<_>>();
 
-    let what_version = match &kind {
+    let statement = match &kind {
         CertifyKind::Full { version } => {
-            format!("version {version}")
+            format!(
+                    "I, {username}, certify that I have audited version {version} of {package} in accordance with the above criteria.",
+                )
         }
         CertifyKind::Delta { from, to } => {
-            format!("the changes from version {from} to {to}")
+            format!(
+                    "I, {username}, certify that I have audited the changes from version {from} to {to} of {package} in accordance with the above criteria.",
+                )
         }
         CertifyKind::Wildcard {
             user_login,
@@ -932,12 +936,11 @@ fn do_cmd_certify(
             end,
             ..
         } => {
-            format!("all versions published by user '{user_login}' between {start} and {end}")
+            format!(
+                    "I, {username}, certify that any version of {package} published by '{user_login}' between {start} and {end} will satisfy the above criteria.",
+                )
         }
     };
-    let statement = format!(
-        "I, {username}, certify that I have audited {what_version} of {package} in accordance with the above criteria.",
-    );
 
     let mut notes = sub_args.notes.clone();
     if !sub_args.accept_all {

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -227,7 +227,7 @@ fn mock_wildcard_certify_flow() {
         |_| Ok("\n".to_owned()),
         |_| {
             Ok("\
-            I, testing, certify that I have audited all versions published by user 'testuser' between 2022-12-12 and 2024-01-01 of third-party1 in accordance with the above criteria.\n\
+            I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.\n\
             \n\
             These are testing notes. They contain some\n\
             newlines. Trailing whitespace        \n    \

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -152,6 +152,69 @@ fn mock_simple_certify_flow() {
 }
 
 #[test]
+fn mock_delta_certify_flow() {
+    let mock = MockMetadata::simple();
+
+    let _enter = TEST_RUNTIME.enter();
+    let metadata = mock.metadata();
+
+    let (config, audits, imports) = files_inited(&metadata);
+
+    let mut store = Store::mock(config, audits, imports);
+
+    let output = BasicTestOutput::with_callbacks(
+        |_| Ok("\n".to_owned()),
+        |_| {
+            Ok("\
+            I, testing, certify that I have audited the changes from version 10.0.0 to 10.0.1 of third-party1 in accordance with the above criteria.\n\
+            \n\
+            These are testing notes. They contain some\n\
+            newlines. Trailing whitespace        \n    \
+            and leading whitespace\n\
+            \n".to_owned())
+        },
+    );
+
+    let cfg = mock_cfg_args(
+        &metadata,
+        [
+            "cargo",
+            "vet",
+            "certify",
+            "third-party1",
+            "10.0.0",
+            "10.0.1",
+            "--who",
+            "testing",
+            "--criteria",
+            "safe-to-deploy",
+        ],
+    );
+    let sub_args = if let Some(crate::cli::Commands::Certify(sub_args)) = &cfg.cli.command {
+        sub_args
+    } else {
+        unreachable!();
+    };
+
+    crate::do_cmd_certify(
+        &output.clone().as_dyn(),
+        &cfg,
+        sub_args,
+        &mut store,
+        None,
+        None,
+        chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
+    )
+    .expect("do_cmd_certify failed");
+
+    let audits = crate::serialization::to_formatted_toml(&store.audits).unwrap();
+
+    let result = format!("OUTPUT:\n{output}\nAUDITS:\n{audits}");
+
+    insta::assert_snapshot!("mock-delta-certify-flow", result);
+}
+
+#[test]
 fn mock_wildcard_certify_flow() {
     let mock = MockMetadata::simple();
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-delta-certify-flow.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-delta-certify-flow.snap
@@ -1,0 +1,74 @@
+---
+source: src/tests/certify.rs
+expression: result
+---
+OUTPUT:
+<<<EDITING VET_CERTIFY>>>
+# Please read the following criteria and then follow the instructions below:
+
+# === BEGIN CRITERIA "safe-to-deploy" ===
+#
+# This crate will not introduce a serious security vulnerability to production
+# software exposed to untrusted input.
+#
+# Auditors are not required to perform a full logic review of the entire crate.
+# Rather, they must review enough to fully reason about the behavior of all unsafe
+# blocks and usage of powerful imports. For any reasonable usage of the crate in
+# real-world software, an attacker must not be able to manipulate the runtime
+# behavior of these sections in an exploitable or surprising way.
+#
+# Ideally, all unsafe code is fully sound, and ambient capabilities (e.g.
+# filesystem access) are hardened against manipulation and consistent with the
+# advertised behavior of the crate. However, some discretion is permitted. In such
+# cases, the nature of the discretion should be recorded in the `notes` field of
+# the audit record.
+#
+# For crates which generate deployed code (e.g. build dependencies or procedural
+# macros), reasonable usage of the crate should output code which meets the above
+# criteria.
+#
+# === END CRITERIA ===
+#
+# Uncomment the following statement:
+
+# I, testing, certify that I have audited the changes from version 10.0.0 to 10.0.1 of third-party1 in accordance with the above criteria.
+
+# Add any notes about your audit below this line:
+
+
+<<<EDIT OK>>>
+I, testing, certify that I have audited the changes from version 10.0.0 to 10.0.1 of third-party1 in accordance with the above criteria.
+
+These are testing notes. They contain some
+newlines. Trailing whitespace        
+    and leading whitespace
+
+
+<<<END EDIT>>>
+
+AUDITS:
+
+[criteria.fuzzed]
+description = "fuzzed"
+
+[criteria.reviewed]
+description = "reviewed"
+implies = "weak-reviewed"
+
+[criteria.strong-reviewed]
+description = "strongly reviewed"
+implies = "reviewed"
+
+[criteria.weak-reviewed]
+description = "weakly reviewed"
+
+[[audits.third-party1]]
+who = "testing"
+criteria = "safe-to-deploy"
+delta = "10.0.0 -> 10.0.1"
+notes = """
+These are testing notes. They contain some
+newlines. Trailing whitespace
+    and leading whitespace
+"""
+

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
@@ -45,13 +45,13 @@ current selection: ["safe-to-deploy"]
 #
 # Uncomment the following statement:
 
-# I, testing, certify that I have audited all versions published by user 'testuser' between 2022-12-12 and 2024-01-01 of third-party1 in accordance with the above criteria.
+# I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.
 
 # Add any notes about your audit below this line:
 
 
 <<<EDIT OK>>>
-I, testing, certify that I have audited all versions published by user 'testuser' between 2022-12-12 and 2024-01-01 of third-party1 in accordance with the above criteria.
+I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.
 
 These are testing notes. They contain some
 newlines. Trailing whitespace        


### PR DESCRIPTION
- Add a test for the delta certification flow.
- Reword the certification message for wildcard audits.
