### PR TITLE
Add --cargo-arg option for arguments to pass through to cargo

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,16 @@ pub struct Cli {
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
     pub filter_graph: Option<Vec<GraphFilter>>,
 
+    /// Arguments to pass through to cargo. It can be specified multiple times for
+    /// multiple arguments.
+    ///
+    /// Example: `--cargo-arg=-Zbindeps`
+    ///
+    /// This allows using unstable options in Cargo if a project's Cargo.toml requires them.
+    #[clap(long, action)]
+    #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
+    pub cargo_arg: Vec<String>,
+
     // Args for `Check` when the subcommand is not explicitly specified.
     //
     // These are exclusive with specifying a subcommand due to

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,7 @@ fn real_main() -> Result<(), miette::Report> {
     {
         other_options.push("--color=always".to_string());
     }
+    other_options.extend(cli.cargo_arg.iter().cloned());
     cmd.other_options(other_options);
 
     info!("Running: {:#?}", cmd.cargo_command());

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 104
 expression: format_outputs(&output)
 ---
 stdout:
@@ -124,6 +125,14 @@ GLOBAL OPTIONS:
             * `is_third_party($bool)`: whether the package is considered third-party by vet
             * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
             graph
+
+        --cargo-arg <CARGO_ARG>
+            Arguments to pass through to cargo. It can be specified multiple times for multiple
+            arguments.
+            
+            Example: `--cargo-arg=-Zbindeps`
+            
+            This allows using unstable options in Cargo if a project's Cargo.toml requires them.
 
 SUBCOMMANDS:
     check

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 134
 expression: format_outputs(&output)
 ---
 stdout:
@@ -133,6 +134,14 @@ tested)
 * `is_third_party($bool)`: whether the package is considered third-party by vet
 * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
 graph
+
+#### `--cargo-arg <CARGO_ARG>`
+Arguments to pass through to cargo. It can be specified multiple times for multiple
+arguments.
+
+Example: `--cargo-arg=-Zbindeps`
+
+This allows using unstable options in Cargo if a project's Cargo.toml requires them.
 
 ### SUBCOMMANDS
 * [check](#cargo-vet-check): \[default\] Check that the current project has been vetted

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test-cli.rs
+assertion_line: 119
 expression: format_outputs(&output)
 ---
 stdout:
@@ -62,6 +63,10 @@ GLOBAL OPTIONS:
 
         --filter-graph <FILTER_GRAPH>
             Filter out different parts of the build graph and pretend that's the true graph
+
+        --cargo-arg <CARGO_ARG>
+            Arguments to pass through to cargo. It can be specified multiple times for multiple
+            arguments
 
 SUBCOMMANDS:
     check               \[default\] Check that the current project has been vetted


### PR DESCRIPTION
Some projects may require additional arguments in the cargo metadata command in order to parse their Cargo.toml. For example Chromium requires `-Zbindeps` as it uses the feature for a dependency on cxxbridge-cmd. This allows such projects to use `cargo vet --cargo-arg=<STUFF>` in order to add one or more arguments to the cargo metadata command line.