### PR TITLE
allow setting git diff command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -484,6 +484,9 @@ pub struct DiffArgs {
     /// How to inspect the source
     #[clap(long, action, default_value = "sourcegraph")]
     pub mode: FetchMode,
+    /// The local git diff command
+    #[clap(long, action, default_value = "diff")]
+    pub diffcmd: String,
 }
 
 /// Certifies a package as audited

--- a/src/main.rs
+++ b/src/main.rs
@@ -2055,7 +2055,7 @@ fn cmd_diff(out: &Arc<dyn Out>, cfg: &Config, sub_args: &DiffArgs) -> Result<(),
         let output = std::process::Command::new("git")
             .arg("-c")
             .arg("core.safecrlf=false")
-            .arg("diff")
+            .arg(&sub_args.diffcmd)
             .arg(if pager.use_color() {
                 "--color=always"
             } else {


### PR DESCRIPTION
nothing too fancy, adds a new argument to allow changing `git diff` to `git difftool` 