### PR TITLE
Improve handling of trust --all

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -576,10 +576,15 @@ pub struct TrustArgs {
     /// If not provided, there will be no notes.
     #[clap(long, action)]
     pub notes: Option<String>,
-    /// If specified, trusts all packages with exemptions which are solely
-    /// published by the given user.
+    /// If specified, trusts all packages with exemptions or failures which are
+    /// solely published by the given user.
     #[clap(long, action, conflicts_with("package"))]
     pub all: Option<String>,
+    /// If specified along with --all, also trusts packages with multiple
+    /// publishers, so long as at least one version was published by the given
+    /// user.
+    #[clap(long, action, requires("all"))]
+    pub allow_multiple_publishers: bool,
 }
 
 /// Forbids the given version

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all_allow_multiple.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all_allow_multiple.snap
@@ -4,7 +4,7 @@ expression: result
 ---
 OUTPUT:
 <<<CLEAR SCREEN>>>
-choose trusted criteria for packages published by testuser (third-party2 and transitive-third-party1)
+choose trusted criteria for packages published by testuser (third-party1, third-party2, and 1 other)
   1. safe-to-run
   2. safe-to-deploy
   3. fuzzed
@@ -34,6 +34,12 @@ implies = "reviewed"
 description = "weakly reviewed"
 
 [audits]
+
+[[trusted.third-party1]]
+criteria = "reviewed"
+user-id = 2 # Test user (testuser)
+start = "2022-12-12"
+end = "2024-01-01"
 
 [[trusted.third-party2]]
 criteria = "reviewed"

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -470,8 +470,12 @@ A free-form string to include with the new audit entry
 If not provided, there will be no notes.
 
 #### `--all <ALL>`
-If specified, trusts all packages with exemptions which are solely published by the
-given user
+If specified, trusts all packages with exemptions or failures which are solely published
+by the given user
+
+#### `--allow-multiple-publishers`
+If specified along with --all, also trusts packages with multiple publishers, so long as
+at least one version was published by the given user
 
 #### `-h, --help`
 Print help information


### PR DESCRIPTION
This patch makes a few changes to how trust --all is handled.

1. `trust --all` will now also trust crates which fail to vet, even if they don't have any exemptions.

2. A new flag, `--allow-multiple-publishers`, can be specified to also trust packages with multiple publishers.

3. `trust --all` will now more intelligently pick the default criteira based on your existing audit graph, providing better support for custom criteria.

Fixes #499