### PR TITLE
Specify the number of chars to show with "git diff".

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2054,6 +2054,7 @@ fn cmd_diff(out: &Arc<dyn Out>, cfg: &Config, sub_args: &DiffArgs) -> Result<(),
             })
             .arg("--no-index")
             .arg("--ignore-cr-at-eol")
+            .arg("--abbrev=7")
             .arg(&from)
             .arg(&to)
             .stdout(Stdio::piped())


### PR DESCRIPTION
On my system, "git diff" shows 8 hex digits by default, causing test_project_diff_output and test_project_diff_output_git to fail when I run "cargo test". I assume this is due to different versions of diff having different behaviors, but I have not verified.