### PR TITLE
Remove violations when pruning if no crates in the graph match the violation crate

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2721,21 +2721,22 @@ pub(crate) fn get_store_updates(
                             .iter()
                             .enumerate()
                             .filter(|&(audit_index, entry)| {
-                                // Always keep any violations.
-                                if matches!(entry.kind, AuditKind::Violation { .. }) {
-                                    return true;
-                                }
-
                                 // Keep existing if we're not pruning imports.
                                 if !prune_imports && !entry.is_fresh_import {
                                     return true;
                                 }
 
                                 if let Some(required_entries) = required_entries {
-                                    required_entries.contains_key(&RequiredEntry::Audit {
-                                        import_index,
-                                        audit_index,
-                                    })
+                                    if matches!(entry.kind, AuditKind::Violation { .. }) {
+                                        // Keep violations if there are any required entries for
+                                        // the package.
+                                        !required_entries.is_empty()
+                                    } else {
+                                        required_entries.contains_key(&RequiredEntry::Audit {
+                                            import_index,
+                                            audit_index,
+                                        })
+                                    }
                                 } else {
                                     !entry.is_fresh_import
                                 }

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -220,8 +220,9 @@ fn existing_peer_skip_import() {
 
 #[test]
 fn existing_peer_remove_unused() {
-    // (Pass) When pruning, we'll remove unused audits (including violations) when unlocked, even
-    // if our peer hasn't changed. These audits will be preserved when not pruning.
+    // (Pass) When pruning, we'll remove unused audits (including violations)
+    // when unlocked, even if our peer hasn't changed. These audits will be
+    // preserved when not pruning.
 
     let _enter = TEST_RUNTIME.enter();
     let mock = MockMetadata::simple();

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused.snap
@@ -22,4 +22,8 @@ expression: output
 -[[audits.peer-company.audits.unused-package]]
 -criteria = "safe-to-deploy"
 -version = "10.0.0"
+-
+-[[audits.peer-company.audits.unused-violation]]
+-criteria = "safe-to-deploy"
+-violation = "1.*"
 

--- a/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused_noprune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__existing_peer_remove_unused_noprune.snap
@@ -22,4 +22,8 @@ expression: output
  [[audits.peer-company.audits.unused-package]]
  criteria = "safe-to-deploy"
  version = "10.0.0"
+ 
+ [[audits.peer-company.audits.unused-violation]]
+ criteria = "safe-to-deploy"
+ violation = "1.*"
 

--- a/src/tests/snapshots/cargo_vet__tests__import__new_audit_needed_violation.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_audit_needed_violation.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/import.rs
+expression: output
+---
++
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++violation = "10.*"
+

--- a/src/tests/snapshots/cargo_vet__tests__import__new_audit_unneeded_violation.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__new_audit_unneeded_violation.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/import.rs
+expression: output
+---
++
++[[audits.peer-company.audits.third-party2]]
++criteria = "safe-to-deploy"
++version = "10.0.0"
+


### PR DESCRIPTION
If a crate does match, keep all violations (regardless of version).

Closes #486.