### PR TITLE
Suggest git audit failures in two stages

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -381,6 +381,15 @@ impl Serialize for Delta {
     }
 }
 
+impl fmt::Display for Delta {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.from {
+            Some(from) => writeln!(f, "{} -> {}", from, self.to),
+            None => self.to.fmt(f),
+        }
+    }
+}
+
 /// An entry specifying a wildcard audit for a specific crate based on crates.io
 /// publication time and user-id.
 ///

--- a/tests/cache/diff-cache.toml
+++ b/tests/cache/diff-cache.toml
@@ -300,6 +300,11 @@ insertions = 5691
 deletions = 0
 files_changed = 19
 
+[diffs.proc-macro2."1.0.37 -> 1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9"]
+insertions = 63
+deletions = 7
+files_changed = 3
+
 [diffs.proc-macro2."1.0.39 -> 1.0.37"]
 insertions = 16
 deletions = 71

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -696,6 +696,22 @@ stdout:
   "suggest": {
     "suggestions": [
       {
+        "name": "proc-macro2",
+        "notable_parents": "test-project",
+        "suggested_criteria": [
+          "safe-to-deploy"
+        ],
+        "suggested_diff": {
+          "from": "1.0.37",
+          "to": "1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9",
+          "diffstat": {
+            "insertions": 63,
+            "deletions": 7,
+            "files_changed": 3
+          }
+        }
+      },
+      {
         "name": "tinyvec_macros",
         "notable_parents": "tinyvec",
         "suggested_criteria": [
@@ -1657,23 +1673,7 @@ stdout:
       },
       {
         "name": "proc-macro2",
-        "notable_parents": "test-project",
-        "suggested_criteria": [
-          "safe-to-deploy"
-        ],
-        "suggested_diff": {
-          "from": null,
-          "to": "1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9",
-          "diffstat": {
-            "insertions": 5691,
-            "deletions": 0,
-            "files_changed": 19
-          }
-        }
-      },
-      {
-        "name": "proc-macro2",
-        "notable_parents": "syn, quote, and 3 others",
+        "notable_parents": "syn, quote, test-project, and 3 others",
         "suggested_criteria": [
           "safe-to-deploy"
         ],
@@ -2250,6 +2250,22 @@ stdout:
     ],
     "suggest_by_criteria": {
       "safe-to-deploy": [
+        {
+          "name": "proc-macro2",
+          "notable_parents": "test-project",
+          "suggested_criteria": [
+            "safe-to-deploy"
+          ],
+          "suggested_diff": {
+            "from": "1.0.37",
+            "to": "1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9",
+            "diffstat": {
+              "insertions": 63,
+              "deletions": 7,
+              "files_changed": 3
+            }
+          }
+        },
         {
           "name": "tinyvec_macros",
           "notable_parents": "tinyvec",
@@ -3196,23 +3212,7 @@ stdout:
         },
         {
           "name": "proc-macro2",
-          "notable_parents": "test-project",
-          "suggested_criteria": [
-            "safe-to-deploy"
-          ],
-          "suggested_diff": {
-            "from": null,
-            "to": "1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9",
-            "diffstat": {
-              "insertions": 5691,
-              "deletions": 0,
-              "files_changed": 19
-            }
-          }
-        },
-        {
-          "name": "proc-macro2",
-          "notable_parents": "syn, quote, and 3 others",
+          "notable_parents": "syn, quote, test-project, and 3 others",
           "suggested_criteria": [
             "safe-to-deploy"
           ],
@@ -3806,7 +3806,7 @@ stdout:
         }
       ]
     },
-    "total_lines": 1712738
+    "total_lines": 1707117
   }
 }
 stderr:

--- a/tests/snapshots/test_cli__test-project-suggest.snap
+++ b/tests/snapshots/test_cli__test-project-suggest.snap
@@ -5,6 +5,8 @@ expression: format_outputs(&output)
 stdout:
 recommended audits for safe-to-deploy:
     Command                                               Publisher      Used By                                              Audit Size
+    cargo vet diff proc-macro2 1.0.37 1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9
+                                                          UNKNOWN        test-project                                         3 files changed, 63 insertions(+), 7 deletions(-)
     cargo vet inspect tinyvec_macros 0.1.0                Soveu          tinyvec                                              81 lines
     cargo vet inspect matches 0.1.9                       SimonSapin     url, idna, and form_urlencoded                       210 lines
     cargo vet inspect foreign-types-shared 0.1.1          UNKNOWN        foreign-types                                        302 lines
@@ -66,9 +68,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect schannel 0.1.19                     steffengy      native-tls                                           4601 lines
     cargo vet inspect textwrap 0.15.0                     mgeisler       clap                                                 5196 lines
     cargo vet inspect log 0.4.16                          KodrAus        mio, want, reqwest, native-tls, and 1 other          5625 lines
-    cargo vet inspect proc-macro2 1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9
-                                                          UNKNOWN        test-project                                         5691 lines
-    cargo vet inspect proc-macro2 1.0.37                  dtolnay        syn, quote, and 3 others                             5695 lines
+    cargo vet inspect proc-macro2 1.0.37                  dtolnay        syn, quote, test-project, and 3 others               5695 lines
     cargo vet inspect socket2 0.4.4                       Thomasdezeeuw  hyper and tokio                                      6011 lines
     cargo vet inspect pin-project-lite 0.2.8              taiki-e        hyper, tokio, reqwest, and 4 others                  6100 lines
     cargo vet inspect tracing-core 0.1.25                 hawkw          tracing                                              6156 lines
@@ -112,7 +112,7 @@ recommended audits for safe-to-run:
     Command                              Publisher  Used By  Audit Size
     cargo vet inspect hermit-abi 0.1.19  stlankes   atty     932 lines
 
-estimated audit backlog: 1712738 lines
+estimated audit backlog: 1707117 lines
 
 Use |cargo vet certify| to record the audits.
 


### PR DESCRIPTION
This patch splits suggestions for git failures into two distinct stages,
one of which suggests that the closest published version be audited, and
then a suggestion of a delta-audit from that version to the git version.
In order to keep backlog numbers accurate, we need to suggest both the
delta and the base audit silmultaneously, which requires changes to how
suggestions are resolved.

Care was taken to ensure that these new suggestions should interact
correctly with other suggest features, such as registry suggestions and
trust hints. This is done by making these features only operate on the
"base" suggestion/published version when both are present.

Fixes #378