### PR TITLE
Recover gracefully from errors parsing the cargo-vet registry

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -302,6 +302,8 @@ pub enum CertifyError {
     #[error(transparent)]
     FetchAuditError(#[from] FetchAuditError),
     #[error(transparent)]
+    GetPublishersError(#[from] GetPublishersError),
+    #[error(transparent)]
     CacheAcquire(#[from] CacheAcquireError),
 }
 
@@ -378,6 +380,9 @@ pub enum StoreAcquireError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     FetchAuditError(#[from] Box<FetchAuditError>),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    GetPublishersError(#[from] Box<GetPublishersError>),
     #[diagnostic(transparent)]
     #[error(transparent)]
     CriteriaChange(#[from] CriteriaChangeErrors),
@@ -742,6 +747,36 @@ pub enum FetchAuditError {
     #[diagnostic(transparent)]
     #[error(transparent)]
     Json(#[from] LoadJsonError),
+}
+
+//////////////////////////////////////////////////////////
+// GetPublishersError
+//////////////////////////////////////////////////////////
+
+#[derive(Debug, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum GetPublishersError {
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Download(#[from] DownloadError),
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Json(#[from] LoadJsonError),
+}
+
+//////////////////////////////////////////////////////////
+// FetchRegistryError
+//////////////////////////////////////////////////////////
+
+#[derive(Debug, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum FetchRegistryError {
+    #[error("Encountered an error fetching the cargo-vet registry.")]
+    Download(#[from] DownloadError),
+    #[error("Import suggestions are disabled due to an incompatible registry. Consider upgrading to the most recent release of cargo-vet.")]
+    Toml(#[from] LoadTomlError),
+    #[error("Error when fetching publisher information. Registry suggestions may be incomplete.")]
+    GetPublishers(#[from] GetPublishersError),
 }
 
 //////////////////////////////////////////////////////////

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod certify;
 mod crate_policies;
 mod import;
 mod regenerate_unaudited;
+mod registry;
 mod store_parsing;
 mod vet;
 mod violations;

--- a/src/tests/registry.rs
+++ b/src/tests/registry.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[test]
+fn test_registry_parse_error() {
+    // Check that we can recover from an invalid registry with a useful error.
+    let _enter = TEST_RUNTIME.enter();
+    let mock = MockMetadata::simple();
+
+    let metadata = mock.metadata();
+    let (config, audits, imports) = builtin_files_no_exemptions(&metadata);
+
+    let mut network = Network::new_mock();
+    network.mock_serve(
+        crate::storage::REGISTRY_URL,
+        r#"
+[registry.remote]
+url = 10 # invalid!
+"#,
+    );
+
+    let cfg = mock_cfg(&metadata);
+
+    let store = Store::mock_online(&cfg, config, audits, imports, &network, false).unwrap();
+
+    let report = crate::resolver::resolve(&metadata, None, &store);
+    let suggest = report
+        .compute_suggest(&cfg, &store, Some(&network))
+        .unwrap();
+
+    let human_output = BasicTestOutput::new();
+    report
+        .print_human(&human_output.clone().as_dyn(), &cfg, suggest.as_ref())
+        .unwrap();
+
+    insta::assert_snapshot!(human_output.to_string());
+}

--- a/src/tests/snapshots/cargo_vet__tests__registry__registry_parse_error.snap
+++ b/src/tests/snapshots/cargo_vet__tests__registry__registry_parse_error.snap
@@ -1,0 +1,22 @@
+---
+source: src/tests/registry.rs
+expression: human_output.to_string()
+---
+Vetting Failed!
+
+3 unvetted dependencies:
+  third-party1:10.0.0 missing ["safe-to-deploy"]
+  third-party2:10.0.0 missing ["safe-to-deploy"]
+  transitive-third-party1:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect third-party1 10.0.0             (used by first-party)   (100 lines)
+    cargo vet inspect third-party2 10.0.0             (used by first-party)   (100 lines)
+    cargo vet inspect transitive-third-party1 10.0.0  (used by third-party1)  (100 lines)
+
+estimated audit backlog: 300 lines
+
+WARNING: Import suggestions are disabled due to an incompatible registry. Consider upgrading to the most recent release of cargo-vet.
+
+Use |cargo vet certify| to record the audits.
+

--- a/src/tests/snapshots/cargo_vet__tests__registry__test_registry_parse_error.snap
+++ b/src/tests/snapshots/cargo_vet__tests__registry__test_registry_parse_error.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/registry.rs
+expression: human
+---
+Vetting Failed!
+
+3 unvetted dependencies:
+  third-party1:10.0.0 missing ["safe-to-deploy"]
+  third-party2:10.0.0 missing ["safe-to-deploy"]
+  transitive-third-party1:10.0.0 missing ["safe-to-deploy"]
+
+recommended audits for safe-to-deploy:
+    cargo vet inspect third-party1 10.0.0             (used by first-party)   (100 lines)
+    cargo vet inspect third-party2 10.0.0             (used by first-party)   (100 lines)
+    cargo vet inspect transitive-third-party1 10.0.0  (used by third-party1)  (100 lines)
+
+estimated audit backlog: 300 lines
+
+Use |cargo vet certify| to record the audits.
+


### PR DESCRIPTION
This should avoid issues which could be caused by changes to the registry in the future making it no longer parse by older versions of cargo-vet. After this change, we should automatically recover by ignoring registry suggestions and showing a warning if there was an issue parsing the registry.