### PR TITLE
Add --store-path to CLI to specify supply-chain directory.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,10 +33,10 @@ pub struct Cli {
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub manifest_path: Option<PathBuf>,
 
-    /// Path to the audits directory
-    #[clap(long, name = "SUPPLY_CHAIN_DIR", parse(from_os_str))]
+    /// Path to the supply-chain directory
+    #[clap(long, name = "STORE_PATH", parse(from_os_str))]
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
-    pub config: Option<PathBuf>,
+    pub store_path: Option<PathBuf>,
 
     /// Don't use --all-features
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,11 @@ pub struct Cli {
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub manifest_path: Option<PathBuf>,
 
+    /// Path to the audits directory
+    #[clap(long, name = "SUPPLY_CHAIN_DIR", parse(from_os_str))]
+    #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
+    pub config: Option<PathBuf>,
+
     /// Don't use --all-features
     ///
     /// We default to passing --all-features to `cargo metadata`

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,7 +419,7 @@ fn real_main() -> Result<(), miette::Report> {
         })
         .transpose()?;
 
-    let cli_metacfg = cli.config.as_ref().map(|path| {
+    let cli_metacfg = cli.store_path.as_ref().map(|path| {
         MetaConfigInstance {
             version: Some(1),
             store: Some(StoreInfo {
@@ -434,13 +434,13 @@ fn real_main() -> Result<(), miette::Report> {
     }
 
     let mut metacfgs = vec![default_config];
-    if let Some(metacfg) = cli_metacfg {
-        metacfgs.push(metacfg);
-    }
     if let Some(metacfg) = workspace_metacfg {
         metacfgs.push(metacfg);
     }
     if let Some(metacfg) = package_metacfg {
+        metacfgs.push(metacfg);
+    }
+    if let Some(metacfg) = cli_metacfg {
         metacfgs.push(metacfg);
     }
     let metacfg = MetaConfig(metacfgs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,13 +419,11 @@ fn real_main() -> Result<(), miette::Report> {
         })
         .transpose()?;
 
-    let cli_metacfg = cli.store_path.as_ref().map(|path| {
-        MetaConfigInstance {
-            version: Some(1),
-            store: Some(StoreInfo {
-                path: Some(path.clone())
-            })
-        }
+    let cli_metacfg = cli.store_path.as_ref().map(|path| MetaConfigInstance {
+        version: Some(1),
+        store: Some(StoreInfo {
+            path: Some(path.clone()),
+        }),
     });
 
     if workspace_metacfg.is_some() && package_metacfg.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,12 +419,24 @@ fn real_main() -> Result<(), miette::Report> {
         })
         .transpose()?;
 
+    let cli_metacfg = cli.config.as_ref().map(|path| {
+        MetaConfigInstance {
+            version: Some(1),
+            store: Some(StoreInfo {
+                path: Some(path.clone())
+            })
+        }
+    });
+
     if workspace_metacfg.is_some() && package_metacfg.is_some() {
         // ERRORS: immediate fatal diagnostic
         return Err(miette!("Both a workspace and a package defined [metadata.vet]! We don't know what that means, if you do, let us know!"));
     }
 
     let mut metacfgs = vec![default_config];
+    if let Some(metacfg) = cli_metacfg {
+        metacfgs.push(metacfg);
+    }
     if let Some(metacfg) = workspace_metacfg {
         metacfgs.push(metacfg);
     }

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 104
 expression: format_outputs(&output)
 ---
 stdout:
@@ -23,6 +24,9 @@ OPTIONS:
 GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
+
+        --config <SUPPLY_CHAIN_DIR>
+            Path to the audits directory
 
         --no-all-features
             Don't use --all-features

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 104
 expression: format_outputs(&output)
 ---
 stdout:
@@ -25,8 +24,8 @@ GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
 
-        --config <SUPPLY_CHAIN_DIR>
-            Path to the audits directory
+        --store-path <STORE_PATH>
+            Path to the supply-chain directory
 
         --no-all-features
             Don't use --all-features

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 134
 expression: format_outputs(&output)
 ---
 stdout:
@@ -34,8 +33,8 @@ Print version information
 #### `--manifest-path <PATH>`
 Path to Cargo.toml
 
-#### `--config <SUPPLY_CHAIN_DIR>`
-Path to the audits directory
+#### `--store-path <STORE_PATH>`
+Path to the supply-chain directory
 
 #### `--no-all-features`
 Don't use --all-features

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 134
 expression: format_outputs(&output)
 ---
 stdout:
@@ -32,6 +33,9 @@ Print version information
 ### GLOBAL OPTIONS
 #### `--manifest-path <PATH>`
 Path to Cargo.toml
+
+#### `--config <SUPPLY_CHAIN_DIR>`
+Path to the audits directory
 
 #### `--no-all-features`
 Don't use --all-features

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test-cli.rs
-assertion_line: 119
 expression: format_outputs(&output)
 ---
 stdout:
@@ -19,8 +18,8 @@ GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
 
-        --config <SUPPLY_CHAIN_DIR>
-            Path to the audits directory
+        --store-path <STORE_PATH>
+            Path to the supply-chain directory
 
         --no-all-features
             Don't use --all-features

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 119
 expression: format_outputs(&output)
 ---
 stdout:
@@ -17,6 +18,9 @@ OPTIONS:
 GLOBAL OPTIONS:
         --manifest-path <PATH>
             Path to Cargo.toml
+
+        --config <SUPPLY_CHAIN_DIR>
+            Path to the audits directory
 
         --no-all-features
             Don't use --all-features


### PR DESCRIPTION
Our use case for this is the following:

* We want to import and build 3rd party Rust binaries -- such as `cargo-vet` itself.
* We want to apply our own auditing criteria, not necessarily what is use by the upstream maintainers.
* We want to leave the imported code untouched -- simply mirror the upstream repo, and not fork or maintain patches.

Without the ability to override the path to the supply-chain directory, we would have to fork or patch Config.toml to set `[package.metadata.vet]`.

As a side note, the behavior of `cargo vet` with respect to the current working directory differs from that of `cargo vendor`. `cargo vendor --manifest-path blah/Cargo.toml` uses a vendor directory in the current working directory, while `cargo vet init --manifest-path blah/Cargo.toml` creates a supply-chain directory in the same directory as the manifest.