### PR TITLE
Fix mistyped typename

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2052,7 +2052,7 @@ fn cmd_diff(out: &Arc<dyn Out>, cfg: &Config, sub_args: &DiffArgs) -> Result<(),
             version2: version2.clone(),
         });
 
-        if sub_args.mode != FetchMode::Local
+        if sub_args.mode != DiffFetchMode::Local
             && version1.git_rev.is_none()
             && version2.git_rev.is_none()
         {


### PR DESCRIPTION
I accidentally introduced a build error when I applied a suggestion to #625. This patch is to fix that build error I introduced.