### PR TITLE
Default audit-as-crates-io to true on init if description matches

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1060,7 +1060,16 @@ pub struct CratesAPIVersion {
 
 // NOTE: This is a subset of the format returned from the crates.io v1 API.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CratesAPICrateMetadata {
+    pub description: Option<String>,
+    pub repository: Option<String>,
+}
+
+// NOTE: This is a subset of the format returned from the crates.io v1 API.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CratesAPICrate {
+    #[serde(rename = "crate")]
+    pub crate_data: CratesAPICrateMetadata,
     pub versions: Vec<CratesAPIVersion>,
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -172,7 +172,7 @@ impl Store {
             lock: Some(lock),
             config: ConfigFile {
                 cargo_vet: Default::default(),
-                default_criteria: String::new(),
+                default_criteria: format::get_default_criteria(),
                 imports: SortedMap::new(),
                 policy: Default::default(),
                 exemptions: SortedMap::new(),

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -257,6 +257,7 @@ fn mock_wildcard_certify_flow() {
     network.mock_serve_json(
         "https://crates.io/api/v1/crates/third-party1",
         &serde_json::json!({
+            "crate": { "description": "description" },
             "versions": [
                 {
                     "crate": "third-party1",

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -180,6 +180,7 @@ fn existing_peer_skip_import() {
     network.mock_serve_json(
         "https://crates.io/api/v1/crates/third-party2",
         &serde_json::json!({
+            "crate": { "description": "description" },
             "versions": [
                 {
                     "crate": "third-party2",
@@ -1495,6 +1496,7 @@ fn import_wildcard_audit_publisher() {
     network.mock_serve_json(
         "https://crates.io/api/v1/crates/third-party1",
         &serde_json::json!({
+            "crate": { "description": "description" },
             "versions": [
                 {
                     "crate": "third-party1",
@@ -1524,6 +1526,7 @@ fn import_wildcard_audit_publisher() {
     network.mock_serve_json(
         "https://crates.io/api/v1/crates/third-party2",
         &serde_json::json!({
+            "crate": { "description": "description" },
             "versions": [
                 {
                     "crate": "third-party2",


### PR DESCRIPTION
This adds an extra layer of checking above name/version against crates.io, of also checking if the crate's description appears to match. This is done by querying the crates.io API to get the published description for the most recent version.

This also required changing how we initialize exemptions when initialize a new repo. The new logic now relies on the regenerate-exemptions logic, and is run after fix_audit_as. This also required changing how test setup works under the hood to create a mock store. We may want to tweak this in the future.