### PR TITLE
More consistently tidy files before serializing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use out::{progress_bar, IncProgressOnDrop};
 use reqwest::Url;
 use serde::de::Deserialize;
 use serialization::spanned::Spanned;
+use serialization::Tidyable;
 use storage::fetch_registry;
 use thiserror::Error;
 use tracing::{error, info, trace, warn};
@@ -2553,6 +2554,9 @@ fn do_aggregate_audits(sources: Vec<(String, AuditsFile)>) -> Result<AuditsFile,
                 }));
         }
     }
+
+    aggregate.tidy();
+
     if errors.is_empty() {
         Ok(aggregate)
     } else {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -372,6 +372,25 @@ pub mod audit {
     }
 }
 
+/// Trait implemented by format data types which may want to be cleaned up
+/// before they are serialized.
+pub trait Tidyable {
+    /// Ensure that the data structure is tidy and ready to be serialized.
+    /// This may remove empty entries from maps, ensure lists are sorted, etc.
+    fn tidy(&mut self);
+}
+
+/// Helper for tidying the common audit data structure, removing empty entries,
+/// and sorting audit lists.
+impl<K: Ord, E: Ord> Tidyable for SortedMap<K, Vec<E>> {
+    fn tidy(&mut self) {
+        self.retain(|_, entries| {
+            entries.sort();
+            !entries.is_empty()
+        });
+    }
+}
+
 /// Inline arrays which have a representation longer than this will be rendered
 /// over multiple lines.
 const ARRAY_WRAP_THRESHOLD: usize = 80;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -41,7 +41,7 @@ use crate::{
     },
     network::Network,
     out::{progress_bar, IncProgressOnDrop},
-    serialization::{parse_from_value, spanned::Spanned, to_formatted_toml},
+    serialization::{parse_from_value, spanned::Spanned, to_formatted_toml, Tidyable},
     Config, PackageExt, PartialConfig, CARGO_ENV,
 };
 
@@ -2992,12 +2992,14 @@ where
 }
 fn store_toml<T>(
     heading: &str,
-    val: T,
+    mut val: T,
     user_info: Option<&FastMap<CratesUserId, CratesCacheUser>>,
 ) -> Result<String, StoreTomlError>
 where
-    T: Serialize,
+    T: Serialize + Tidyable,
 {
+    val.tidy();
+
     let toml_document = to_formatted_toml(val, user_info)?;
     Ok(format!("{heading}{toml_document}"))
 }
@@ -3019,25 +3021,16 @@ where
     Ok(json_string)
 }
 fn store_audits(
-    mut audits: AuditsFile,
+    audits: AuditsFile,
     user_info: &FastMap<CratesUserId, CratesCacheUser>,
 ) -> Result<String, StoreTomlError> {
     let heading = r###"
 # cargo-vet audits file
 "###;
-    audits
-        .audits
-        .values_mut()
-        .for_each(|entries| entries.sort());
 
     store_toml(heading, audits, Some(user_info))
 }
-fn store_config(mut config: ConfigFile) -> Result<String, StoreTomlError> {
-    config
-        .exemptions
-        .values_mut()
-        .for_each(|entries| entries.sort());
-
+fn store_config(config: ConfigFile) -> Result<String, StoreTomlError> {
     let heading = r###"
 # cargo-vet config file
 "###;

--- a/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_basic.snap
+++ b/src/tests/snapshots/cargo_vet__tests__aggregate__merge_audits_files_basic.snap
@@ -26,13 +26,13 @@ aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
 
 [[audits.package1]]
 criteria = "safe-to-deploy"
-version = "10.0.0"
-aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
+version = "5.0.0"
+aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
 
 [[audits.package1]]
 criteria = "safe-to-deploy"
-version = "5.0.0"
-aggregated-from = "https://source2.example.com/supply_chain/audits.toml"
+version = "10.0.0"
+aggregated-from = "https://source1.example.com/supply_chain/audits.toml"
 
 [[audits.package1]]
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Before these changes, we wouldn't tidy the files when aggregating, which could lead to empty entries appearing in aggregated audits files (e.g. github.com/mozilla/supply-chain/blob/0473560de259e980a703711cfbe64987c22fe3df/audits.toml#L838)