### PR TITLE
Fix trust test to use MockRegistryBuilder

### DIFF
--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -538,104 +538,30 @@ fn mock_trust_flow_all_allow_multiple() {
     };
 
     let mut network = Network::new_mock();
-    network.mock_serve_json(
-        "https://crates.io/api/v1/crates/third-party1",
-        &serde_json::json!({
-            "crate": { "description": "description" },
-            "versions": [
-                {
-                    "crate": "third-party1",
-                    "created_at": "2022-10-12T04:51:37.251648+00:00",
-                    "num": "1.0.0",
-                },
-                {
-                    "crate": "third-party1",
-                    "created_at": "2022-10-12T04:51:37.251648+00:00",
-                    "num": "9.0.0",
-                    "published_by": {
-                        "id": 5,
-                        "login": "otheruser",
-                        "name": "Other user",
-                        "url": "https://github.com/otheruser"
-                    }
-                },
-                {
-                    "crate": "third-party1",
-                    "created_at": "2022-12-12T04:51:37.251648+00:00",
-                    "num": "10.0.0",
-                    "published_by": {
-                        "id": 2,
-                        "login": "testuser",
-                        "name": "Test user",
-                        "url": "https://github.com/testuser"
-                    }
-                },
-            ]
-        }),
-    );
-    network_mock_index(&mut network, "third-party1", &["1.0.0", "9.0.0", "10.0.0"]);
-
-    network.mock_serve_json(
-        "https://crates.io/api/v1/crates/transitive-third-party1",
-        &serde_json::json!({
-            "crate": { "description": "description" },
-            "versions": [
-                {
-                    "crate": "transitive-third-party1",
-                    "created_at": "2022-10-12T04:51:37.251648+00:00",
-                    "num": "1.0.0",
-                },
-                {
-                    "crate": "transitive-third-party1",
-                    "created_at": "2022-10-12T04:51:37.251648+00:00",
-                    "num": "9.0.0",
-                    "published_by": {
-                        "id": 2,
-                        "login": "testuser",
-                        "name": "Test user",
-                        "url": "https://github.com/testuser"
-                    }
-                },
-                {
-                    "crate": "transitive-third-party1",
-                    "created_at": "2022-12-12T04:51:37.251648+00:00",
-                    "num": "10.0.0",
-                    "published_by": {
-                        "id": 2,
-                        "login": "testuser",
-                        "name": "Test user",
-                        "url": "https://github.com/testuser"
-                    }
-                },
-            ]
-        }),
-    );
-    network_mock_index(
-        &mut network,
-        "transitive-third-party1",
-        &["1.0.0", "9.0.0", "10.0.0"],
-    );
-
-    network.mock_serve_json(
-        "https://crates.io/api/v1/crates/third-party2",
-        &serde_json::json!({
-            "crate": { "description": "description" },
-            "versions": [
-                {
-                    "crate": "third-party2",
-                    "created_at": "2022-12-12T04:51:37.251648+00:00",
-                    "num": "10.0.0",
-                    "published_by": {
-                        "id": 2,
-                        "login": "testuser",
-                        "name": "Test user",
-                        "url": "https://github.com/testuser"
-                    }
-                },
-            ]
-        }),
-    );
-    network_mock_index(&mut network, "third-party2", &["10.0.0"]);
+    MockRegistryBuilder::new()
+        .user(2, "testuser", "Test user")
+        .user(5, "otheruser", "Other user")
+        .package(
+            "third-party1",
+            &[
+                reg_published_by(ver(1), None, "2022-10-12"),
+                reg_published_by(ver(9), Some(5), "2022-10-12"),
+                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+            ],
+        )
+        .package(
+            "transitive-third-party1",
+            &[
+                reg_published_by(ver(1), None, "2022-10-12"),
+                reg_published_by(ver(9), Some(2), "2022-10-12"),
+                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+            ],
+        )
+        .package(
+            "third-party2",
+            &[reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12")],
+        )
+        .serve(&mut network);
 
     let mut store = Store::mock_online(&cfg, config, audits, imports, &network, true)
         .expect("store acquisition failed");


### PR DESCRIPTION
I merged both patches without rebasing, and forgot that I needed to change this test after the unpublished changes.