### PR TITLE
Replace "chromeos" entry with combined "google" entry.

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -1,14 +1,17 @@
 [registry.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 
-[registry.chromeos]
-url = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
-
 [registry.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
 
 [registry.fermyon]
 url = "https://raw.githubusercontent.com/fermyon/spin/main/supply-chain/audits.toml"
+
+[registry.google]
+url = [
+    "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT",
+    "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT",
+]
 
 [registry.isrg]
 url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"


### PR DESCRIPTION
The array syntax here requires version 0.6 or greater.