### PR TITLE
Support crates.io installs using the http crates.io registry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2699,11 +2699,6 @@ async fn check_audit_as_crates_io(
     network: Option<&Network>,
     cache: &mut Cache,
 ) -> Result<(), AuditAsErrors> {
-    // If we don't have a registry, we can't check audit-as-crates-io.
-    if !cache.has_registry() {
-        return Ok(());
-    }
-
     let first_party_packages: Vec<_> =
         first_party_packages_strict(&cfg.metadata, &store.config).collect();
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     ffi::OsString,
     fmt, fs, io,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
@@ -13,9 +13,9 @@ use serde_json::{json, Value};
 use crate::{
     format::{
         AuditEntry, AuditKind, AuditsFile, ConfigFile, CratesPublisher, CriteriaEntry, CriteriaMap,
-        CriteriaName, CriteriaStr, ExemptedDependency, FastMap, ImportsFile, MetaConfig,
-        PackageName, PackagePolicyEntry, PackageStr, PolicyEntry, SortedMap, SortedSet, TrustEntry,
-        VersionReq, VetVersion, WildcardEntry, SAFE_TO_DEPLOY, SAFE_TO_RUN,
+        CriteriaName, CriteriaStr, ExemptedDependency, ImportsFile, MetaConfig, PackageName,
+        PackagePolicyEntry, PackageStr, PolicyEntry, SortedMap, SortedSet, TrustEntry, VersionReq,
+        VetVersion, WildcardEntry, SAFE_TO_DEPLOY, SAFE_TO_RUN,
     },
     git_tool::Editor,
     network::Network,
@@ -167,81 +167,6 @@ struct MockPackage {
 struct MockDependency {
     name: &'static str,
     version: VetVersion,
-}
-
-pub struct MockIndex {
-    packages: FastMap<PackageStr<'static>, Vec<MockRegistryVersion>>,
-    path: PathBuf,
-}
-
-struct MockRegistryVersion {
-    _version: VetVersion,
-    /// Dependency info dummied out in case we ever want that
-    _deps: Vec<()>,
-}
-
-fn reg_ver(pub_ver: u64) -> MockRegistryVersion {
-    MockRegistryVersion {
-        _version: ver(pub_ver),
-        _deps: vec![],
-    }
-}
-
-// The `MockIndex` type should provide the same interface as the
-// `crates_index::Index` type, as it is used in place of that type in test
-// builds.
-impl MockIndex {
-    pub fn new_cargo_default() -> Result<Self, crates_index::Error> {
-        Ok(Self {
-            packages: [
-                ("root-package", vec![reg_ver(DEFAULT_VER)]),
-                ("third-party1", vec![reg_ver(DEFAULT_VER)]),
-                ("third-party2", vec![reg_ver(DEFAULT_VER)]),
-                ("transitive-third-party1", vec![reg_ver(DEFAULT_VER)]),
-                ("first-party", vec![reg_ver(DEFAULT_VER)]),
-                ("firstA", vec![reg_ver(DEFAULT_VER)]),
-                ("firstAB", vec![reg_ver(DEFAULT_VER)]),
-                ("firstB", vec![reg_ver(DEFAULT_VER)]),
-                ("firstB-nodeps", vec![reg_ver(DEFAULT_VER)]),
-                ("thirdA", vec![reg_ver(DEFAULT_VER)]),
-                ("thirdAB", vec![reg_ver(DEFAULT_VER)]),
-                ("third-core", vec![reg_ver(DEFAULT_VER), reg_ver(5)]),
-                ("normal", vec![reg_ver(DEFAULT_VER)]),
-                ("dev", vec![reg_ver(DEFAULT_VER)]),
-                ("build", vec![reg_ver(DEFAULT_VER)]),
-                ("proc-macro", vec![reg_ver(DEFAULT_VER)]),
-                ("dev-proc-macro", vec![reg_ver(DEFAULT_VER)]),
-                ("build-proc-macro", vec![reg_ver(DEFAULT_VER)]),
-                ("dev-cycle", vec![reg_ver(DEFAULT_VER)]),
-                ("both", vec![reg_ver(DEFAULT_VER)]),
-                ("simple-dev", vec![reg_ver(DEFAULT_VER)]),
-                ("simple-dev-indirect", vec![reg_ver(DEFAULT_VER)]),
-                ("dev-cycle-direct", vec![reg_ver(DEFAULT_VER)]),
-                ("dev-cycle-indirect", vec![reg_ver(DEFAULT_VER)]),
-                ("third-normal", vec![reg_ver(DEFAULT_VER)]),
-                ("third-dev", vec![reg_ver(DEFAULT_VER)]),
-                ("first", vec![reg_ver(1)]),
-            ]
-            .into_iter()
-            .collect(),
-            path: Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("/tests/mock-registry/index/testing-cinematic-universe"),
-        })
-    }
-    pub fn update(&mut self) -> Result<(), crates_index::Error> {
-        if self.packages.contains_key("new-package") {
-            return Ok(()); // already updated
-        }
-        self.packages.insert("root", vec![reg_ver(DEFAULT_VER)]);
-        self.packages
-            .get_mut("first")
-            .unwrap()
-            .push(reg_ver(DEFAULT_VER));
-        Ok(())
-    }
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
 }
 
 impl Default for MockPackage {


### PR DESCRIPTION
Since Rust 1.70.0, the default protocol for the crates.io registry has been the sparse protocol. This protocol uses a different directory for its caches than the previous git-based protocol, and stores the index cache very differently on disk.

We already support using the sparse protocol for reading the index directly, however we were still relying on the non-sparse index on disk in order to locate cached source directories when computing diffs and generating suggest output.

This patch stops using crates-index to locate the crates.io index, as we don't need to handle more advanced features like custom indexes.  The simplified logic now checks for both the sparse and non-sparse crates.io indexes, and gracefully falls back if neither is found to downloading the crates ourselves.