### PR TITLE
Filter out missing information in `get_publishers`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1060,17 +1060,16 @@ pub struct CratesCacheVersionDetails {
     pub published_by: Option<CratesUserId>,
 }
 
-/// Versions are a sorted map because we sometimes need to iterate in order. We don't use a sorted
-/// Vec because we may partially update the versions when we access the index (though technically
-/// that update _should_ only have new versions which would append to a Vec if it were that).
-pub type CratesCacheVersions = SortedMap<semver::Version, Option<CratesCacheVersionDetails>>;
-
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct CratesCacheEntry {
     pub last_fetched: chrono::DateTime<chrono::Utc>,
     /// If versions is empty, this indicates that we queried the info and found that the crate has
     /// no published versions (and thus doesn't exist as of `last_fetched`).
-    pub versions: CratesCacheVersions,
+    ///
+    /// Versions are a sorted map because we sometimes need to iterate in order. We don't use a sorted
+    /// Vec because we may partially update the versions when we access the index (though technically
+    /// that update _should_ only have new versions which would append to a Vec if it were that).
+    pub versions: SortedMap<semver::Version, Option<CratesCacheVersionDetails>>,
     pub metadata: Option<CratesAPICrateMetadata>,
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -965,7 +965,7 @@ impl Default for DiffCache {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct DiffStat {
     pub insertions: u64,
     pub deletions: u64,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1670,14 +1670,14 @@ impl<'a> ResolveReport<'a> {
                                 .unwrap_or_default();
                             let publisher_count = versions
                                 .iter()
-                                .flat_map(|(_, details)| &details.as_ref().unwrap().published_by)
+                                .flat_map(|(_, details)| &details.published_by)
                                 .collect::<FastSet<_>>()
                                 .len();
                             is_sole_publisher = publisher_count == 1;
                             versions
                                 .into_iter()
                                 .find(|(v, _)| v == &suggested_diff.to.semver)
-                                .and_then(|(_, d)| d.unwrap().published_by)
+                                .and_then(|(_, d)| d.published_by)
                         } else {
                             None
                         };
@@ -1702,9 +1702,7 @@ impl<'a> ResolveReport<'a> {
                                 .get_cached_publishers(package.name)
                                 .iter()
                                 .rev()
-                                .filter_map(|(_, details)| {
-                                    details.as_ref().and_then(|d| d.published_by)
-                                })
+                                .filter_map(|(_, details)| details.published_by)
                                 .find(|i| trusted_publishers.contains_key(i))
                         } else {
                             None

--- a/tests/cache/diff-cache.toml
+++ b/tests/cache/diff-cache.toml
@@ -15,6 +15,11 @@ insertions = 6554
 deletions = 0
 files_changed = 19
 
+[diffs.cfg-if."0.1.10"]
+insertions = 579
+deletions = 0
+files_changed = 9
+
 [diffs.cfg-if."1.0.0"]
 insertions = 582
 deletions = 0

--- a/tests/snapshots/test_cli__test-project-dump-graph-full-json.snap
+++ b/tests/snapshots/test_cli__test-project-dump-graph-full-json.snap
@@ -9,24 +9,24 @@ stdout:
     "name": "atty",
     "version": "0.2.14",
     "normal_deps": [
-      24,
-      38,
-      101
+      25,
+      39,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      24,
-      38,
-      101
+      25,
+      39,
+      102
     ],
     "all_deps": [
-      24,
-      38,
-      101
+      25,
+      39,
+      102
     ],
     "reverse_deps": [
-      8
+      9
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -43,8 +43,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      32,
-      50
+      33,
+      51
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -61,7 +61,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -78,10 +78,10 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      8,
-      48,
-      59,
-      64
+      9,
+      49,
+      60,
+      65
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -98,7 +98,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      95
+      96
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -115,14 +115,14 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      22,
-      25,
+      23,
       26,
-      29,
+      27,
       30,
-      61,
-      79,
-      81
+      31,
+      62,
+      80,
+      82
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -139,7 +139,24 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      50
+      51
+    ],
+    "is_workspace_member": false,
+    "is_third_party": true,
+    "is_root": false,
+    "is_dev_only": false
+  },
+  {
+    "package_id": "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+    "name": "cfg-if",
+    "version": "0.1.10",
+    "normal_deps": [],
+    "build_deps": [],
+    "dev_deps": [],
+    "normal_and_build_deps": [],
+    "all_deps": [],
+    "reverse_deps": [
+      76
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -156,14 +173,14 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      11,
-      33,
-      39,
-      48,
-      73,
-      83,
-      94,
-      96
+      12,
+      34,
+      40,
+      49,
+      74,
+      84,
+      95,
+      97
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -177,34 +194,34 @@ stdout:
     "normal_deps": [
       0,
       3,
-      32,
-      51,
-      71,
-      74,
-      76
+      33,
+      52,
+      72,
+      75,
+      77
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       0,
       3,
-      32,
-      51,
-      71,
-      74,
-      76
+      33,
+      52,
+      72,
+      75,
+      77
     ],
     "all_deps": [
       0,
       3,
-      32,
-      51,
-      71,
-      74,
-      76
+      33,
+      52,
+      72,
+      75,
+      77
     ],
     "reverse_deps": [
-      75
+      76
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -216,21 +233,21 @@ stdout:
     "name": "core-foundation",
     "version": "0.9.3",
     "normal_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "all_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "reverse_deps": [
-      64
+      65
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -247,9 +264,9 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      9,
-      64,
-      65
+      10,
+      65,
+      66
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -261,18 +278,18 @@ stdout:
     "name": "encoding_rs",
     "version": "0.8.31",
     "normal_deps": [
-      7
+      8
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7
+      8
     ],
     "all_deps": [
-      7
+      8
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -284,18 +301,18 @@ stdout:
     "name": "fastrand",
     "version": "1.7.0",
     "normal_deps": [
-      33
+      34
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      33
+      34
     ],
     "all_deps": [
-      33
+      34
     ],
     "reverse_deps": [
-      73
+      74
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -312,8 +329,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      22,
-      25
+      23,
+      26
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -325,18 +342,18 @@ stdout:
     "name": "foreign-types",
     "version": "0.3.2",
     "normal_deps": [
-      15
+      16
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      15
+      16
     ],
     "all_deps": [
-      15
+      16
     ],
     "reverse_deps": [
-      48
+      49
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -353,7 +370,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      14
+      15
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -365,22 +382,22 @@ stdout:
     "name": "form_urlencoded",
     "version": "1.0.1",
     "normal_deps": [
-      40,
-      52
+      41,
+      53
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      40,
-      52
+      41,
+      53
     ],
     "all_deps": [
-      40,
-      52
+      41,
+      53
     ],
     "reverse_deps": [
-      68,
-      90
+      69,
+      91
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -392,18 +409,18 @@ stdout:
     "name": "futures-channel",
     "version": "0.3.21",
     "normal_deps": [
-      18
+      19
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      18
+      19
     ],
     "all_deps": [
-      18
+      19
     ],
     "reverse_deps": [
-      29
+      30
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -420,12 +437,12 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      17,
-      21,
+      18,
       22,
-      29,
-      61,
-      81
+      23,
+      30,
+      62,
+      82
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -442,8 +459,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      22,
-      81
+      23,
+      82
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -460,7 +477,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      21
+      22
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -472,29 +489,29 @@ stdout:
     "name": "futures-util",
     "version": "0.3.21",
     "normal_deps": [
-      18,
-      20,
-      53,
-      54
+      19,
+      21,
+      54,
+      55
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      18,
-      20,
-      53,
-      54
+      19,
+      21,
+      54,
+      55
     ],
     "all_deps": [
-      18,
-      20,
-      53,
-      54
+      19,
+      21,
+      54,
+      55
     ],
     "reverse_deps": [
-      22,
-      29,
-      61
+      23,
+      30,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -507,48 +524,48 @@ stdout:
     "version": "0.3.13",
     "normal_deps": [
       5,
-      13,
-      18,
+      14,
       19,
-      21,
-      25,
-      32,
-      69,
-      79,
-      81,
-      83
+      20,
+      22,
+      26,
+      33,
+      70,
+      80,
+      82,
+      84
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      13,
-      18,
+      14,
       19,
-      21,
-      25,
-      32,
-      69,
-      79,
-      81,
-      83
+      20,
+      22,
+      26,
+      33,
+      70,
+      80,
+      82,
+      84
     ],
     "all_deps": [
       5,
-      13,
-      18,
+      14,
       19,
-      21,
-      25,
-      32,
-      69,
-      79,
-      81,
-      83
+      20,
+      22,
+      26,
+      33,
+      70,
+      80,
+      82,
+      84
     ],
     "reverse_deps": [
-      29,
-      61
+      30,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -565,7 +582,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      32
+      33
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -577,15 +594,15 @@ stdout:
     "name": "hermit-abi",
     "version": "0.1.19",
     "normal_deps": [
-      38
+      39
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      38
+      39
     ],
     "all_deps": [
-      38
+      39
     ],
     "reverse_deps": [
       0
@@ -601,26 +618,26 @@ stdout:
     "version": "0.2.6",
     "normal_deps": [
       5,
-      13,
-      35
+      14,
+      36
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      13,
-      35
+      14,
+      36
     ],
     "all_deps": [
       5,
-      13,
-      35
+      14,
+      36
     ],
     "reverse_deps": [
-      22,
-      26,
-      29,
-      61
+      23,
+      27,
+      30,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -633,24 +650,24 @@ stdout:
     "version": "0.4.4",
     "normal_deps": [
       5,
-      25,
-      53
+      26,
+      54
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      25,
-      53
+      26,
+      54
     ],
     "all_deps": [
       5,
-      25,
-      53
+      26,
+      54
     ],
     "reverse_deps": [
-      29,
-      61
+      30,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -667,7 +684,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      29
+      30
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -684,7 +701,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      29
+      30
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -697,63 +714,63 @@ stdout:
     "version": "0.14.18",
     "normal_deps": [
       5,
-      17,
       18,
-      21,
+      19,
       22,
-      25,
+      23,
       26,
       27,
       28,
-      35,
-      53,
-      70,
-      79,
-      82,
+      29,
+      36,
+      54,
+      71,
+      80,
       83,
-      92
+      84,
+      93
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      17,
       18,
-      21,
+      19,
       22,
-      25,
+      23,
       26,
       27,
       28,
-      35,
-      53,
-      70,
-      79,
-      82,
+      29,
+      36,
+      54,
+      71,
+      80,
       83,
-      92
+      84,
+      93
     ],
     "all_deps": [
       5,
-      17,
       18,
-      21,
+      19,
       22,
-      25,
+      23,
       26,
       27,
       28,
-      35,
-      53,
-      70,
-      79,
-      82,
+      29,
+      36,
+      54,
+      71,
+      80,
       83,
-      92
+      84,
+      93
     ],
     "reverse_deps": [
-      30,
-      61
+      31,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -766,29 +783,29 @@ stdout:
     "version": "0.5.0",
     "normal_deps": [
       5,
-      29,
-      45,
-      79,
-      80
+      30,
+      46,
+      80,
+      81
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      29,
-      45,
-      79,
-      80
+      30,
+      46,
+      80,
+      81
     ],
     "all_deps": [
       5,
-      29,
-      45,
-      79,
-      80
+      30,
+      46,
+      80,
+      81
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -800,24 +817,24 @@ stdout:
     "name": "idna",
     "version": "0.2.3",
     "normal_deps": [
-      40,
-      87,
-      88
+      41,
+      88,
+      89
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      40,
-      87,
-      88
+      41,
+      88,
+      89
     ],
     "all_deps": [
-      40,
-      87,
-      88
+      41,
+      88,
+      89
     ],
     "reverse_deps": [
-      90
+      91
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -829,7 +846,7 @@ stdout:
     "name": "indexmap",
     "version": "1.8.1",
     "normal_deps": [
-      23
+      24
     ],
     "build_deps": [
       1
@@ -837,15 +854,15 @@ stdout:
     "dev_deps": [],
     "normal_and_build_deps": [
       1,
-      23
+      24
     ],
     "all_deps": [
       1,
-      23
+      24
     ],
     "reverse_deps": [
-      8,
-      22
+      9,
+      23
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -857,18 +874,18 @@ stdout:
     "name": "instant",
     "version": "0.1.12",
     "normal_deps": [
-      7
+      8
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7
+      8
     ],
     "all_deps": [
-      7
+      8
     ],
     "reverse_deps": [
-      12
+      13
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -885,7 +902,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -902,10 +919,10 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      25,
-      29,
-      67,
-      68
+      26,
+      30,
+      68,
+      69
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -917,20 +934,20 @@ stdout:
     "name": "js-sys",
     "version": "0.3.57",
     "normal_deps": [
-      94
+      95
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      94
+      95
     ],
     "all_deps": [
-      94
+      95
     ],
     "reverse_deps": [
-      61,
-      96,
-      100
+      62,
+      97,
+      101
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -947,11 +964,11 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      45,
-      61,
-      63,
-      85,
-      95
+      46,
+      62,
+      64,
+      86,
+      96
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -969,17 +986,17 @@ stdout:
     "all_deps": [],
     "reverse_deps": [
       0,
-      9,
-      24,
-      43,
-      45,
-      48,
-      50,
-      64,
+      10,
+      25,
+      44,
+      46,
+      49,
+      51,
       65,
-      70,
-      73,
-      79
+      66,
+      71,
+      74,
+      80
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -991,22 +1008,22 @@ stdout:
     "name": "log",
     "version": "0.4.16",
     "normal_deps": [
-      7
+      8
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7
+      8
     ],
     "all_deps": [
-      7
+      8
     ],
     "reverse_deps": [
-      43,
-      45,
-      61,
-      92,
-      95
+      44,
+      46,
+      62,
+      93,
+      96
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1023,9 +1040,9 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      16,
-      31,
-      90
+      17,
+      32,
+      91
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1042,8 +1059,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      51,
-      79
+      52,
+      80
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1060,7 +1077,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1072,33 +1089,33 @@ stdout:
     "name": "mio",
     "version": "0.8.2",
     "normal_deps": [
-      38,
       39,
-      44,
-      46,
-      93,
-      101
+      40,
+      45,
+      47,
+      94,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      38,
       39,
-      44,
-      46,
-      93,
-      101
+      40,
+      45,
+      47,
+      94,
+      102
     ],
     "all_deps": [
-      38,
       39,
-      44,
-      46,
-      93,
-      101
+      40,
+      45,
+      47,
+      94,
+      102
     ],
     "reverse_deps": [
-      79
+      80
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1110,18 +1127,18 @@ stdout:
     "name": "miow",
     "version": "0.3.7",
     "normal_deps": [
-      101
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      101
+      102
     ],
     "all_deps": [
-      101
+      102
     ],
     "reverse_deps": [
-      43
+      44
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1133,47 +1150,47 @@ stdout:
     "name": "native-tls",
     "version": "0.2.10",
     "normal_deps": [
-      37,
       38,
       39,
-      48,
+      40,
       49,
       50,
-      63,
+      51,
       64,
       65,
-      73
+      66,
+      74
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      37,
       38,
       39,
-      48,
+      40,
       49,
       50,
-      63,
+      51,
       64,
       65,
-      73
+      66,
+      74
     ],
     "all_deps": [
-      37,
       38,
       39,
-      48,
+      40,
       49,
       50,
-      63,
+      51,
       64,
       65,
-      73
+      66,
+      74
     ],
     "reverse_deps": [
-      30,
-      61,
-      80
+      31,
+      62,
+      81
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1185,18 +1202,18 @@ stdout:
     "name": "ntapi",
     "version": "0.3.7",
     "normal_deps": [
-      101
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      101
+      102
     ],
     "all_deps": [
-      101
+      102
     ],
     "reverse_deps": [
-      43
+      44
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1213,7 +1230,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      48
+      49
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1226,32 +1243,32 @@ stdout:
     "version": "0.10.38",
     "normal_deps": [
       3,
-      7,
-      14,
-      38,
-      47,
-      50
+      8,
+      15,
+      39,
+      48,
+      51
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       3,
-      7,
-      14,
-      38,
-      47,
-      50
+      8,
+      15,
+      39,
+      48,
+      51
     ],
     "all_deps": [
       3,
-      7,
-      14,
-      38,
-      47,
-      50
+      8,
+      15,
+      39,
+      48,
+      51
     ],
     "reverse_deps": [
-      45
+      46
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1268,7 +1285,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      45
+      46
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1280,32 +1297,32 @@ stdout:
     "name": "openssl-sys",
     "version": "0.9.72",
     "normal_deps": [
-      38
+      39
     ],
     "build_deps": [
       1,
       6,
-      55,
-      91
+      56,
+      92
     ],
     "dev_deps": [],
     "normal_and_build_deps": [
       1,
       6,
-      38,
-      55,
-      91
+      39,
+      56,
+      92
     ],
     "all_deps": [
       1,
       6,
-      38,
-      55,
-      91
+      39,
+      56,
+      92
     ],
     "reverse_deps": [
-      45,
-      48
+      46,
+      49
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1317,18 +1334,18 @@ stdout:
     "name": "os_str_bytes",
     "version": "6.0.0",
     "normal_deps": [
-      41
+      42
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      41
+      42
     ],
     "all_deps": [
-      41
+      42
     ],
     "reverse_deps": [
-      8
+      9
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1345,9 +1362,9 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      16,
-      61,
-      90
+      17,
+      62,
+      91
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1364,13 +1381,13 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      21,
-      26,
-      29,
-      61,
-      79,
-      81,
-      83
+      22,
+      27,
+      30,
+      62,
+      80,
+      82,
+      84
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1387,7 +1404,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      21
+      22
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1404,7 +1421,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      50
+      51
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1416,18 +1433,18 @@ stdout:
     "name": "proc-macro2",
     "version": "1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9",
     "normal_deps": [
-      89
+      90
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      89
+      90
     ],
     "all_deps": [
-      89
+      90
     ],
     "reverse_deps": [
-      75
+      76
     ],
     "is_workspace_member": false,
     "is_third_party": false,
@@ -1439,22 +1456,22 @@ stdout:
     "name": "proc-macro2",
     "version": "1.0.37",
     "normal_deps": [
-      89
+      90
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      89
+      90
     ],
     "all_deps": [
-      89
+      90
     ],
     "reverse_deps": [
-      58,
-      72,
-      84,
-      95,
-      98
+      59,
+      73,
+      85,
+      96,
+      99
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1466,22 +1483,22 @@ stdout:
     "name": "quote",
     "version": "1.0.18",
     "normal_deps": [
-      57
+      58
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      57
+      58
     ],
     "all_deps": [
-      57
+      58
     ],
     "reverse_deps": [
-      72,
-      84,
-      95,
-      97,
-      98
+      73,
+      85,
+      96,
+      98,
+      99
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1504,7 +1521,7 @@ stdout:
       3
     ],
     "reverse_deps": [
-      73
+      74
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1516,18 +1533,18 @@ stdout:
     "name": "remove_dir_all",
     "version": "0.5.3",
     "normal_deps": [
-      101
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      101
+      102
     ],
     "all_deps": [
-      101
+      102
     ],
     "reverse_deps": [
-      73
+      74
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1541,97 +1558,97 @@ stdout:
     "normal_deps": [
       2,
       5,
-      11,
-      18,
-      21,
+      12,
+      19,
       22,
-      25,
+      23,
       26,
-      29,
+      27,
       30,
-      34,
-      36,
+      31,
+      35,
       37,
-      39,
-      42,
-      45,
-      52,
+      38,
+      40,
+      43,
+      46,
       53,
-      66,
+      54,
       67,
       68,
-      79,
+      69,
       80,
-      90,
-      94,
-      96,
-      100,
-      105
+      81,
+      91,
+      95,
+      97,
+      101,
+      106
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       2,
       5,
-      11,
-      18,
-      21,
+      12,
+      19,
       22,
-      25,
+      23,
       26,
-      29,
+      27,
       30,
-      34,
-      36,
+      31,
+      35,
       37,
-      39,
-      42,
-      45,
-      52,
+      38,
+      40,
+      43,
+      46,
       53,
-      66,
+      54,
       67,
       68,
-      79,
+      69,
       80,
-      90,
-      94,
-      96,
-      100,
-      105
+      81,
+      91,
+      95,
+      97,
+      101,
+      106
     ],
     "all_deps": [
       2,
       5,
-      11,
-      18,
-      21,
+      12,
+      19,
       22,
-      25,
+      23,
       26,
-      29,
+      27,
       30,
-      34,
-      36,
+      31,
+      35,
       37,
-      39,
-      42,
-      45,
-      52,
+      38,
+      40,
+      43,
+      46,
       53,
-      66,
+      54,
       67,
       68,
-      79,
+      69,
       80,
-      90,
-      94,
-      96,
-      100,
-      105
+      81,
+      91,
+      95,
+      97,
+      101,
+      106
     ],
     "reverse_deps": [
-      75
+      76
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1648,8 +1665,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      67,
-      68
+      68,
+      69
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1661,21 +1678,21 @@ stdout:
     "name": "schannel",
     "version": "0.1.19",
     "normal_deps": [
-      37,
-      101
+      38,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      37,
-      101
+      38,
+      102
     ],
     "all_deps": [
-      37,
-      101
+      38,
+      102
     ],
     "reverse_deps": [
-      45
+      46
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1688,29 +1705,29 @@ stdout:
     "version": "2.6.1",
     "normal_deps": [
       3,
-      9,
       10,
-      38,
-      65
+      11,
+      39,
+      66
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       3,
-      9,
       10,
-      38,
-      65
+      11,
+      39,
+      66
     ],
     "all_deps": [
       3,
-      9,
       10,
-      38,
-      65
+      11,
+      39,
+      66
     ],
     "reverse_deps": [
-      45
+      46
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1722,22 +1739,22 @@ stdout:
     "name": "security-framework-sys",
     "version": "2.6.1",
     "normal_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "all_deps": [
-      10,
-      38
+      11,
+      39
     ],
     "reverse_deps": [
-      45,
-      64
+      46,
+      65
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1754,9 +1771,9 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      61,
-      67,
-      68
+      62,
+      68,
+      69
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1768,25 +1785,25 @@ stdout:
     "name": "serde_json",
     "version": "1.0.79",
     "normal_deps": [
-      35,
-      62,
-      66
+      36,
+      63,
+      67
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      35,
-      62,
-      66
+      36,
+      63,
+      67
     ],
     "all_deps": [
-      35,
-      62,
-      66
+      36,
+      63,
+      67
     ],
     "reverse_deps": [
-      61,
-      75
+      62,
+      76
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1798,27 +1815,27 @@ stdout:
     "name": "serde_urlencoded",
     "version": "0.7.1",
     "normal_deps": [
-      16,
-      35,
-      62,
-      66
+      17,
+      36,
+      63,
+      67
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      16,
-      35,
-      62,
-      66
+      17,
+      36,
+      63,
+      67
     ],
     "all_deps": [
-      16,
-      35,
-      62,
-      66
+      17,
+      36,
+      63,
+      67
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1835,7 +1852,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      22
+      23
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1847,22 +1864,22 @@ stdout:
     "name": "socket2",
     "version": "0.4.4",
     "normal_deps": [
-      38,
-      101
+      39,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      38,
-      101
+      39,
+      102
     ],
     "all_deps": [
-      38,
-      101
+      39,
+      102
     ],
     "reverse_deps": [
-      29,
-      79
+      30,
+      80
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1879,7 +1896,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      8
+      9
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1891,26 +1908,26 @@ stdout:
     "name": "syn",
     "version": "1.0.91",
     "normal_deps": [
-      57,
       58,
-      89
+      59,
+      90
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      57,
       58,
-      89
+      59,
+      90
     ],
     "all_deps": [
-      57,
       58,
-      89
+      59,
+      90
     ],
     "reverse_deps": [
-      84,
-      95,
-      98
+      85,
+      96,
+      99
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1922,33 +1939,33 @@ stdout:
     "name": "tempfile",
     "version": "3.3.0",
     "normal_deps": [
-      7,
-      12,
-      38,
-      59,
+      8,
+      13,
+      39,
       60,
-      101
+      61,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7,
-      12,
-      38,
-      59,
+      8,
+      13,
+      39,
       60,
-      101
+      61,
+      102
     ],
     "all_deps": [
-      7,
-      12,
-      38,
-      59,
+      8,
+      13,
+      39,
       60,
-      101
+      61,
+      102
     ],
     "reverse_deps": [
-      45
+      46
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1960,18 +1977,18 @@ stdout:
     "name": "termcolor",
     "version": "1.1.3",
     "normal_deps": [
-      103
+      104
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      103
+      104
     ],
     "all_deps": [
-      103
+      104
     ],
     "reverse_deps": [
-      8
+      9
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -1982,27 +1999,30 @@ stdout:
     "name": "test-project",
     "version": "0.1.0",
     "normal_deps": [
-      8,
-      56,
-      61,
-      67,
-      79
+      7,
+      9,
+      57,
+      62,
+      68,
+      80
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      8,
-      56,
-      61,
-      67,
-      79
+      7,
+      9,
+      57,
+      62,
+      68,
+      80
     ],
     "all_deps": [
-      8,
-      56,
-      61,
-      67,
-      79
+      7,
+      9,
+      57,
+      62,
+      68,
+      80
     ],
     "reverse_deps": [],
     "is_workspace_member": true,
@@ -2020,7 +2040,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      8
+      9
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2032,18 +2052,18 @@ stdout:
     "name": "tinyvec",
     "version": "1.5.1",
     "normal_deps": [
-      78
+      79
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      78
+      79
     ],
     "all_deps": [
-      78
+      79
     ],
     "reverse_deps": [
-      88
+      89
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2060,7 +2080,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      77
+      78
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2073,41 +2093,41 @@ stdout:
     "version": "1.17.0",
     "normal_deps": [
       5,
-      38,
-      41,
-      43,
-      53,
-      70,
-      101
+      39,
+      42,
+      44,
+      54,
+      71,
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      38,
-      41,
-      43,
-      53,
-      70,
-      101
+      39,
+      42,
+      44,
+      54,
+      71,
+      102
     ],
     "all_deps": [
       5,
-      38,
-      41,
-      43,
-      53,
-      70,
-      101
+      39,
+      42,
+      44,
+      54,
+      71,
+      102
     ],
     "reverse_deps": [
-      22,
-      29,
+      23,
       30,
-      61,
-      75,
-      80,
-      81
+      31,
+      62,
+      76,
+      81,
+      82
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2119,22 +2139,22 @@ stdout:
     "name": "tokio-native-tls",
     "version": "0.3.0",
     "normal_deps": [
-      45,
-      79
+      46,
+      80
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      45,
-      79
+      46,
+      80
     ],
     "all_deps": [
-      45,
-      79
+      46,
+      80
     ],
     "reverse_deps": [
-      30,
-      61
+      31,
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2147,32 +2167,32 @@ stdout:
     "version": "0.7.1",
     "normal_deps": [
       5,
-      18,
       19,
-      53,
-      79,
-      83
+      20,
+      54,
+      80,
+      84
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       5,
-      18,
       19,
-      53,
-      79,
-      83
+      20,
+      54,
+      80,
+      84
     ],
     "all_deps": [
       5,
-      18,
       19,
-      53,
-      79,
-      83
+      20,
+      54,
+      80,
+      84
     ],
     "reverse_deps": [
-      22
+      23
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2189,7 +2209,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      29
+      30
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2201,29 +2221,29 @@ stdout:
     "name": "tracing",
     "version": "0.1.33",
     "normal_deps": [
-      7,
-      53,
-      84,
-      85
+      8,
+      54,
+      85,
+      86
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7,
-      53,
-      84,
-      85
+      8,
+      54,
+      85,
+      86
     ],
     "all_deps": [
-      7,
-      53,
-      84,
-      85
+      8,
+      54,
+      85,
+      86
     ],
     "reverse_deps": [
-      22,
-      29,
-      81
+      23,
+      30,
+      82
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2235,24 +2255,24 @@ stdout:
     "name": "tracing-attributes",
     "version": "0.1.20",
     "normal_deps": [
-      57,
       58,
-      72
+      59,
+      73
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      57,
       58,
-      72
+      59,
+      73
     ],
     "all_deps": [
-      57,
       58,
-      72
+      59,
+      73
     ],
     "reverse_deps": [
-      83
+      84
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2264,18 +2284,18 @@ stdout:
     "name": "tracing-core",
     "version": "0.1.25",
     "normal_deps": [
-      37
+      38
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      37
+      38
     ],
     "all_deps": [
-      37
+      38
     ],
     "reverse_deps": [
-      83
+      84
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2292,7 +2312,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      92
+      93
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2309,7 +2329,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      31
+      32
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2321,18 +2341,18 @@ stdout:
     "name": "unicode-normalization",
     "version": "0.1.19",
     "normal_deps": [
-      77
+      78
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      77
+      78
     ],
     "all_deps": [
-      77
+      78
     ],
     "reverse_deps": [
-      31
+      32
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2349,9 +2369,9 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      56,
       57,
-      72
+      58,
+      73
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2363,27 +2383,27 @@ stdout:
     "name": "url",
     "version": "2.2.2",
     "normal_deps": [
-      16,
-      31,
-      40,
-      52
+      17,
+      32,
+      41,
+      53
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      16,
-      31,
-      40,
-      52
+      17,
+      32,
+      41,
+      53
     ],
     "all_deps": [
-      16,
-      31,
-      40,
-      52
+      17,
+      32,
+      41,
+      53
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2400,7 +2420,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      50
+      51
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2412,21 +2432,21 @@ stdout:
     "name": "want",
     "version": "0.3.0",
     "normal_deps": [
-      39,
-      86
+      40,
+      87
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      39,
-      86
+      40,
+      87
     ],
     "all_deps": [
-      39,
-      86
+      40,
+      87
     ],
     "reverse_deps": [
-      29
+      30
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2443,7 +2463,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      43
+      44
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2455,24 +2475,24 @@ stdout:
     "name": "wasm-bindgen",
     "version": "0.2.80",
     "normal_deps": [
-      7,
-      97
+      8,
+      98
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7,
-      97
+      8,
+      98
     ],
     "all_deps": [
-      7,
-      97
+      8,
+      98
     ],
     "reverse_deps": [
-      36,
-      61,
-      96,
-      100
+      37,
+      62,
+      97,
+      101
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2485,35 +2505,35 @@ stdout:
     "version": "0.2.80",
     "normal_deps": [
       4,
-      37,
-      39,
-      57,
+      38,
+      40,
       58,
-      72,
-      99
+      59,
+      73,
+      100
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
       4,
-      37,
-      39,
-      57,
+      38,
+      40,
       58,
-      72,
-      99
+      59,
+      73,
+      100
     ],
     "all_deps": [
       4,
-      37,
-      39,
-      57,
+      38,
+      40,
       58,
-      72,
-      99
+      59,
+      73,
+      100
     ],
     "reverse_deps": [
-      98
+      99
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2525,27 +2545,27 @@ stdout:
     "name": "wasm-bindgen-futures",
     "version": "0.4.30",
     "normal_deps": [
-      7,
-      36,
-      94,
-      100
+      8,
+      37,
+      95,
+      101
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      7,
-      36,
-      94,
-      100
+      8,
+      37,
+      95,
+      101
     ],
     "all_deps": [
-      7,
-      36,
-      94,
-      100
+      8,
+      37,
+      95,
+      101
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2557,21 +2577,21 @@ stdout:
     "name": "wasm-bindgen-macro",
     "version": "0.2.80",
     "normal_deps": [
-      58,
-      98
+      59,
+      99
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      58,
-      98
+      59,
+      99
     ],
     "all_deps": [
-      58,
-      98
+      59,
+      99
     ],
     "reverse_deps": [
-      94
+      95
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2583,30 +2603,30 @@ stdout:
     "name": "wasm-bindgen-macro-support",
     "version": "0.2.80",
     "normal_deps": [
-      57,
       58,
-      72,
-      95,
-      99
+      59,
+      73,
+      96,
+      100
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      57,
       58,
-      72,
-      95,
-      99
+      59,
+      73,
+      96,
+      100
     ],
     "all_deps": [
-      57,
       58,
-      72,
-      95,
-      99
+      59,
+      73,
+      96,
+      100
     ],
     "reverse_deps": [
-      97
+      98
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2623,8 +2643,8 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      95,
-      98
+      96,
+      99
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2636,22 +2656,22 @@ stdout:
     "name": "web-sys",
     "version": "0.3.57",
     "normal_deps": [
-      36,
-      94
+      37,
+      95
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      36,
-      94
+      37,
+      95
     ],
     "all_deps": [
-      36,
-      94
+      37,
+      95
     ],
     "reverse_deps": [
-      61,
-      96
+      62,
+      97
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2663,31 +2683,31 @@ stdout:
     "name": "winapi",
     "version": "0.3.9",
     "normal_deps": [
-      102,
-      104
+      103,
+      105
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      102,
-      104
+      103,
+      105
     ],
     "all_deps": [
-      102,
-      104
+      103,
+      105
     ],
     "reverse_deps": [
       0,
-      43,
       44,
-      46,
-      60,
-      63,
-      70,
-      73,
-      79,
-      103,
-      105
+      45,
+      47,
+      61,
+      64,
+      71,
+      74,
+      80,
+      104,
+      106
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2704,7 +2724,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      101
+      102
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2716,18 +2736,18 @@ stdout:
     "name": "winapi-util",
     "version": "0.1.5",
     "normal_deps": [
-      101
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      101
+      102
     ],
     "all_deps": [
-      101
+      102
     ],
     "reverse_deps": [
-      74
+      75
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2744,7 +2764,7 @@ stdout:
     "normal_and_build_deps": [],
     "all_deps": [],
     "reverse_deps": [
-      101
+      102
     ],
     "is_workspace_member": false,
     "is_third_party": true,
@@ -2756,18 +2776,18 @@ stdout:
     "name": "winreg",
     "version": "0.10.1",
     "normal_deps": [
-      101
+      102
     ],
     "build_deps": [],
     "dev_deps": [],
     "normal_and_build_deps": [
-      101
+      102
     ],
     "all_deps": [
-      101
+      102
     ],
     "reverse_deps": [
-      61
+      62
     ],
     "is_workspace_member": false,
     "is_third_party": true,

--- a/tests/snapshots/test_cli__test-project-dump-graph-full.snap
+++ b/tests/snapshots/test_cli__test-project-dump-graph-full.snap
@@ -5,12 +5,12 @@ expression: format_outputs(&output)
 stdout:
 graph LR
     subgraph roots
-        node75{test-project:0.1.0}
+        node76{test-project:0.1.0}
     end
     subgraph workspace-members
     end
     subgraph first-party
-        node56[proc-macro2:1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9]
+        node57[proc-macro2:1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9]
     end
     subgraph third-party
         node0(atty:0.2.14)
@@ -20,326 +20,328 @@ graph LR
         node4(bumpalo:3.9.1)
         node5(bytes:1.1.0)
         node6(cc:1.0.73)
-        node7(cfg-if:1.0.0)
-        node8(clap:3.1.8)
-        node9(core-foundation:0.9.3)
-        node10(core-foundation-sys:0.8.3)
-        node11(encoding_rs:0.8.31)
-        node12(fastrand:1.7.0)
-        node13(fnv:1.0.7)
-        node14(foreign-types:0.3.2)
-        node15(foreign-types-shared:0.1.1)
-        node16(form_urlencoded:1.0.1)
-        node17(futures-channel:0.3.21)
-        node18(futures-core:0.3.21)
-        node19(futures-sink:0.3.21)
-        node20(futures-task:0.3.21)
-        node21(futures-util:0.3.21)
-        node22(h2:0.3.13)
-        node23(hashbrown:0.11.2)
-        node24(hermit-abi:0.1.19)
-        node25(http:0.2.6)
-        node26(http-body:0.4.4)
-        node27(httparse:1.7.0)
-        node28(httpdate:1.0.2)
-        node29(hyper:0.14.18)
-        node30(hyper-tls:0.5.0)
-        node31(idna:0.2.3)
-        node32(indexmap:1.8.1)
-        node33(instant:0.1.12)
-        node34(ipnet:2.4.0)
-        node35(itoa:1.0.1)
-        node36(js-sys:0.3.57)
-        node37(lazy_static:1.4.0)
-        node38(libc:0.2.123)
-        node39(log:0.4.16)
-        node40(matches:0.1.9)
-        node41(memchr:2.4.1)
-        node42(mime:0.3.16)
-        node43(mio:0.8.2)
-        node44(miow:0.3.7)
-        node45(native-tls:0.2.10)
-        node46(ntapi:0.3.7)
-        node47(once_cell:1.10.0)
-        node48(openssl:0.10.38)
-        node49(openssl-probe:0.1.5)
-        node50(openssl-sys:0.9.72)
-        node51(os_str_bytes:6.0.0)
-        node52(percent-encoding:2.1.0)
-        node53(pin-project-lite:0.2.8)
-        node54(pin-utils:0.1.0)
-        node55(pkg-config:0.3.25)
-        node57(proc-macro2:1.0.37)
-        node58(quote:1.0.18)
-        node59(redox_syscall:0.2.13)
-        node60(remove_dir_all:0.5.3)
-        node61(reqwest:0.11.10)
-        node62(ryu:1.0.9)
-        node63(schannel:0.1.19)
-        node64(security-framework:2.6.1)
-        node65(security-framework-sys:2.6.1)
-        node66(serde:1.0.136)
-        node67(serde_json:1.0.79)
-        node68(serde_urlencoded:0.7.1)
-        node69(slab:0.4.6)
-        node70(socket2:0.4.4)
-        node71(strsim:0.10.0)
-        node72(syn:1.0.91)
-        node73(tempfile:3.3.0)
-        node74(termcolor:1.1.3)
-        node76(textwrap:0.15.0)
-        node77(tinyvec:1.5.1)
-        node78(tinyvec_macros:0.1.0)
-        node79(tokio:1.17.0)
-        node80(tokio-native-tls:0.3.0)
-        node81(tokio-util:0.7.1)
-        node82(tower-service:0.3.1)
-        node83(tracing:0.1.33)
-        node84(tracing-attributes:0.1.20)
-        node85(tracing-core:0.1.25)
-        node86(try-lock:0.2.3)
-        node87(unicode-bidi:0.3.7)
-        node88(unicode-normalization:0.1.19)
-        node89(unicode-xid:0.2.2)
-        node90(url:2.2.2)
-        node91(vcpkg:0.2.15)
-        node92(want:0.3.0)
-        node93(wasi:0.11.0+wasi-snapshot-preview1)
-        node94(wasm-bindgen:0.2.80)
-        node95(wasm-bindgen-backend:0.2.80)
-        node96(wasm-bindgen-futures:0.4.30)
-        node97(wasm-bindgen-macro:0.2.80)
-        node98(wasm-bindgen-macro-support:0.2.80)
-        node99(wasm-bindgen-shared:0.2.80)
-        node100(web-sys:0.3.57)
-        node101(winapi:0.3.9)
-        node102(winapi-i686-pc-windows-gnu:0.4.0)
-        node103(winapi-util:0.1.5)
-        node104(winapi-x86_64-pc-windows-gnu:0.4.0)
-        node105(winreg:0.10.1)
+        node7(cfg-if:0.1.10)
+        node8(cfg-if:1.0.0)
+        node9(clap:3.1.8)
+        node10(core-foundation:0.9.3)
+        node11(core-foundation-sys:0.8.3)
+        node12(encoding_rs:0.8.31)
+        node13(fastrand:1.7.0)
+        node14(fnv:1.0.7)
+        node15(foreign-types:0.3.2)
+        node16(foreign-types-shared:0.1.1)
+        node17(form_urlencoded:1.0.1)
+        node18(futures-channel:0.3.21)
+        node19(futures-core:0.3.21)
+        node20(futures-sink:0.3.21)
+        node21(futures-task:0.3.21)
+        node22(futures-util:0.3.21)
+        node23(h2:0.3.13)
+        node24(hashbrown:0.11.2)
+        node25(hermit-abi:0.1.19)
+        node26(http:0.2.6)
+        node27(http-body:0.4.4)
+        node28(httparse:1.7.0)
+        node29(httpdate:1.0.2)
+        node30(hyper:0.14.18)
+        node31(hyper-tls:0.5.0)
+        node32(idna:0.2.3)
+        node33(indexmap:1.8.1)
+        node34(instant:0.1.12)
+        node35(ipnet:2.4.0)
+        node36(itoa:1.0.1)
+        node37(js-sys:0.3.57)
+        node38(lazy_static:1.4.0)
+        node39(libc:0.2.123)
+        node40(log:0.4.16)
+        node41(matches:0.1.9)
+        node42(memchr:2.4.1)
+        node43(mime:0.3.16)
+        node44(mio:0.8.2)
+        node45(miow:0.3.7)
+        node46(native-tls:0.2.10)
+        node47(ntapi:0.3.7)
+        node48(once_cell:1.10.0)
+        node49(openssl:0.10.38)
+        node50(openssl-probe:0.1.5)
+        node51(openssl-sys:0.9.72)
+        node52(os_str_bytes:6.0.0)
+        node53(percent-encoding:2.1.0)
+        node54(pin-project-lite:0.2.8)
+        node55(pin-utils:0.1.0)
+        node56(pkg-config:0.3.25)
+        node58(proc-macro2:1.0.37)
+        node59(quote:1.0.18)
+        node60(redox_syscall:0.2.13)
+        node61(remove_dir_all:0.5.3)
+        node62(reqwest:0.11.10)
+        node63(ryu:1.0.9)
+        node64(schannel:0.1.19)
+        node65(security-framework:2.6.1)
+        node66(security-framework-sys:2.6.1)
+        node67(serde:1.0.136)
+        node68(serde_json:1.0.79)
+        node69(serde_urlencoded:0.7.1)
+        node70(slab:0.4.6)
+        node71(socket2:0.4.4)
+        node72(strsim:0.10.0)
+        node73(syn:1.0.91)
+        node74(tempfile:3.3.0)
+        node75(termcolor:1.1.3)
+        node77(textwrap:0.15.0)
+        node78(tinyvec:1.5.1)
+        node79(tinyvec_macros:0.1.0)
+        node80(tokio:1.17.0)
+        node81(tokio-native-tls:0.3.0)
+        node82(tokio-util:0.7.1)
+        node83(tower-service:0.3.1)
+        node84(tracing:0.1.33)
+        node85(tracing-attributes:0.1.20)
+        node86(tracing-core:0.1.25)
+        node87(try-lock:0.2.3)
+        node88(unicode-bidi:0.3.7)
+        node89(unicode-normalization:0.1.19)
+        node90(unicode-xid:0.2.2)
+        node91(url:2.2.2)
+        node92(vcpkg:0.2.15)
+        node93(want:0.3.0)
+        node94(wasi:0.11.0+wasi-snapshot-preview1)
+        node95(wasm-bindgen:0.2.80)
+        node96(wasm-bindgen-backend:0.2.80)
+        node97(wasm-bindgen-futures:0.4.30)
+        node98(wasm-bindgen-macro:0.2.80)
+        node99(wasm-bindgen-macro-support:0.2.80)
+        node100(wasm-bindgen-shared:0.2.80)
+        node101(web-sys:0.3.57)
+        node102(winapi:0.3.9)
+        node103(winapi-i686-pc-windows-gnu:0.4.0)
+        node104(winapi-util:0.1.5)
+        node105(winapi-x86_64-pc-windows-gnu:0.4.0)
+        node106(winreg:0.10.1)
     end
-    node0 --> node24
-    node0 --> node38
-    node0 --> node101
-    node8 --> node0
-    node8 --> node3
-    node8 --> node32
-    node8 --> node51
-    node8 --> node71
-    node8 --> node74
-    node8 --> node76
-    node9 --> node10
-    node9 --> node38
-    node11 --> node7
-    node12 --> node33
-    node14 --> node15
-    node16 --> node40
-    node16 --> node52
-    node17 --> node18
-    node21 --> node18
-    node21 --> node20
-    node21 --> node53
-    node21 --> node54
-    node22 --> node5
-    node22 --> node13
-    node22 --> node18
+    node0 --> node25
+    node0 --> node39
+    node0 --> node102
+    node9 --> node0
+    node9 --> node3
+    node9 --> node33
+    node9 --> node52
+    node9 --> node72
+    node9 --> node75
+    node9 --> node77
+    node10 --> node11
+    node10 --> node39
+    node12 --> node8
+    node13 --> node34
+    node15 --> node16
+    node17 --> node41
+    node17 --> node53
+    node18 --> node19
     node22 --> node19
     node22 --> node21
-    node22 --> node25
-    node22 --> node32
-    node22 --> node69
-    node22 --> node79
-    node22 --> node81
-    node22 --> node83
-    node24 --> node38
-    node25 --> node5
-    node25 --> node13
-    node25 --> node35
+    node22 --> node54
+    node22 --> node55
+    node23 --> node5
+    node23 --> node14
+    node23 --> node19
+    node23 --> node20
+    node23 --> node22
+    node23 --> node26
+    node23 --> node33
+    node23 --> node70
+    node23 --> node80
+    node23 --> node82
+    node23 --> node84
+    node25 --> node39
     node26 --> node5
-    node26 --> node25
-    node26 --> node53
-    node29 --> node5
-    node29 --> node17
-    node29 --> node18
-    node29 --> node21
-    node29 --> node22
-    node29 --> node25
-    node29 --> node26
-    node29 --> node27
-    node29 --> node28
-    node29 --> node35
-    node29 --> node53
-    node29 --> node70
-    node29 --> node79
-    node29 --> node82
-    node29 --> node83
-    node29 --> node92
+    node26 --> node14
+    node26 --> node36
+    node27 --> node5
+    node27 --> node26
+    node27 --> node54
     node30 --> node5
+    node30 --> node18
+    node30 --> node19
+    node30 --> node22
+    node30 --> node23
+    node30 --> node26
+    node30 --> node27
+    node30 --> node28
     node30 --> node29
-    node30 --> node45
-    node30 --> node79
+    node30 --> node36
+    node30 --> node54
+    node30 --> node71
     node30 --> node80
-    node31 --> node40
-    node31 --> node87
-    node31 --> node88
-    node32 --> node1
-    node32 --> node23
-    node33 --> node7
-    node36 --> node94
-    node39 --> node7
-    node43 --> node38
-    node43 --> node39
-    node43 --> node44
-    node43 --> node46
-    node43 --> node93
-    node43 --> node101
-    node44 --> node101
-    node45 --> node37
-    node45 --> node38
-    node45 --> node39
-    node45 --> node48
-    node45 --> node49
-    node45 --> node50
-    node45 --> node63
-    node45 --> node64
-    node45 --> node65
-    node45 --> node73
-    node46 --> node101
-    node48 --> node3
-    node48 --> node7
-    node48 --> node14
-    node48 --> node38
-    node48 --> node47
-    node48 --> node50
-    node50 --> node1
-    node50 --> node6
-    node50 --> node38
-    node50 --> node55
-    node50 --> node91
-    node51 --> node41
-    node56 --> node89
-    node57 --> node89
-    node58 --> node57
-    node59 --> node3
-    node60 --> node101
-    node61 --> node2
-    node61 --> node5
-    node61 --> node11
-    node61 --> node18
-    node61 --> node21
-    node61 --> node22
-    node61 --> node25
-    node61 --> node26
-    node61 --> node29
-    node61 --> node30
-    node61 --> node34
-    node61 --> node36
-    node61 --> node37
-    node61 --> node39
-    node61 --> node42
-    node61 --> node45
-    node61 --> node52
-    node61 --> node53
-    node61 --> node66
-    node61 --> node67
-    node61 --> node68
-    node61 --> node79
-    node61 --> node80
-    node61 --> node90
-    node61 --> node94
-    node61 --> node96
-    node61 --> node100
-    node61 --> node105
-    node63 --> node37
-    node63 --> node101
-    node64 --> node3
-    node64 --> node9
-    node64 --> node10
+    node30 --> node83
+    node30 --> node84
+    node30 --> node93
+    node31 --> node5
+    node31 --> node30
+    node31 --> node46
+    node31 --> node80
+    node31 --> node81
+    node32 --> node41
+    node32 --> node88
+    node32 --> node89
+    node33 --> node1
+    node33 --> node24
+    node34 --> node8
+    node37 --> node95
+    node40 --> node8
+    node44 --> node39
+    node44 --> node40
+    node44 --> node45
+    node44 --> node47
+    node44 --> node94
+    node44 --> node102
+    node45 --> node102
+    node46 --> node38
+    node46 --> node39
+    node46 --> node40
+    node46 --> node49
+    node46 --> node50
+    node46 --> node51
+    node46 --> node64
+    node46 --> node65
+    node46 --> node66
+    node46 --> node74
+    node47 --> node102
+    node49 --> node3
+    node49 --> node8
+    node49 --> node15
+    node49 --> node39
+    node49 --> node48
+    node49 --> node51
+    node51 --> node1
+    node51 --> node6
+    node51 --> node39
+    node51 --> node56
+    node51 --> node92
+    node52 --> node42
+    node57 --> node90
+    node58 --> node90
+    node59 --> node58
+    node60 --> node3
+    node61 --> node102
+    node62 --> node2
+    node62 --> node5
+    node62 --> node12
+    node62 --> node19
+    node62 --> node22
+    node62 --> node23
+    node62 --> node26
+    node62 --> node27
+    node62 --> node30
+    node62 --> node31
+    node62 --> node35
+    node62 --> node37
+    node62 --> node38
+    node62 --> node40
+    node62 --> node43
+    node62 --> node46
+    node62 --> node53
+    node62 --> node54
+    node62 --> node67
+    node62 --> node68
+    node62 --> node69
+    node62 --> node80
+    node62 --> node81
+    node62 --> node91
+    node62 --> node95
+    node62 --> node97
+    node62 --> node101
+    node62 --> node106
     node64 --> node38
-    node64 --> node65
+    node64 --> node102
+    node65 --> node3
     node65 --> node10
-    node65 --> node38
-    node67 --> node35
-    node67 --> node62
-    node67 --> node66
-    node68 --> node16
-    node68 --> node35
-    node68 --> node62
-    node68 --> node66
-    node70 --> node38
-    node70 --> node101
-    node72 --> node57
-    node72 --> node58
-    node72 --> node89
-    node73 --> node7
-    node73 --> node12
-    node73 --> node38
+    node65 --> node11
+    node65 --> node39
+    node65 --> node66
+    node66 --> node11
+    node66 --> node39
+    node68 --> node36
+    node68 --> node63
+    node68 --> node67
+    node69 --> node17
+    node69 --> node36
+    node69 --> node63
+    node69 --> node67
+    node71 --> node39
+    node71 --> node102
+    node73 --> node58
     node73 --> node59
-    node73 --> node60
-    node73 --> node101
-    node74 --> node103
-    node75 --> node8
-    node75 --> node56
-    node75 --> node61
-    node75 --> node67
-    node75 --> node79
-    node77 --> node78
-    node79 --> node5
-    node79 --> node38
-    node79 --> node41
-    node79 --> node43
-    node79 --> node53
-    node79 --> node70
-    node79 --> node101
-    node80 --> node45
-    node80 --> node79
-    node81 --> node5
-    node81 --> node18
-    node81 --> node19
-    node81 --> node53
-    node81 --> node79
-    node81 --> node83
-    node83 --> node7
-    node83 --> node53
-    node83 --> node84
-    node83 --> node85
-    node84 --> node57
-    node84 --> node58
-    node84 --> node72
-    node85 --> node37
-    node88 --> node77
-    node90 --> node16
-    node90 --> node31
-    node90 --> node40
-    node90 --> node52
-    node92 --> node39
-    node92 --> node86
-    node94 --> node7
-    node94 --> node97
-    node95 --> node4
-    node95 --> node37
-    node95 --> node39
-    node95 --> node57
-    node95 --> node58
-    node95 --> node72
-    node95 --> node99
-    node96 --> node7
-    node96 --> node36
-    node96 --> node94
+    node73 --> node90
+    node74 --> node8
+    node74 --> node13
+    node74 --> node39
+    node74 --> node60
+    node74 --> node61
+    node74 --> node102
+    node75 --> node104
+    node76 --> node7
+    node76 --> node9
+    node76 --> node57
+    node76 --> node62
+    node76 --> node68
+    node76 --> node80
+    node78 --> node79
+    node80 --> node5
+    node80 --> node39
+    node80 --> node42
+    node80 --> node44
+    node80 --> node54
+    node80 --> node71
+    node80 --> node102
+    node81 --> node46
+    node81 --> node80
+    node82 --> node5
+    node82 --> node19
+    node82 --> node20
+    node82 --> node54
+    node82 --> node80
+    node82 --> node84
+    node84 --> node8
+    node84 --> node54
+    node84 --> node85
+    node84 --> node86
+    node85 --> node58
+    node85 --> node59
+    node85 --> node73
+    node86 --> node38
+    node89 --> node78
+    node91 --> node17
+    node91 --> node32
+    node91 --> node41
+    node91 --> node53
+    node93 --> node40
+    node93 --> node87
+    node95 --> node8
+    node95 --> node98
+    node96 --> node4
+    node96 --> node38
+    node96 --> node40
+    node96 --> node58
+    node96 --> node59
+    node96 --> node73
     node96 --> node100
-    node97 --> node58
-    node97 --> node98
-    node98 --> node57
-    node98 --> node58
-    node98 --> node72
-    node98 --> node95
+    node97 --> node8
+    node97 --> node37
+    node97 --> node95
+    node97 --> node101
+    node98 --> node59
     node98 --> node99
-    node100 --> node36
-    node100 --> node94
-    node101 --> node102
-    node101 --> node104
-    node103 --> node101
-    node105 --> node101
+    node99 --> node58
+    node99 --> node59
+    node99 --> node73
+    node99 --> node96
+    node99 --> node100
+    node101 --> node37
+    node101 --> node95
+    node102 --> node103
+    node102 --> node105
+    node104 --> node102
+    node106 --> node102
 
 stderr:
 

--- a/tests/snapshots/test_cli__test-project-json.snap
+++ b/tests/snapshots/test_cli__test-project-json.snap
@@ -37,6 +37,10 @@ stdout:
   ],
   "vetted_partially": [
     {
+      "name": "cfg-if",
+      "version": "1.0.0"
+    },
+    {
       "name": "unicode-bidi",
       "version": "0.3.7"
     }
@@ -56,7 +60,7 @@ stdout:
     },
     {
       "name": "cfg-if",
-      "version": "1.0.0"
+      "version": "0.1.10"
     },
     {
       "name": "core-foundation",

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -29,6 +29,13 @@ stdout:
     },
     {
       "name": "cfg-if",
+      "version": "0.1.10",
+      "missing_criteria": [
+        "safe-to-deploy"
+      ]
+    },
+    {
+      "name": "cfg-if",
       "version": "1.0.0",
       "missing_criteria": [
         "safe-to-deploy"
@@ -834,15 +841,15 @@ stdout:
       },
       {
         "name": "cfg-if",
-        "notable_parents": "log, instant, openssl, and 5 others",
+        "notable_parents": "log, instant, openssl, and 6 others",
         "suggested_criteria": [
           "safe-to-deploy"
         ],
         "suggested_diff": {
           "from": null,
-          "to": "1.0.0",
+          "to": "0.1.10",
           "diffstat": {
-            "insertions": 582,
+            "insertions": 579,
             "deletions": 0,
             "files_changed": 9
           }
@@ -1282,7 +1289,7 @@ stdout:
       },
       {
         "name": "unicode-xid",
-        "notable_parents": "syn, proc-macro2, and proc-macro2",
+        "notable_parents": "syn and proc-macro2",
         "suggested_criteria": [
           "safe-to-deploy"
         ],
@@ -2389,15 +2396,15 @@ stdout:
         },
         {
           "name": "cfg-if",
-          "notable_parents": "log, instant, openssl, and 5 others",
+          "notable_parents": "log, instant, openssl, and 6 others",
           "suggested_criteria": [
             "safe-to-deploy"
           ],
           "suggested_diff": {
             "from": null,
-            "to": "1.0.0",
+            "to": "0.1.10",
             "diffstat": {
-              "insertions": 582,
+              "insertions": 579,
               "deletions": 0,
               "files_changed": 9
             }
@@ -2821,7 +2828,7 @@ stdout:
         },
         {
           "name": "unicode-xid",
-          "notable_parents": "syn, proc-macro2, and proc-macro2",
+          "notable_parents": "syn and proc-macro2",
           "suggested_criteria": [
             "safe-to-deploy"
           ],
@@ -3799,7 +3806,7 @@ stdout:
         }
       ]
     },
-    "total_lines": 1712741
+    "total_lines": 1712738
   }
 }
 stderr:

--- a/tests/snapshots/test_cli__test-project-suggest.snap
+++ b/tests/snapshots/test_cli__test-project-suggest.snap
@@ -15,7 +15,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect wasm-bindgen-shared 0.2.80          alexcrichton   wasm-bindgen-backend and wasm-bindgen-macro-support  515 lines
     cargo vet inspect pin-utils 0.1.0                     cramertj       futures-util                                         538 lines
     cargo vet inspect futures-sink 0.3.21                 taiki-e        h2 and tokio-util                                    544 lines
-    cargo vet inspect cfg-if 1.0.0                        alexcrichton   log, instant, openssl, and 5 others                  582 lines
+    cargo vet inspect cfg-if 0.1.10                       alexcrichton   log, instant, openssl, and 6 others                  579 lines
     cargo vet inspect foreign-types 0.3.2                 UNKNOWN        openssl                                              583 lines
     cargo vet inspect remove_dir_all 0.5.3                XAMPPRocky     tempfile                                             592 lines
     cargo vet inspect instant 0.1.12                      sebcrozet      fastrand                                             672 lines
@@ -42,7 +42,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect core-foundation-sys 0.8.3           jdm            core-foundation and 2 others                         1965 lines
     cargo vet inspect wasm-bindgen-macro-support 0.2.80   alexcrichton   wasm-bindgen-macro                                   1965 lines
     cargo vet inspect security-framework-sys 2.6.1        kornelski      native-tls and security-framework                    2016 lines
-    cargo vet inspect unicode-xid 0.2.2                   Manishearth    syn, proc-macro2, and proc-macro2                    2044 lines
+    cargo vet inspect unicode-xid 0.2.2                   Manishearth    syn and proc-macro2                                  2044 lines
     cargo vet inspect serde_urlencoded 0.7.1              nox            reqwest                                              2120 lines
     cargo vet inspect termcolor 1.1.3                     BurntSushi     clap                                                 2578 lines
     cargo vet inspect slab 0.4.6                          taiki-e        h2                                                   2615 lines
@@ -112,7 +112,7 @@ recommended audits for safe-to-run:
     Command                              Publisher  Used By  Audit Size
     cargo vet inspect hermit-abi 0.1.19  stlankes   atty     932 lines
 
-estimated audit backlog: 1712741 lines
+estimated audit backlog: 1712738 lines
 
 Use |cargo vet certify| to record the audits.
 

--- a/tests/snapshots/test_cli__test-project.snap
+++ b/tests/snapshots/test_cli__test-project.snap
@@ -3,7 +3,7 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-Vetting Succeeded (7 fully audited, 1 partially audited, 97 exempted)
+Vetting Succeeded (7 fully audited, 2 partially audited, 97 exempted)
 
 stderr:
 

--- a/tests/test-project/Cargo.lock
+++ b/tests/test-project/Cargo.lock
@@ -51,6 +51,12 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -92,7 +98,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -306,7 +312,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -348,7 +354,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -432,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -678,7 +684,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -699,6 +705,7 @@ dependencies = [
 name = "test-project"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.10",
  "clap",
  "proc-macro2 1.0.37 (git+https://github.com/dtolnay/proc-macro2?rev=4445659b0f753a928059244c875a58bb12f791e9)",
  "reqwest",
@@ -778,7 +785,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -871,7 +878,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -896,7 +903,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/tests/test-project/Cargo.toml
+++ b/tests/test-project/Cargo.toml
@@ -11,3 +11,4 @@ reqwest = "0.11.10"
 serde_json = "1.0.79"
 tokio = "1.17.0"
 proc-macro2 = { git = "https://github.com/dtolnay/proc-macro2", rev = "4445659b0f753a928059244c875a58bb12f791e9" }
+cfg-if = "0.1.10"

--- a/tests/test-project/supply-chain/audits.toml
+++ b/tests/test-project/supply-chain/audits.toml
@@ -77,6 +77,11 @@ delta = "0.1.0 -> 1.3.2"
 criteria = "fuzzed"
 delta = "0.2.0 -> 1.3.2"
 
+[[audits.cfg-if]]
+criteria = "safe-to-deploy"
+delta = "0.1.10 -> 1.0.0"
+notes = "test for duplicate suggestions"
+
 [[audits.clap]]
 criteria = "safe-to-deploy"
 version = "3.1.8"

--- a/tests/test-project/supply-chain/config.toml
+++ b/tests/test-project/supply-chain/config.toml
@@ -28,7 +28,7 @@ version = "1.0.73"
 criteria = "safe-to-deploy"
 
 [[exemptions.cfg-if]]
-version = "1.0.0"
+version = "0.1.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.core-foundation]]


### PR DESCRIPTION
This avoids a potential crash when the set of relevant versions does not force an update of crates.io API information, despite more version numbers being known.

This PR also contains a fix for #481, removing duplicated suggestions from the output.