### PR TITLE
Book: Add repository URL

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -6,3 +6,4 @@ title = "Cargo Vet"
 
 [output.html]
 additional-css = ["src/custom.css"]
+git-repository-url = "https://github.com/mozilla/cargo-vet"

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -29,3 +29,8 @@ gradually as time permits.
 > **Note**: `cargo vet` is under active development. If you're interested in
 > deploying it, [get in touch](mailto:bholley@mozilla.com).
 
+## Contributing
+
+`cargo-vet` is free and open source.
+You can find the source code on [GitHub](https://github.com/mozilla/cargo-vet)
+and issues and feature requests can be posted on the [GitHub issue tracker](https://github.com/mozilla/cargo-vet/issues).


### PR DESCRIPTION
While looking at the docs I realized it doesn't link to the repository anywhere directly.
Adding the config adds an icon on the top right. While I was at it I also added a short paragraph on the main page.