### PR TITLE
Specify the supported rust version for cargo-vet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/mozilla/cargo-vet"
 homepage = "https://mozilla.github.io/cargo-vet/"
 description = "Supply-chain security for Rust"
+rust-version = "1.65"
 exclude = [
   "book/*",
   "src/snapshots/*",


### PR DESCRIPTION
This helps avoid CI failures due to clippy suggesting changes which are not compatible with our MSRV.