### PR TITLE
Include criteria which imply the required criteria in suggest output

### DIFF
--- a/src/criteria.rs
+++ b/src/criteria.rs
@@ -177,6 +177,16 @@ impl CriteriaMapper {
     pub fn criteria_index(&self, criteria_name: CriteriaStr<'_>) -> usize {
         self.index[criteria_name]
     }
+
+    /// Yields the indicies for all criteria which imply the the given criteria.
+    pub fn implied_by_indices(&self, criteria_idx: usize) -> impl Iterator<Item = usize> + '_ {
+        self.all_criteria_iter()
+            .enumerate()
+            .filter(move |&(idx, implies_set)| {
+                implies_set.has_criteria(criteria_idx) && criteria_idx != idx
+            })
+            .map(|(idx, _)| idx)
+    }
 }
 
 impl CriteriaSet {

--- a/src/criteria.rs
+++ b/src/criteria.rs
@@ -178,7 +178,7 @@ impl CriteriaMapper {
         self.index[criteria_name]
     }
 
-    /// Yields the indicies for all criteria which imply the the given criteria.
+    /// Yields the indices for all criteria which imply the given criteria.
     pub fn implied_by_indices(&self, criteria_idx: usize) -> impl Iterator<Item = usize> + '_ {
         self.all_criteria_iter()
             .enumerate()

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.json.snap
@@ -74,7 +74,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "dev-cycle",
           "notable_parents": "root",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-cycle-unaudited.snap
@@ -12,7 +12,7 @@ recommended audits for safe-to-deploy:
     Command                          Publisher  Used By  Audit Size
     cargo vet inspect normal 10.0.0  UNKNOWN    root     100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                             Publisher  Used By  Audit Size
     cargo vet inspect dev-cycle 10.0.0  UNKNOWN    root     100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.json.snap
@@ -182,7 +182,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "dev-cycle-direct",
           "notable_parents": "root",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty-deeper.snap
@@ -17,7 +17,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect both 10.0.0    UNKNOWN    root     100 lines
     cargo vet inspect normal 10.0.0  UNKNOWN    root     100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                                       Publisher  Used By           Audit Size
     cargo vet inspect dev-cycle-direct 10.0.0     UNKNOWN    root              100 lines
     cargo vet inspect dev-cycle-indirect 10.0.0   UNKNOWN    dev-cycle-direct  100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.json.snap
@@ -182,7 +182,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "dev-cycle-direct",
           "notable_parents": "root",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-dev-detection-empty.snap
@@ -17,7 +17,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect both 10.0.0    UNKNOWN    root     100 lines
     cargo vet inspect normal 10.0.0  UNKNOWN    root     100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                                       Publisher  Used By           Audit Size
     cargo vet inspect dev-cycle-direct 10.0.0     UNKNOWN    root              100 lines
     cargo vet inspect dev-cycle-indirect 10.0.0   UNKNOWN    dev-cycle-direct  100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.json.snap
@@ -74,7 +74,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "third-dev",
           "notable_parents": "first",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited-deeper.snap
@@ -12,7 +12,7 @@ recommended audits for safe-to-deploy:
     Command                                Publisher  Used By  Audit Size
     cargo vet inspect third-normal 10.0.0  UNKNOWN    first    100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                             Publisher  Used By  Audit Size
     cargo vet inspect third-dev 10.0.0  UNKNOWN    first    100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.json.snap
@@ -74,7 +74,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "third-dev",
           "notable_parents": "first",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-haunted-no-unaudited.snap
@@ -12,7 +12,7 @@ recommended audits for safe-to-deploy:
     Command                                Publisher  Used By  Audit Size
     cargo vet inspect third-normal 10.0.0  UNKNOWN    first    100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                             Publisher  Used By  Audit Size
     cargo vet inspect third-dev 10.0.0  UNKNOWN    first    100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.json.snap
@@ -214,7 +214,7 @@ expression: json
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy)": [
         {
           "name": "dev",
           "notable_parents": "root",

--- a/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__builtin-simple-deps-no-unaudited.snap
@@ -19,7 +19,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect normal 10.0.0            UNKNOWN    root     100 lines
     cargo vet inspect proc-macro 10.0.0        UNKNOWN    root     100 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy):
     Command                                  Publisher  Used By  Audit Size
     cargo vet inspect dev 10.0.0             UNKNOWN    root     100 lines
     cargo vet inspect dev-proc-macro 10.0.0  UNKNOWN    root     100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstB, thirdA, and thirdAB",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-strong-delta.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                             Publisher  Used By                      Audit Size
     cargo vet inspect third-core 5.0.0  UNKNOWN    firstB, thirdA, and thirdAB  25 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstB, thirdA, and thirdAB",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak-via-weak-delta.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                 Publisher  Used By                      Audit Size
     cargo vet diff third-core 5.0.0 10.0.0  UNKNOWN    firstB, thirdA, and thirdAB  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstB, thirdA, and thirdAB",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-partially-too-weak.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                 Publisher  Used By                      Audit Size
     cargo vet diff third-core 5.0.0 10.0.0  UNKNOWN    firstB, thirdA, and thirdAB  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstB, thirdA, and thirdAB",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-core10-too-weak.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                 Publisher  Used By                      Audit Size
     cargo vet diff third-core 5.0.0 10.0.0  UNKNOWN    firstB, thirdA, and thirdAB  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstB, thirdA, and thirdAB",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core10.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                 Publisher  Used By                      Audit Size
     cargo vet diff third-core 5.0.0 10.0.0  UNKNOWN    firstB, thirdA, and thirdAB  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstA",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-missing-core5.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-core:5.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                             Publisher  Used By  Audit Size
     cargo vet inspect third-core 5.0.0  UNKNOWN    firstA   25 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.json.snap
@@ -102,7 +102,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-core",
           "notable_parents": "firstA",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-complex-no-unaudited.snap
@@ -10,7 +10,7 @@ Vetting Failed!
   thirdA:10.0.0 missing ["reviewed"]
   thirdAB:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                              Publisher  Used By                      Audit Size
     cargo vet inspect third-core 5.0.0   UNKNOWN    firstA                       25 lines
     cargo vet inspect third-core 10.0.0  UNKNOWN    firstB, thirdA, and thirdAB  100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-overshoot.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                  Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 4.0.0  UNKNOWN    first-party  1 files changed, 9 deletions(-)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-too-weak.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-full-audit-undershoot.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                  Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 7.0.0  UNKNOWN    first-party  1 files changed, 24 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-too-weak-full-audit.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                               Publisher  Used By      Audit Size
     cargo vet inspect third-party1 5.0.0  UNKNOWN    first-party  25 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-overshoot.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                  Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 4.0.0  UNKNOWN    first-party  1 files changed, 9 deletions(-)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-too-weak.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-delta-to-unaudited-undershoot.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                  Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 7.0.0  UNKNOWN    first-party  1 files changed, 24 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-and-lower-version-review.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 9.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 19 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-higher-version-review.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                    Publisher  Used By      Audit Size
     cargo vet diff third-party1 11.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 21 deletions(-)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-lower-version-review.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 9.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 19 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-internal.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                Publisher  Used By      Audit Size
     cargo vet inspect third-party1 10.0.0  UNKNOWN    first-party  100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party2",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-direct-leaf.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party2:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                Publisher  Used By      Audit Size
     cargo vet inspect third-party2 10.0.0  UNKNOWN    first-party  100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.json.snap
@@ -56,7 +56,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party2",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-leaves.snap
@@ -8,7 +8,7 @@ Vetting Failed!
   third-party2:10.0.0 missing ["reviewed"]
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect third-party2 10.0.0             UNKNOWN    first-party   100 lines
     cargo vet inspect transitive-third-party1 10.0.0  UNKNOWN    third-party1  100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "transitive-third-party1",
           "notable_parents": "third-party1",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-missing-transitive.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect transitive-third-party1 10.0.0  UNKNOWN    third-party1  100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-needed-reversed-delta-to-unaudited.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                Publisher  Used By      Audit Size
     cargo vet inspect third-party1 10.0.0  UNKNOWN    first-party  100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.json.snap
@@ -79,7 +79,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-no-unaudited.snap
@@ -9,7 +9,7 @@ Vetting Failed!
   third-party2:10.0.0 missing ["reviewed"]
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect third-party1 10.0.0             UNKNOWN    first-party   100 lines
     cargo vet inspect third-party2 10.0.0             UNKNOWN    first-party   100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "transitive-third-party1",
           "notable_parents": "third-party1",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-reviewed-too-weakly.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect transitive-third-party1 10.0.0  UNKNOWN    third-party1  100 lines
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-full-audit.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.json.snap
@@ -33,7 +33,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock-simple-wrongly-reversed-delta-to-unaudited.snap
@@ -7,7 +7,7 @@ Vetting Failed!
 1 unvetted dependencies:
   third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                   Publisher  Used By      Audit Size
     cargo vet diff third-party1 5.0.0 10.0.0  UNKNOWN    first-party  1 files changed, 75 insertions(+)
 

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.json.snap
@@ -79,7 +79,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_no_mapping.snap
@@ -9,7 +9,7 @@ Vetting Failed!
   third-party2:10.0.0 missing ["reviewed"]
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect third-party1 10.0.0             UNKNOWN    first-party   100 lines
     cargo vet inspect third-party2 10.0.0             UNKNOWN    first-party   100 lines

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.json.snap
@@ -79,7 +79,7 @@ expression: json
       }
     ],
     "suggest_by_criteria": {
-      "reviewed": [
+      "reviewed (or strong-reviewed)": [
         {
           "name": "third-party1",
           "notable_parents": "first-party",

--- a/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.snap
+++ b/src/tests/snapshots/cargo_vet__tests__vet__mock_simple_foreign_audited_pun_wrong_mapped.snap
@@ -9,7 +9,7 @@ Vetting Failed!
   third-party2:10.0.0 missing ["reviewed"]
   transitive-third-party1:10.0.0 missing ["reviewed"]
 
-recommended audits for reviewed:
+recommended audits for reviewed (or strong-reviewed):
     Command                                           Publisher  Used By       Audit Size
     cargo vet inspect third-party1 10.0.0             UNKNOWN    first-party   100 lines
     cargo vet inspect third-party2 10.0.0             UNKNOWN    first-party   100 lines

--- a/tests/snapshots/test_cli__test-project-suggest-json.snap
+++ b/tests/snapshots/test_cli__test-project-suggest-json.snap
@@ -2249,7 +2249,7 @@ stdout:
       }
     ],
     "suggest_by_criteria": {
-      "safe-to-deploy": [
+      "safe-to-deploy (or audited)": [
         {
           "name": "proc-macro2",
           "notable_parents": "test-project",
@@ -3787,7 +3787,7 @@ stdout:
           }
         }
       ],
-      "safe-to-run": [
+      "safe-to-run (or safe-to-deploy, or audited)": [
         {
           "name": "hermit-abi",
           "notable_parents": "atty",

--- a/tests/snapshots/test_cli__test-project-suggest.snap
+++ b/tests/snapshots/test_cli__test-project-suggest.snap
@@ -3,7 +3,7 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-recommended audits for safe-to-deploy:
+recommended audits for safe-to-deploy (or audited):
     Command                                               Publisher      Used By                                              Audit Size
     cargo vet diff proc-macro2 1.0.37 1.0.37@git:4445659b0f753a928059244c875a58bb12f791e9
                                                           UNKNOWN        test-project                                         3 files changed, 63 insertions(+), 7 deletions(-)
@@ -108,7 +108,7 @@ recommended audits for safe-to-deploy:
     cargo vet inspect web-sys 0.3.57                      alexcrichton   reqwest and wasm-bindgen-futures                     197013 lines
     cargo vet inspect encoding_rs 0.8.31                  hsivonen       reqwest                                              507245 lines
 
-recommended audits for safe-to-run:
+recommended audits for safe-to-run (or safe-to-deploy, or audited):
     Command                              Publisher  Used By  Audit Size
     cargo vet inspect hermit-abi 0.1.19  stlankes   atty     932 lines
 


### PR DESCRIPTION
For most consumers using exclusively the default criteria, this will only impact the output for `safe-to-run` recommendations to mention that `safe-to-deploy` would also be applicable. For consumers using more complex criteria, this may increase the size of the suggest output more substantially.

This change does impact JSON output, but only for strings generally intended for human consumption. If a script was previously parsing these strings it may be broken by the change.

Fixes #613