### PR TITLE
Pass a high visibility parameter when loading sourcegraph diffs.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1528,7 +1528,7 @@ fn cmd_diff(out: &Arc<dyn Out>, cfg: &Config, sub_args: &DiffArgs) -> Result<(),
             && version2.git_rev.is_none()
         {
             let url = format!(
-                "https://sourcegraph.com/crates/{package}/-/compare/v{version1}...v{version2}"
+                "https://sourcegraph.com/crates/{package}/-/compare/v{version1}...v{version2}?visible=1000000"
             );
             tokio::runtime::Handle::current()
                 .block_on(prompt_criteria_eulas(


### PR DESCRIPTION
Sourcegraph currently divides segments long diffs into multiple pages,
with a "show more" button at the bottom (see [1] for an example).

Unfortunately, the "show more" button is small and easy to miss, which
could result in people mistakenly auditing only a subset of the diff. As
an interim fix, Sourcegraph just recommends passing a high value for
the "visibility" parameter. This parameter controls the number of files
whose diff is displayed, and assuming it's higher than the number of
actual files present in the diff, will redirect to the latter (so
passing ?visiblity=1000000 will result in ?visibility=24 showing in the
URL bar in the below example).

[1] https://sourcegraph.com/crates/async-task/-/compare/v4.0.3...v4.3.0
