### PR TITLE
Upgrade libz-sys in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "libc",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -247,7 +247,7 @@ version = "0.13.4+1.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
-version = "1.1.8"
+version = "1.1.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]


### PR DESCRIPTION
In Firefox automation, we build using the Cargo.lock, and the latest libz-sys version contains a fix for clang 18 on mac (https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9)