### PR TITLE
Add SecureDrop's aggregated audits to the registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -16,5 +16,8 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 [registry.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
+[registry.securedrop]
+url = "https://raw.githubusercontent.com/freedomofpress/securedrop-supply-chain/main/audits.toml"
+
 [registry.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"


### PR DESCRIPTION
From <https://github.com/freedomofpress/securedrop-supply-chain>.

-- 

We weren't sure if "securedrop" or "freedomofpress" would be preferred; so far all of our audits are specifically for SecureDrop and not other FPF projects.