### PR TITLE
remove dollar sign from shell commands

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -2,12 +2,12 @@
 
 Installing `cargo vet` can be done through Cargo:
 
-```
-$ cargo install --locked cargo-vet
+```sh
+cargo install --locked cargo-vet
 ```
 
 Afterwards you can confirm that it's installed via:
 
-```
-$ cargo vet --version
+```sh
+cargo vet --version
 ```


### PR DESCRIPTION
Copying these commands otherwise do not work out of the box. I get the doc convention to vizually indicicate a command over output, but it interfers with the copy aspect.