### PR TITLE
Allow import and registry URLs to be an array

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -511,12 +511,12 @@ pub struct ImportArgs {
     /// The name of the peer to import
     #[clap(action)]
     pub name: ImportName,
-    /// The URL of the peer's audits.toml file.
+    /// The URL(s) of the peer's audits.toml file(s).
     ///
     /// If a URL is not provided, a peer with the given name will be looked up
-    /// in the cargo-vet registry to determine the import URL.
+    /// in the cargo-vet registry to determine the import URL(s).
     #[clap(action)]
-    pub url: Option<String>,
+    pub url: Vec<String>,
 }
 
 /// Forbids the given version

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -738,6 +738,12 @@ pub enum FetchAuditError {
         #[source]
         error: url::ParseError,
     },
+    #[error("error when aggregating multiple sources for {import_name}")]
+    Aggregate {
+        import_name: ImportName,
+        #[related]
+        errors: Vec<AggregateError>,
+    },
     #[diagnostic(transparent)]
     #[error(transparent)]
     Download(#[from] DownloadError),

--- a/src/format.rs
+++ b/src/format.rs
@@ -700,7 +700,7 @@ pub static DEFAULT_POLICY_DEV_CRITERIA: CriteriaStr = SAFE_TO_RUN;
 /// A remote audits.toml that we trust the contents of (by virtue of trusting the maintainer).
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct RemoteImport {
-    /// URL of the foreign audits.toml
+    /// URL(s) of the foreign audits.toml
     #[serde(with = "serialization::string_or_vec")]
     pub url: Vec<String>,
     /// A list of crates for which no audits or violations should be imported.

--- a/src/format.rs
+++ b/src/format.rs
@@ -701,7 +701,8 @@ pub static DEFAULT_POLICY_DEV_CRITERIA: CriteriaStr = SAFE_TO_RUN;
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Default)]
 pub struct RemoteImport {
     /// URL of the foreign audits.toml
-    pub url: String,
+    #[serde(with = "serialization::string_or_vec")]
+    pub url: Vec<String>,
     /// A list of crates for which no audits or violations should be imported.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
@@ -1090,7 +1091,8 @@ pub struct RegistryFile {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RegistryEntry {
-    pub url: String,
+    #[serde(with = "serialization::string_or_vec")]
+    pub url: Vec<String>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -158,7 +158,7 @@ pub struct DiffRecommendation {
 #[derive(Debug, Clone)]
 pub struct RegistrySuggestion {
     pub name: ImportName,
-    pub url: String,
+    pub url: Vec<String>,
     pub diff: DiffRecommendation,
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -32,12 +32,11 @@ use crate::{
     flock::{FileLock, Filesystem},
     format::{
         self, AuditEntry, AuditKind, AuditedDependencies, AuditsFile, CommandHistory, ConfigFile,
-        CratesAPICrate, CratesPublisher, CriteriaEntry, CriteriaName, CriteriaStr, Delta,
-        DiffCache, DiffStat, FastMap, FastSet, FetchCommand, ForeignAuditsFile, ImportName,
+        CratesAPICrate, CratesPublisher, CriteriaEntry, CriteriaMap, CriteriaName, CriteriaStr,
+        Delta, DiffCache, DiffStat, FastMap, FastSet, FetchCommand, ForeignAuditsFile, ImportName,
         ImportsFile, MetaConfig, PackageName, PackageStr, PublisherCache, PublisherCacheEntry,
-        PublisherCacheUser, PublisherCacheVersion, RegistryEntry, RegistryFile, RemoteImport,
-        SortedMap, StoreVersion, VetVersion, WildcardAudits, WildcardEntry, SAFE_TO_DEPLOY,
-        SAFE_TO_RUN,
+        PublisherCacheUser, PublisherCacheVersion, RegistryEntry, RegistryFile, SortedMap,
+        StoreVersion, VetVersion, WildcardAudits, WildcardEntry, SAFE_TO_DEPLOY, SAFE_TO_RUN,
     },
     network::Network,
     out::{indeterminate_spinner, progress_bar, IncProgressOnDrop},
@@ -285,14 +284,11 @@ impl Store {
 
         // If this command isn't locked, and the network is available, fetch the
         // live state of imported audits.
-        let fetched_audits = fetch_imported_audits(network, &self.config).await?;
-        let mut live_imports = process_imported_audits(
-            fetched_audits,
-            &self.audits,
-            &self.config,
-            &self.imports,
-            allow_criteria_changes,
-        )?;
+        let local_criteria_mapper = CriteriaMapper::new(&self.audits.criteria);
+        let fetched_audits =
+            fetch_imported_audits(network, &local_criteria_mapper, &self.config).await?;
+        let mut live_imports =
+            process_imported_audits(fetched_audits, &self.imports, allow_criteria_changes)?;
         import_publisher_versions(
             &cfg.metadata,
             network,
@@ -339,15 +335,14 @@ impl Store {
         network: &Network,
         allow_criteria_changes: bool,
     ) -> Result<Self, StoreAcquireError> {
-        let fetched_audits =
-            tokio::runtime::Handle::current().block_on(fetch_imported_audits(network, &config))?;
-        let mut live_imports = process_imported_audits(
-            fetched_audits,
-            &audits,
+        let local_criteria_mapper = CriteriaMapper::new(&audits.criteria);
+        let fetched_audits = tokio::runtime::Handle::current().block_on(fetch_imported_audits(
+            network,
+            &local_criteria_mapper,
             &config,
-            &imports,
-            allow_criteria_changes,
-        )?;
+        ))?;
+        let mut live_imports =
+            process_imported_audits(fetched_audits, &imports, allow_criteria_changes)?;
         let cache = Cache::acquire(cfg).map_err(Box::new)?;
         tokio::runtime::Handle::current()
             .block_on(import_publisher_versions(
@@ -777,25 +772,20 @@ impl Store {
                     .map(|(name, entry)| (name.clone(), entry.clone()))
                     .map(|(name, entry)| async {
                         let _guard = IncProgressOnDrop(&progress_bar, 1);
-                        match fetch_imported_audit(network, &name, &entry.url).await {
-                            Ok(audit_file) => {
-                                let audit_file = process_imported_audit(
-                                    audit_file,
-                                    &local_criteria_mapper,
-                                    &RemoteImport {
-                                        url: entry.url.clone(),
-                                        ..Default::default()
-                                    },
-                                    None,
-                                    |_, _, _| (),
-                                );
-                                Some((name, entry, audit_file))
-                            }
-                            Err(error) => {
-                                error!("Error fetching registry audits for '{name}': {error:?}");
-                                None
-                            }
-                        }
+                        fetch_imported_audit(
+                            network,
+                            &local_criteria_mapper,
+                            &name,
+                            &entry.url,
+                            &[],
+                            &SortedMap::new(),
+                        )
+                        .await
+                        .map_err(|error| {
+                            error!("Error fetching registry audits for '{name}': {error:?}")
+                        })
+                        .map(|audit_file| (name, entry, audit_file))
+                        .ok()
                     }),
             )
             .await
@@ -836,8 +826,6 @@ impl Store {
 /// description of the live state of imported audits.
 fn process_imported_audits(
     fetched_audits: Vec<(ImportName, AuditsFile)>,
-    local_audits_file: &AuditsFile,
-    config_file: &ConfigFile,
     imports_lock: &ImportsFile,
     allow_criteria_changes: bool,
 ) -> Result<ImportsFile, CriteriaChangeErrors> {
@@ -847,32 +835,31 @@ fn process_imported_audits(
     };
     let mut changed_criteria = Vec::new();
 
-    let local_criteria_mapper = CriteriaMapper::new(&local_audits_file.criteria);
-    for (import_name, audits_file) in fetched_audits {
-        let config = config_file
-            .imports
-            .get(&import_name)
-            .expect("fetched audit without config?");
-        let existing_audits_file = imports_lock.audits.get(&import_name);
-
-        let audits_file = process_imported_audit(
-            audits_file,
-            &local_criteria_mapper,
-            config,
-            existing_audits_file,
-            |criteria_name, old_desc, new_desc| {
-                if !allow_criteria_changes {
-                    // Compare the new criteria descriptions with existing criteria
-                    // descriptions. If the description already exists, record a
-                    // CriteriaChangeError.
-                    changed_criteria.push(CriteriaChangeError {
-                        import_name: import_name.clone(),
-                        criteria_name: criteria_name.to_owned(),
-                        unified_diff: unified_diff(Algorithm::Myers, old_desc, new_desc, 5, None),
-                    });
-                }
-            },
-        );
+    for (import_name, mut audits_file) in fetched_audits {
+        if let Some(existing_audits_file) = imports_lock.audits.get(&import_name) {
+            update_import_freshness(
+                &mut audits_file,
+                existing_audits_file,
+                |criteria_name, old_desc, new_desc| {
+                    if !allow_criteria_changes {
+                        // Compare the new criteria descriptions with existing criteria
+                        // descriptions. If the description already exists, record a
+                        // CriteriaChangeError.
+                        changed_criteria.push(CriteriaChangeError {
+                            import_name: import_name.clone(),
+                            criteria_name: criteria_name.to_owned(),
+                            unified_diff: unified_diff(
+                                Algorithm::Myers,
+                                old_desc,
+                                new_desc,
+                                5,
+                                None,
+                            ),
+                        });
+                    }
+                },
+            );
+        }
 
         // Now add the new import
         new_imports.audits.insert(import_name, audits_file);
@@ -890,146 +877,77 @@ fn process_imported_audits(
     Ok(new_imports)
 }
 
-fn process_imported_audit(
-    mut audits_file: AuditsFile,
-    local_criteria_mapper: &CriteriaMapper,
-    config: &RemoteImport,
-    existing_audits_file: Option<&AuditsFile>,
+fn update_import_freshness(
+    audits_file: &mut AuditsFile,
+    existing_audits_file: &AuditsFile,
     mut on_changed_criteria_description: impl FnMut(CriteriaStr<'_>, &str, &str),
-) -> AuditsFile {
-    // Remove any excluded audits from the live copy. We'll effectively
-    // pretend they don't exist upstream.
-    for excluded in &config.exclude {
-        audits_file.audits.remove(excluded);
-    }
-
-    // Construct a mapping from the foreign criteria namespace into the
-    // local criteria namespace based on the criteria map from the config.
-    let foreign_criteria_mapper = CriteriaMapper::new(&audits_file.criteria);
-    let foreign_to_local_mapping: Vec<_> = foreign_criteria_mapper
-        .all_criteria_names()
-        .map(|foreign_name| {
-            // NOTE: We try the map before we check for built-in criteria to
-            // allow overriding the default behaviour.
-            if let Some(mapped) = config.criteria_map.get(foreign_name) {
-                local_criteria_mapper.criteria_from_list(mapped)
-            } else if foreign_name == SAFE_TO_DEPLOY {
-                local_criteria_mapper.criteria_from_list([SAFE_TO_DEPLOY])
-            } else if foreign_name == SAFE_TO_RUN {
-                local_criteria_mapper.criteria_from_list([SAFE_TO_RUN])
-            } else {
-                local_criteria_mapper.no_criteria()
-            }
-        })
-        .collect();
-
-    // Helper to re-write foreign criteria into the local criteria
-    // namespace.
-    let make_criteria_local = |criteria: &mut Vec<Spanned<CriteriaName>>| {
-        let foreign_set = foreign_criteria_mapper.criteria_from_list(&*criteria);
-        let mut local_set = local_criteria_mapper.no_criteria();
-        for foreign_criteria_idx in foreign_set.indices() {
-            local_set.unioned_with(&foreign_to_local_mapping[foreign_criteria_idx]);
-        }
-        *criteria = local_criteria_mapper
-            .criteria_names(&local_set)
-            .map(|name| name.to_owned().into())
-            .collect();
-    };
-
-    // By default all audits read from the network are fresh.
-    //
-    // Note: This may leave behind useless audits which imply no criteria,
-    // but that's OK - we'll never choose to import them. In the future we
-    // might want to trim them.
-    for audit_entry in audits_file.audits.values_mut().flat_map(|v| v.iter_mut()) {
-        audit_entry.is_fresh_import = true;
-        make_criteria_local(&mut audit_entry.criteria);
-    }
-    for audit_entry in audits_file
-        .wildcard_audits
-        .values_mut()
-        .flat_map(|v| v.iter_mut())
-    {
-        audit_entry.is_fresh_import = true;
-        make_criteria_local(&mut audit_entry.criteria);
-    }
-
-    // Now that we're done with foreign criteria, trim the set to only
-    // contain mapped criteria, as we don't care about other criteria, so
-    // shouldn't bother importing them.
-    //
-    // We also clear out description_url and implies, as those fields will
-    // not be used locally.
-    audits_file.criteria.retain(|name, entry| {
-        entry.description_url = None;
-        entry.implies = Vec::new();
-        config.criteria_map.contains_key(name)
-    });
-
-    // If we have an existing audits file for these imports, compare against it.
-    if let Some(existing_audits_file) = existing_audits_file {
-        // Compare the new criteria descriptions with existing criteria
-        // descriptions. If the description already exists, notify our caller.
-        for (criteria_name, old_entry) in &existing_audits_file.criteria {
-            if let Some(new_entry) = audits_file.criteria.get(criteria_name) {
-                let old_desc = old_entry.description.as_ref().unwrap();
-                let new_desc = new_entry.description.as_ref().unwrap();
-                if old_desc != new_desc {
-                    on_changed_criteria_description(criteria_name, old_desc, new_desc);
-                }
+) {
+    // Compare the new criteria descriptions with existing criteria
+    // descriptions. If the description already exists, notify our caller.
+    for (criteria_name, old_entry) in &existing_audits_file.criteria {
+        if let Some(new_entry) = audits_file.criteria.get(criteria_name) {
+            let old_desc = old_entry.description.as_ref().unwrap();
+            let new_desc = new_entry.description.as_ref().unwrap();
+            if old_desc != new_desc {
+                on_changed_criteria_description(criteria_name, old_desc, new_desc);
             }
         }
+    }
 
-        // Compare the new audits with existing audits. If an audit already
-        // existed in the existing audits file, mark it as non-fresh.
-        for (package, existing_audits) in &existing_audits_file.audits {
-            let new_audits = audits_file
-                .audits
-                .get_mut(package)
-                .map(|v| &mut v[..])
-                .unwrap_or(&mut []);
-            for existing_audit in existing_audits {
-                for new_audit in &mut *new_audits {
-                    if new_audit.is_fresh_import && new_audit.same_audit_as(existing_audit) {
-                        new_audit.is_fresh_import = false;
-                        break;
-                    }
-                }
-            }
-        }
-        for (package, existing_audits) in &existing_audits_file.wildcard_audits {
-            let new_audits = audits_file
-                .wildcard_audits
-                .get_mut(package)
-                .map(|v| &mut v[..])
-                .unwrap_or(&mut []);
-            for existing_audit in existing_audits {
-                for new_audit in &mut *new_audits {
-                    if new_audit.is_fresh_import && new_audit.same_audit_as(existing_audit) {
-                        new_audit.is_fresh_import = false;
-                        break;
-                    }
+    // Compare the new audits with existing audits. If an audit already
+    // existed in the existing audits file, mark it as non-fresh.
+    for (package, existing_audits) in &existing_audits_file.audits {
+        let new_audits = audits_file
+            .audits
+            .get_mut(package)
+            .map(|v| &mut v[..])
+            .unwrap_or(&mut []);
+        for existing_audit in existing_audits {
+            for new_audit in &mut *new_audits {
+                if new_audit.is_fresh_import && new_audit.same_audit_as(existing_audit) {
+                    new_audit.is_fresh_import = false;
+                    break;
                 }
             }
         }
     }
-
-    audits_file
+    for (package, existing_audits) in &existing_audits_file.wildcard_audits {
+        let new_audits = audits_file
+            .wildcard_audits
+            .get_mut(package)
+            .map(|v| &mut v[..])
+            .unwrap_or(&mut []);
+        for existing_audit in existing_audits {
+            for new_audit in &mut *new_audits {
+                if new_audit.is_fresh_import && new_audit.same_audit_as(existing_audit) {
+                    new_audit.is_fresh_import = false;
+                    break;
+                }
+            }
+        }
+    }
 }
 
-/// Fetch all declared imports from the network, filling in any criteria
-/// descriptions.
+/// Fetch all declared imports from the network, mapping criteria to the local
+/// namespace, and filling in any criteria descriptions.
 async fn fetch_imported_audits(
     network: &Network,
+    local_criteria_mapper: &CriteriaMapper,
     config: &ConfigFile,
 ) -> Result<Vec<(ImportName, AuditsFile)>, Box<FetchAuditError>> {
     let progress_bar = progress_bar("Fetching", "imported audits", config.imports.len() as u64);
     try_join_all(config.imports.iter().map(|(name, import)| async {
         let _guard = IncProgressOnDrop(&progress_bar, 1);
-        let audit_file = fetch_imported_audit(network, name, &import.url)
-            .await
-            .map_err(Box::new)?;
+        let audit_file = fetch_imported_audit(
+            network,
+            local_criteria_mapper,
+            name,
+            &import.url,
+            &import.exclude,
+            &import.criteria_map,
+        )
+        .await
+        .map_err(Box::new)?;
         Ok::<_, Box<FetchAuditError>>((name.clone(), audit_file))
     }))
     .await
@@ -1039,8 +957,11 @@ async fn fetch_imported_audits(
 /// descriptions.
 async fn fetch_imported_audit(
     network: &Network,
+    local_criteria_mapper: &CriteriaMapper,
     name: &str,
     url: &str,
+    exclude: &[PackageName],
+    criteria_map: &CriteriaMap,
 ) -> Result<AuditsFile, FetchAuditError> {
     let parsed_url = Url::parse(url).map_err(|error| FetchAuditError::InvalidUrl {
         import_url: url.to_owned(),
@@ -1096,6 +1017,71 @@ async fn fetch_imported_audit(
         );
     }
 
+    // Remove any excluded audits from the live copy. We'll effectively
+    // pretend they don't exist upstream.
+    for excluded in exclude {
+        audit_file.audits.remove(excluded);
+    }
+
+    // Construct a mapping from the foreign criteria namespace into the
+    // local criteria namespace based on the criteria map from the config.
+    let foreign_criteria_mapper = CriteriaMapper::new(&audit_file.criteria);
+    let foreign_to_local_mapping: Vec<_> = foreign_criteria_mapper
+        .all_criteria_names()
+        .map(|foreign_name| {
+            // NOTE: We try the map before we check for built-in criteria to
+            // allow overriding the default behaviour.
+            if let Some(mapped) = criteria_map.get(foreign_name) {
+                local_criteria_mapper.criteria_from_list(mapped)
+            } else if foreign_name == SAFE_TO_DEPLOY {
+                local_criteria_mapper.criteria_from_list([SAFE_TO_DEPLOY])
+            } else if foreign_name == SAFE_TO_RUN {
+                local_criteria_mapper.criteria_from_list([SAFE_TO_RUN])
+            } else {
+                local_criteria_mapper.no_criteria()
+            }
+        })
+        .collect();
+
+    // Helper to re-write foreign criteria into the local criteria
+    // namespace.
+    let make_criteria_local = |criteria: &mut Vec<Spanned<CriteriaName>>| {
+        let foreign_set = foreign_criteria_mapper.criteria_from_list(&*criteria);
+        let mut local_set = local_criteria_mapper.no_criteria();
+        for foreign_criteria_idx in foreign_set.indices() {
+            local_set.unioned_with(&foreign_to_local_mapping[foreign_criteria_idx]);
+        }
+        *criteria = local_criteria_mapper
+            .criteria_names(&local_set)
+            .map(|name| name.to_owned().into())
+            .collect();
+    };
+
+    // By default all audits read from the network are fresh.
+    //
+    // Note: This may leave behind useless audits which imply no criteria,
+    // but that's OK - we'll never choose to import them. In the future we
+    // might want to trim them.
+    for audit_entry in audit_file.audits.values_mut().flat_map(|v| v.iter_mut()) {
+        audit_entry.is_fresh_import = true;
+        make_criteria_local(&mut audit_entry.criteria);
+    }
+    for audit_entry in audit_file
+        .wildcard_audits
+        .values_mut()
+        .flat_map(|v| v.iter_mut())
+    {
+        audit_entry.is_fresh_import = true;
+        make_criteria_local(&mut audit_entry.criteria);
+    }
+
+    // Now that we're done with foreign criteria, trim the set to only
+    // contain mapped criteria, as we don't care about other criteria, so
+    // shouldn't bother importing them.
+    audit_file
+        .criteria
+        .retain(|name, _| criteria_map.contains_key(name));
+
     // Eagerly fetch all descriptions for criteria in the imported audits file,
     // and store them inline. We'll error out if any of these descriptions are
     // unavailable.
@@ -1134,6 +1120,13 @@ async fn fetch_imported_audit(
             }),
     )
     .await?;
+
+    // Clear out the description URL and implies, as those will never be used
+    // locally.
+    for criteria_entry in audit_file.criteria.values_mut() {
+        criteria_entry.description_url = None;
+        criteria_entry.implies = Vec::new();
+    }
 
     Ok(audit_file)
 }

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -87,7 +87,7 @@ fn new_peer_import() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -99,7 +99,7 @@ fn new_peer_import() {
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -168,7 +168,7 @@ fn existing_peer_skip_import() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -250,7 +250,7 @@ fn existing_peer_remove_unused() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -343,7 +343,7 @@ fn existing_peer_import_delta_audit() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -355,7 +355,7 @@ fn existing_peer_import_delta_audit() {
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -426,7 +426,7 @@ fn existing_peer_import_custom_criteria() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 "fuzzed".to_string().into(),
                 vec![SAFE_TO_RUN.to_string().into()],
@@ -489,7 +489,7 @@ fn new_audit_for_unused_criteria_basic() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 "fuzzed".to_string().into(),
                 vec![SAFE_TO_RUN.to_string().into()],
@@ -556,7 +556,7 @@ fn new_audit_for_unused_criteria_transitive() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 "fuzzed".to_string().into(),
                 vec![SAFE_TO_RUN.to_string().into()],
@@ -616,7 +616,7 @@ fn existing_peer_revoked_audit() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -682,7 +682,7 @@ fn existing_peer_add_violation() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -733,7 +733,7 @@ fn peer_audits_exemption_no_minimize() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -813,7 +813,7 @@ fn peer_audits_exemption_minimize() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -920,7 +920,7 @@ fn peer_audits_import_exclusion() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             exclude: vec!["third-party1".to_owned(), "third-party2".to_owned()],
             ..Default::default()
         },
@@ -1005,7 +1005,7 @@ fn existing_peer_updated_description() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 "example".to_string().into(),
                 vec![SAFE_TO_DEPLOY.to_string().into()],
@@ -1069,14 +1069,14 @@ fn fresh_import_preferred_audits() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -1140,14 +1140,14 @@ fn old_import_preferred_audits() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -1197,7 +1197,7 @@ fn equal_length_preferred_audits() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -1244,7 +1244,7 @@ fn import_multiple_versions() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -1485,7 +1485,7 @@ fn import_wildcard_audit_publisher() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -1574,7 +1574,7 @@ fn import_criteria_map() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [
                 (
                     "foreign-reviewed".to_owned().into(),
@@ -1683,5 +1683,144 @@ fn import_criteria_map() {
     let store = Store::mock_online(&cfg, config, audits, imports, &network, true).unwrap();
 
     let output = get_imports_file_changes_prune(&metadata, &store);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn import_criteria_map_aggregated() {
+    // (Pass) When importing multiple sources, they should be aggregated using
+    // independent mapping of criteria. Because the foreign-criteria audit isn't
+    // mapped, there is no criteria mapping error.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = builtin_files_full_audited(&metadata);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: vec![FOREIGN_URL.to_owned(), OTHER_FOREIGN_URL.to_owned()],
+            ..Default::default()
+        },
+    );
+
+    audits.audits.remove("third-party1");
+
+    let new_foreign_audits = AuditsFile {
+        criteria: [(
+            "foreign-reviewed".to_string(),
+            criteria_implies("foreign reviewed A", [SAFE_TO_DEPLOY]),
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party1".to_owned(),
+            vec![full_audit(ver(9), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+        wildcard_audits: SortedMap::new(),
+    };
+
+    let new_other_foreign_audits = AuditsFile {
+        criteria: [(
+            "foreign-reviewed".to_string(),
+            criteria_implies("foreign reviewed B", [SAFE_TO_DEPLOY]),
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party1".to_owned(),
+            vec![delta_audit(ver(9), ver(DEFAULT_VER), "foreign-reviewed")],
+        )]
+        .into_iter()
+        .collect(),
+        wildcard_audits: SortedMap::new(),
+    };
+
+    let cfg = mock_cfg(&metadata);
+
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let store = Store::mock_online(&cfg, config, audits, imports, &network, true).unwrap();
+
+    let output = get_imports_file_changes_prune(&metadata, &store);
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn import_criteria_map_aggregated_error() {
+    // (Pass) If a foreign criteria is mapped, and has different descriptions it
+    // should produce an error when importing.
+
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (mut config, mut audits, imports) = files_full_audited(&metadata);
+
+    config.imports.insert(
+        FOREIGN.to_owned(),
+        crate::format::RemoteImport {
+            url: vec![FOREIGN_URL.to_owned(), OTHER_FOREIGN_URL.to_owned()],
+            criteria_map: [(
+                "foreign-reviewed".to_owned().into(),
+                vec!["reviewed".to_owned().into()],
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        },
+    );
+
+    audits.audits.remove("third-party1");
+
+    let new_foreign_audits = AuditsFile {
+        criteria: [(
+            "foreign-reviewed".to_string(),
+            criteria_implies("foreign reviewed A", [SAFE_TO_DEPLOY]),
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party1".to_owned(),
+            vec![full_audit(ver(9), SAFE_TO_DEPLOY)],
+        )]
+        .into_iter()
+        .collect(),
+        wildcard_audits: SortedMap::new(),
+    };
+
+    let new_other_foreign_audits = AuditsFile {
+        criteria: [(
+            "foreign-reviewed".to_string(),
+            criteria_implies("foreign reviewed B", [SAFE_TO_DEPLOY]),
+        )]
+        .into_iter()
+        .collect(),
+        audits: [(
+            "third-party1".to_owned(),
+            vec![delta_audit(ver(9), ver(DEFAULT_VER), "foreign-reviewed")],
+        )]
+        .into_iter()
+        .collect(),
+        wildcard_audits: SortedMap::new(),
+    };
+
+    let cfg = mock_cfg(&metadata);
+
+    let mut network = Network::new_mock();
+    network.mock_serve_toml(FOREIGN_URL, &new_foreign_audits);
+    network.mock_serve_toml(OTHER_FOREIGN_URL, &new_other_foreign_audits);
+
+    let output = match Store::mock_online(&cfg, config, audits, imports, &network, true) {
+        Ok(_) => panic!("unexpected success"),
+        Err(err) => format!("{:?}", miette::Report::new(err)),
+    };
+
     insta::assert_snapshot!(output);
 }

--- a/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/import.rs
+expression: output
+---
++
++[[audits.peer-company.audits.third-party1]]
++criteria = "safe-to-deploy"
++version = "9.0.0"
++aggregated-from = "https://peercompany.co.uk"
++
++[[audits.peer-company.audits.third-party1]]
++criteria = "safe-to-deploy"
++delta = "9.0.0 -> 10.0.0"
++aggregated-from = "https://rivalcompany.ca"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated_error.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated_error.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/import.rs
+expression: output
+---
+
+  × error when aggregating multiple sources for peer-company
+
+Error: 
+  × criteria description mismatch for foreign-reviewed
+  │ https://peercompany.co.uk:
+  │ foreign reviewed A
+  │ https://rivalcompany.ca:
+  │ foreign reviewed B
+

--- a/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated_error.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_criteria_map_aggregated_error.snap
@@ -4,6 +4,8 @@ expression: output
 ---
 
   × error when aggregating multiple sources for peer-company
+  help: all sources for mapped custom criteria must have identical
+        descriptions
 
 Error: 
   × criteria description mismatch for foreign-reviewed
@@ -11,4 +13,5 @@ Error:
   │ foreign reviewed A
   │ https://rivalcompany.ca:
   │ foreign reviewed B
+  help: foreign-reviewed is mapped to the local criteria ["reviewed"]
 

--- a/src/tests/vet.rs
+++ b/src/tests/vet.rs
@@ -2296,7 +2296,7 @@ fn builtin_simple_foreign_audited() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2324,7 +2324,7 @@ fn mock_simple_foreign_audited_pun_no_mapping() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2363,7 +2363,7 @@ fn mock_simple_foreign_audited_pun_mapped() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 DEFAULT_CRIT.to_owned().into(),
                 vec![DEFAULT_CRIT.to_owned().into()],
@@ -2407,7 +2407,7 @@ fn mock_simple_foreign_audited_pun_wrong_mapped() {
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             criteria_map: [(
                 DEFAULT_CRIT.to_owned().into(),
                 vec![DEFAULT_CRIT.to_owned().into()],
@@ -2420,7 +2420,7 @@ fn mock_simple_foreign_audited_pun_wrong_mapped() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2471,7 +2471,7 @@ fn builtin_simple_foreign_tag_team() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2510,7 +2510,7 @@ fn builtin_simple_mega_foreign_tag_team() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2530,7 +2530,7 @@ fn builtin_simple_mega_foreign_tag_team() {
     config.imports.insert(
         OTHER_FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: OTHER_FOREIGN_URL.to_owned(),
+            url: vec![OTHER_FOREIGN_URL.to_owned()],
             ..Default::default()
         },
     );
@@ -2559,13 +2559,13 @@ fn builtin_simple_registry_suggestions() {
                 (
                     FOREIGN.to_owned(),
                     RegistryEntry {
-                        url: FOREIGN_URL.to_owned(),
+                        url: vec![FOREIGN_URL.to_owned()],
                     },
                 ),
                 (
                     OTHER_FOREIGN.to_owned(),
                     RegistryEntry {
-                        url: OTHER_FOREIGN_URL.to_owned(),
+                        url: vec![OTHER_FOREIGN_URL.to_owned()],
                     },
                 ),
             ]

--- a/src/tests/wildcard.rs
+++ b/src/tests/wildcard.rs
@@ -151,7 +151,7 @@ fn imported_wildcard_audit() {
     config.imports.insert(
         FOREIGN.to_owned(),
         crate::format::RemoteImport {
-            url: FOREIGN_URL.to_owned(),
+            url: vec![FOREIGN_URL.to_owned()],
             criteria_map: [(
                 "example".to_owned().into(),
                 vec!["example".to_owned().into()],

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -400,18 +400,18 @@ import that peer.
 
 ### USAGE
 ```
-cargo vet import [OPTIONS] <NAME> [URL]
+cargo vet import [OPTIONS] <NAME> [URL]...
 ```
 
 ### ARGS
 #### `<NAME>`
 The name of the peer to import
 
-#### `<URL>`
-The URL of the peer's audits.toml file.
+#### `<URL>...`
+The URL(s) of the peer's audits.toml file(s).
 
 If a URL is not provided, a peer with the given name will be looked up in the cargo-vet
-registry to determine the import URL.
+registry to determine the import URL(s).
 
 ### OPTIONS
 #### `-h, --help`


### PR DESCRIPTION
This changes how imports are specified to allow specifying multiple URLs for an import. In the case where multiple URLs are specified, the import will implicitly aggregate the separate sources into a single import.

In addition, this patch changes how imports and registry suggestions are handled such that existing imports which match registry audits will still be checked for suggestions, and new imports performed by `cargo vet import` will overwrite existing imports with the same name.

Fixes #444