### PR TITLE
Always prune imports when importing new audits for a crate

### DIFF
--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prefer_exemptions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prefer_exemptions.snap
@@ -13,17 +13,11 @@ imports.lock:
 +audited_as = "9.0.0"
 +
  [[publisher.descriptive]]
- version = "8.0.0"
+-version = "8.0.0"
++version = "9.0.0"
  when = "2022-12-15"
  user-id = 1
  user-login = "user1"
  user-name = "User One"
-+
-+[[publisher.descriptive]]
-+version = "9.0.0"
-+when = "2022-12-15"
-+user-id = 1
-+user-login = "user1"
-+user-name = "User One"
 
 


### PR DESCRIPTION
Currently we only prune imports when doing an explicit  prune or when certifying a new audit for the crate. This patch updates the behaviour to also prune imports whenever we are otherwise also adding new imports for the given crate.

This gives us an opportunity to automatically prune old publisher entries when updating a dependency with a trusted entry or wildcard audit, which otherwise wouldn't happen until `cargo vet prune` is explicitly called.

This pruning happens after resolution, so existing imports will still be preferred, and `cargo vet prune` may still perform additional cleanup. Exemptions, git audits, and unpublished entries aren't impacted.

Fixes #620