### PR TITLE
Clean up `rustc` and `clippy` warnings.

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -28,6 +28,7 @@ use crate::{
 /// Wrapper for the pair of a `reqwest::Response` and the `SemaphorePermit` used
 /// to limit concurrent connections, with a test-only variant for mocking.
 enum Response<'a> {
+    #[allow(dead_code)] // It's ok that `SemaphorePermit` is never read.
     Real(reqwest::Response, tokio::sync::SemaphorePermit<'a>),
     #[cfg(test)]
     Mock(Option<Bytes>),

--- a/src/network.rs
+++ b/src/network.rs
@@ -28,8 +28,10 @@ use crate::{
 /// Wrapper for the pair of a `reqwest::Response` and the `SemaphorePermit` used
 /// to limit concurrent connections, with a test-only variant for mocking.
 enum Response<'a> {
-    #[allow(dead_code)] // It's ok that `SemaphorePermit` is never read.
-    Real(reqwest::Response, tokio::sync::SemaphorePermit<'a>),
+    Real(
+        reqwest::Response,
+        #[allow(unused)] tokio::sync::SemaphorePermit<'a>,
+    ),
     #[cfg(test)]
     Mock(Option<Bytes>),
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -518,7 +518,7 @@ pub mod spanned {
     thread_local! {
         /// Hack to work around `toml::Spanned` failing to be deserialized when
         /// used with the `toml::Value` deserializer.
-        pub(super) static DISABLE_SPANNED_DESERIALIZATION: Cell<bool> = Cell::new(false);
+        pub(super) static DISABLE_SPANNED_DESERIALIZATION: Cell<bool> = const { Cell::new(false) };
     }
 
     /// A spanned value, indicating the range at which it is defined in the source.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2828,6 +2828,7 @@ fn create_unpack_lock(unpack_dir: &Path) -> Result<(), io::Error> {
     // which may have been extracted from the package.
     let mut ok = OpenOptions::new()
         .create(true)
+        .truncate(true)
         .read(true)
         .write(true)
         .open(lockfile)?;


### PR DESCRIPTION
This addresses the warnings reported in
https://github.com/mozilla/cargo-vet/actions/runs/8444313897/job/23159306099

For more detailsa about the rationale for the `clippy`-related changes, see:

* https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options
* https://rust-lang.github.io/rust-clippy/master/index.html#/thread_local_initializer_can_be_made_const