### PR TITLE
Track the version of cargo-vet used to create the supply-chain store

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -546,6 +546,7 @@ pub fn init_files(
                 .push(item);
         }
         ConfigFile {
+            cargo_vet: Default::default(),
             default_criteria: format::get_default_criteria(),
             imports: SortedMap::new(),
             exemptions: dependencies,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -756,6 +756,9 @@ mod test {
         );
 
         let formatted = super::to_formatted_toml(ConfigFile {
+            cargo_vet: CargoVetConfig {
+                version: StoreVersion { major: 1, minor: 0 },
+            },
             default_criteria: get_default_criteria(),
             imports: SortedMap::new(),
             policy,

--- a/src/snapshots/cargo_vet__serialization__test__formatted_toml_long_inline.snap
+++ b/src/snapshots/cargo_vet__serialization__test__formatted_toml_long_inline.snap
@@ -3,6 +3,9 @@ source: src/serialization.rs
 expression: formatted
 ---
 
+[cargo-vet]
+version = "1.0"
+
 [policy.long-criteria]
 criteria = "long-criteria"
 notes = "notes go here!"

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_certify.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_certify.snap
@@ -7,6 +7,9 @@ config.toml:
  
  # cargo-vet config file
  
+ [cargo-vet]
+ version = "1.0"
+ 
  [imports.peer-company]
  url = "https://peercompany.co.uk"
  

--- a/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_prune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__peer_audits_exemption_minimize_prune.snap
@@ -7,6 +7,9 @@ config.toml:
  
  # cargo-vet config file
  
+ [cargo-vet]
+ version = "1.0"
+ 
  [imports.peer-company]
  url = "https://peercompany.co.uk"
 -

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
@@ -10,7 +10,7 @@ Error:
   │ 
   │ --- old/config.toml
   │ +++ new/config.toml
-  │ @@ -8,14 +8,14 @@
+  │ @@ -11,14 +11,14 @@
   │  [imports.peer2]
   │  url = "https://peer1.com"
   │ 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_config.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__many_bad_config.snap
@@ -7,47 +7,47 @@ expression: acquire_errors
 
 Error: 
   × 'oops' is not a valid criteria name
-    ╭─[config.toml:18:1]
- 18 │ version = "1.0.0"
- 19 │ criteria = "oops"
+    ╭─[config.toml:21:1]
+ 21 │ version = "1.0.0"
+ 22 │ criteria = "oops"
     ·            ──────
- 20 │ 
+ 23 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'bad' is not a valid criteria name
-    ╭─[config.toml:12:1]
- 12 │ [policy.serde]
- 13 │ criteria = "bad"
+    ╭─[config.toml:15:1]
+ 15 │ [policy.serde]
+ 16 │ criteria = "bad"
     ·            ─────
- 14 │ dev-criteria = "nope"
+ 17 │ dev-criteria = "nope"
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'nope' is not a valid criteria name
-    ╭─[config.toml:13:1]
- 13 │ criteria = "bad"
- 14 │ dev-criteria = "nope"
+    ╭─[config.toml:16:1]
+ 16 │ criteria = "bad"
+ 17 │ dev-criteria = "nope"
     ·                ──────
- 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+ 18 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'unsafe-for-all' is not a valid criteria name
-    ╭─[config.toml:14:1]
- 14 │ dev-criteria = "nope"
- 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+    ╭─[config.toml:17:1]
+ 17 │ dev-criteria = "nope"
+ 18 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
     ·                                                ────────────────
- 16 │ 
+ 19 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 Error: 
   × 'nada' is not a valid criteria name
-    ╭─[config.toml:14:1]
- 14 │ dev-criteria = "nope"
- 15 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
+    ╭─[config.toml:17:1]
+ 17 │ dev-criteria = "nope"
+ 18 │ dependency-criteria = { clap = ["safe-to-run", "unsafe-for-all", "good"], serde_derive = "nada" }
     ·                                                                                          ──────
- 16 │ 
+ 19 │ 
     ╰────
   help: the possible criteria are ["good", "safe-to-run", "safe-to-deploy"]
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_config.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_config.snap
@@ -10,7 +10,7 @@ Error:
   │ 
   │ --- old/config.toml
   │ +++ new/config.toml
-  │ @@ -4,9 +4,7 @@
+  │ @@ -7,9 +7,7 @@
   │  [imports.peer1]
   │  url = "https://peer1.com"
   │  exclude = ["zzz", "aaa"]

--- a/src/tests/store_parsing.rs
+++ b/src/tests/store_parsing.rs
@@ -1,5 +1,8 @@
 const EMPTY_CONFIG: &str = r##"
 # cargo-vet config file
+
+[cargo-vet]
+version = "1.0"
 "##;
 const EMPTY_AUDITS: &str = r##"
 # cargo-vet audits file
@@ -84,6 +87,9 @@ fn test_many_bad_config() {
     let config = r##"
 # cargo-vet config file
 
+[cargo-vet]
+version = "1.0"
+
 [policy.boring]
 audit-as-crates-io = true
 
@@ -125,6 +131,9 @@ fn test_outdated_imports_lock_extra_peer() {
     let config = r##"
 # cargo-vet config file
 
+[cargo-vet]
+version = "1.0"
+
 [imports.peer1]
 url = "https://peer1.com"
 "##;
@@ -150,6 +159,9 @@ fn test_outdated_imports_lock_missing_peer() {
     let config = r##"
 # cargo-vet config file
 
+[cargo-vet]
+version = "1.0"
+
 [imports.peer1]
 url = "https://peer1.com"
 
@@ -173,6 +185,9 @@ version = "10.0.0"
 fn test_outdated_imports_lock_excluded_crate() {
     let config = r##"
 # cargo-vet config file
+
+[cargo-vet]
+version = "1.0"
 
 [imports.peer1]
 url = "https://peer1.com"
@@ -199,6 +214,9 @@ version = "10.0.0"
 fn test_outdated_imports_lock_ok() {
     let config = r##"
 # cargo-vet config file
+
+[cargo-vet]
+version = "1.0"
 
 [imports.peer1]
 url = "https://peer1.com"
@@ -228,6 +246,9 @@ version = "10.0.0"
 fn test_unknown_field_config() {
     let config = r##"
 # cargo-vet config file
+
+[cargo-vet]
+version = "1.0"
 
 [imports.peer1]
 url = "https://peer1.com"
@@ -334,6 +355,9 @@ fn test_invalid_formatting() {
     let config = r##"
 # cargo-vet config file
 
+[cargo-vet]
+version = "1.0"
+
 [imports.peer1]
 url = "https://peer1.com"
 exclude = ["zzz", "aaa"]
@@ -391,6 +415,9 @@ version = "10.0.0"
 fn parse_criteria_map() {
     let config = r##"
 # cargo-vet config file
+
+[cargo-vet]
+version = "1.0"
 
 [imports.peer1]
 url = "https://peer1.com"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,6 +1,9 @@
 
 # cargo-vet config file
 
+[cargo-vet]
+version = "0.4"
+
 [imports.bytecodealliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -1,6 +1,9 @@
 
 # cargo-vet config file
 
+[cargo-vet]
+version = "0.4"
+
 [policy."clap:3.1.8"]
 dependency-criteria = { atty = "safe-to-run", bitflags = ["audited", "fuzzed"] }
 


### PR DESCRIPTION
This is important given changes like https://github.com/mozilla/cargo-vet/issues/431, which will change the meaning of imports.lock in such a way that earlier versions of cargo-vet may not understand parts of it correctly anymore. While we generally need to keep the audits.toml file somewhat forward-and-back compatible due to imports, this is
less of a concern for other files, so preventing downgrades could be valuable here.

This new approach allows implicit upgrades when running without --locked, but prevents downgrades or locked upgrades. cargo-vet versions with the same minor release are considered compatible, so only the major and minor components are considered.

Fixes https://github.com/mozilla/cargo-vet/issues/430