### PR TITLE
Suggest cargo vet fmt for formatting errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -471,7 +471,7 @@ pub struct InvalidCriteriaError {
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("A file in the store is not correctly formatted:\n\n{unified_diff}")]
-#[diagnostic(help("run `cargo vet` without --locked to reformat files in the store"))]
+#[diagnostic(help("run `cargo vet fmt` to reformat files in the store"))]
 pub struct BadFormatError {
     pub unified_diff: String,
 }

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__invalid_formatting.snap
@@ -27,7 +27,7 @@ Error:   × A file in the store is not correctly formatted:
   │  version = "1.0.0"
   │  criteria = "safe-to-deploy"
   │ 
-  help: run `cargo vet` without --locked to reformat files in the store
+  help: run `cargo vet fmt` to reformat files in the store
 Error:   × A file in the store is not correctly formatted:
   │ 
   │ --- old/audits.toml
@@ -46,5 +46,5 @@ Error:   × A file in the store is not correctly formatted:
   │ -notes = "valid field"
   │ +version = "2.0.0"
   │ 
-  help: run `cargo vet` without --locked to reformat files in the store
+  help: run `cargo vet fmt` to reformat files in the store
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_config.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_config.snap
@@ -19,5 +19,5 @@ Error:   × A file in the store is not correctly formatted:
   │  criteria = "safe-to-deploy"
   │ -unknown-field = "hi"
   │ 
-  help: run `cargo vet` without --locked to reformat files in the store
+  help: run `cargo vet fmt` to reformat files in the store
 


### PR DESCRIPTION
Unlike the previous suggestion of `cargo vet`, this will reformat the incorrectly formatted document even if the tree currently fails to vet.

Fixes #617