### PR TITLE
Collapse non-importable audits when certifying.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -543,6 +543,15 @@ pub struct CertifyArgs {
     /// talk about is part of your current build, but this flag disables that.
     #[clap(long, action)]
     pub force: bool,
+    /// Prevent combination of the audit with a prior adjacent non-importable git audit, if any.
+    ///
+    /// This will only have an effect if the supplied `from` version is a git version.
+    ///
+    /// For example, normally an existing audit from `1.0.0->1.0.0@git:1111111` and a new certified
+    /// audit from `1.0.0@git:1111111->1.0.0@git:2222222` would result in a single audit from
+    /// `1.0.0->1.0.0@git:2222222`. Passing this flag would prevent this.
+    #[clap(long, action, requires("version2"))]
+    pub no_collapse: bool,
 }
 
 /// Import a new peer

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -296,6 +296,9 @@ pub enum CertifyError {
     #[error("end date of {0} is too far in the future")]
     #[diagnostic(help("wildcard audit end dates may be at most 1 year in the future"))]
     BadWildcardEndDate(chrono::NaiveDate),
+    #[error("couldn't build an audit graph to determine audit collapse validity")]
+    #[diagnostic(help("use --no-collapse to disable audit collapsing"))]
+    BadAuditGraph,
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-collapse-non-importable-audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-collapse-non-importable-audits.snap
@@ -14,17 +14,15 @@ OUTPUT:
 #
 # Uncomment the following statement:
 
-# I, testing, certify that I have audited version 10.0.0 of third-party1 in accordance with the above criteria.
+# I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112244 to 10.0.0@git:00112233445566778899aabbccddeeff00112233 of third-party1 in accordance with the above criteria.
 
 # Add any notes about your audit below this line:
 
 
 <<<EDIT OK>>>
-I, testing, certify that I have audited version 10.0.0 of third-party1 in accordance with the above criteria.
+I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112244 to 10.0.0@git:00112233445566778899aabbccddeeff00112233 of third-party1 in accordance with the above criteria.
 
-These are testing notes. They contain some
-newlines. Trailing whitespace        
-    and leading whitespace
+New notes
 
 
 <<<END EDIT>>>
@@ -47,16 +45,14 @@ description = "weakly reviewed"
 
 [[audits.third-party1]]
 criteria = "reviewed"
-delta = "10.0.0 -> 10.0.0@git:ffeeddccbbaa99887766554433221100ffeeddcc"
-notes = "This entry intentionally left importable."
+version = "10.0.0"
 
 [[audits.third-party1]]
-who = "testing"
+who = ["other", "testing"]
 criteria = "reviewed"
-version = "10.0.0"
+delta = "10.0.0 -> 10.0.0@git:00112233445566778899aabbccddeeff00112233"
+importable = false
 notes = """
-These are testing notes. They contain some
-newlines. Trailing whitespace
-    and leading whitespace
-"""
+Old notes
+New notes"""
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-collapse-with-full-audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-collapse-with-full-audit.snap
@@ -14,17 +14,15 @@ OUTPUT:
 #
 # Uncomment the following statement:
 
-# I, testing, certify that I have audited version 10.0.0 of third-party1 in accordance with the above criteria.
+# I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112233 to 10.0.0 of third-party1 in accordance with the above criteria.
 
 # Add any notes about your audit below this line:
 
 
 <<<EDIT OK>>>
-I, testing, certify that I have audited version 10.0.0 of third-party1 in accordance with the above criteria.
+I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112233 to 10.0.0 of third-party1 in accordance with the above criteria.
 
-These are testing notes. They contain some
-newlines. Trailing whitespace        
-    and leading whitespace
+New notes
 
 
 <<<END EDIT>>>
@@ -46,17 +44,8 @@ implies = "reviewed"
 description = "weakly reviewed"
 
 [[audits.third-party1]]
-criteria = "reviewed"
-delta = "10.0.0 -> 10.0.0@git:ffeeddccbbaa99887766554433221100ffeeddcc"
-notes = "This entry intentionally left importable."
-
-[[audits.third-party1]]
 who = "testing"
 criteria = "reviewed"
 version = "10.0.0"
-notes = """
-These are testing notes. They contain some
-newlines. Trailing whitespace
-    and leading whitespace
-"""
+notes = "New notes"
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock-dont-collapse-incompatible-criteria-non-importable-audits.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock-dont-collapse-incompatible-criteria-non-importable-audits.snap
@@ -1,0 +1,63 @@
+---
+source: src/tests/certify.rs
+expression: result
+---
+OUTPUT:
+<<<EDITING VET_CERTIFY>>>
+# Please read the following criteria and then follow the instructions below:
+
+# === BEGIN CRITERIA "strong-reviewed" ===
+#
+# strongly reviewed
+#
+# === END CRITERIA ===
+#
+# Uncomment the following statement:
+
+# I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112244 to 10.0.0@git:00112233445566778899aabbccddeeff00112233 of third-party1 in accordance with the above criteria.
+
+# Add any notes about your audit below this line:
+
+
+<<<EDIT OK>>>
+I, testing, certify that I have audited the changes from version 10.0.0@git:00112233445566778899aabbccddeeff00112244 to 10.0.0@git:00112233445566778899aabbccddeeff00112233 of third-party1 in accordance with the above criteria.
+
+New notes
+
+
+<<<END EDIT>>>
+
+AUDITS:
+
+[criteria.fuzzed]
+description = "fuzzed"
+
+[criteria.reviewed]
+description = "reviewed"
+implies = "weak-reviewed"
+
+[criteria.strong-reviewed]
+description = "strongly reviewed"
+implies = "reviewed"
+
+[criteria.weak-reviewed]
+description = "weakly reviewed"
+
+[[audits.third-party1]]
+criteria = "reviewed"
+version = "10.0.0"
+
+[[audits.third-party1]]
+who = ["testing", "other"]
+criteria = "reviewed"
+delta = "10.0.0 -> 10.0.0@git:00112233445566778899aabbccddeeff00112244"
+importable = false
+notes = "Old notes"
+
+[[audits.third-party1]]
+who = "testing"
+criteria = "strong-reviewed"
+delta = "10.0.0@git:00112233445566778899aabbccddeeff00112244 -> 10.0.0@git:00112233445566778899aabbccddeeff00112233"
+importable = false
+notes = "New notes"
+

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -398,6 +398,15 @@ Force the command to ignore whether the package/version makes sense
 To catch typos/mistakes, we check if the thing you're trying to talk about is part of
 your current build, but this flag disables that.
 
+#### `--no-collapse`
+Prevent combination of the audit with a prior adjacent non-importable git audit, if any.
+
+This will only have an effect if the supplied `from` version is a git version.
+
+For example, normally an existing audit from `1.0.0->1.0.0@git:1111111` and a new
+certified audit from `1.0.0@git:1111111->1.0.0@git:2222222` would result in a single
+audit from `1.0.0->1.0.0@git:2222222`. Passing this flag would prevent this.
+
 #### `-h, --help`
 Print help information
 


### PR DESCRIPTION
Closes #580.

This adds the `--collapse-non-importable` flag (name is up for debate) to the `certify` command.