### PR TITLE
Remember user --mode choices, and support diff.rs for inspect

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,6 @@
 //! Details of the file formats used by cargo vet
 
+use crate::cli::FetchMode;
 use crate::errors::{StoreVersionParseError, VersionParseError};
 use crate::resolver::{DiffRecommendation, ViolationConflict};
 use crate::serialization::{spanned::Spanned, Tidyable};
@@ -1182,6 +1183,7 @@ impl FetchCommand {
 pub struct CommandHistory {
     #[serde(flatten)]
     pub last_fetch: Option<FetchCommand>,
+    pub last_fetch_mode: Option<FetchMode>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,8 +570,23 @@ fn cmd_inspect(
             version: version.clone(),
         });
 
-        if sub_args.mode == InspectFetchMode::Sourcegraph && version.git_rev.is_none() {
-            let url = format!("https://sourcegraph.com/crates/{package}@v{version}");
+        // If an explicit mode was set, record it in the cache, then pull the
+        // most recent explicit mode to use for this call.
+        if let Some(mode) = sub_args.mode {
+            cache.set_last_fetch_mode(mode);
+        }
+        let mode = cache.get_last_fetch_mode().unwrap_or(FetchMode::DiffRs);
+
+        if mode != FetchMode::Local && version.git_rev.is_none() {
+            let url = match mode {
+                FetchMode::Sourcegraph => {
+                    format!("https://sourcegraph.com/crates/{package}@v{version}")
+                }
+                FetchMode::DiffRs => {
+                    format!("https://diff.rs/{package}/{version}/{version}/")
+                }
+                FetchMode::Local => unreachable!(),
+            };
             tokio::runtime::Handle::current()
                 .block_on(prompt_criteria_eulas(
                     out,
@@ -2050,20 +2065,24 @@ fn cmd_diff(out: &Arc<dyn Out>, cfg: &Config, sub_args: &DiffArgs) -> Result<(),
             version2: version2.clone(),
         });
 
-        if sub_args.mode != DiffFetchMode::Local
-            && version1.git_rev.is_none()
-            && version2.git_rev.is_none()
-        {
-            let url = match sub_args.mode {
-                DiffFetchMode::Sourcegraph => {
+        // If an explicit mode was set, record it in the cache, then pull the
+        // most recent explicit mode to use for this call.
+        if let Some(mode) = sub_args.mode {
+            cache.set_last_fetch_mode(mode);
+        }
+        let mode = cache.get_last_fetch_mode().unwrap_or(FetchMode::DiffRs);
+
+        if mode != FetchMode::Local && version1.git_rev.is_none() && version2.git_rev.is_none() {
+            let url = match mode {
+                FetchMode::Sourcegraph => {
                     format!(
                         "https://sourcegraph.com/crates/{package}/-/compare/v{version1}...v{version2}?visible=7000"
                     )
                 }
-                DiffFetchMode::DiffRs => {
+                FetchMode::DiffRs => {
                     format!("https://diff.rs/{package}/{version1}/{version2}/")
                 }
-                DiffFetchMode::Local => unreachable!(),
+                FetchMode::Local => unreachable!(),
             };
             tokio::runtime::Handle::current()
                 .block_on(prompt_criteria_eulas(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,6 +19,7 @@ use tar::Archive;
 use tracing::{error, info, log::warn, trace};
 
 use crate::{
+    cli::FetchMode,
     criteria::CriteriaMapper,
     errors::{
         AggregateError, BadFormatError, BadWildcardEndDateError, CacheAcquireError,
@@ -2289,6 +2290,16 @@ impl Cache {
     pub fn set_last_fetch(&self, last_fetch: FetchCommand) {
         let mut guard = self.state.lock().unwrap();
         guard.command_history.last_fetch = Some(last_fetch);
+    }
+
+    pub fn get_last_fetch_mode(&self) -> Option<FetchMode> {
+        let guard = self.state.lock().unwrap();
+        guard.command_history.last_fetch_mode
+    }
+
+    pub fn set_last_fetch_mode(&self, mode: FetchMode) {
+        let mut guard = self.state.lock().unwrap();
+        guard.command_history.last_fetch_mode = Some(mode);
     }
 
     /// For a given package, fetch the list of versions published on crates.io,

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -277,8 +277,12 @@ The version to inspect
 #### `--mode <MODE>`
 How to inspect the source
 
-\[default: sourcegraph]  
-\[possible values: local, sourcegraph]  
+Defaults to the most recently used --mode argument, or diff.rs if no mode argument has
+been used.
+
+This option is ignored if a git version is passed.
+
+\[possible values: local, sourcegraph, diff.rs]  
 
 #### `-h, --help`
 Print help information
@@ -310,9 +314,13 @@ The target version to diff
 
 ### OPTIONS
 #### `--mode <MODE>`
-How to inspect the source
+How to inspect the diff
 
-\[default: sourcegraph]  
+Defaults to the most recently used --mode argument, or diff.rs if no mode argument has
+been used.
+
+This option is ignored if a git version is passed.
+
 \[possible values: local, sourcegraph, diff.rs]  
 
 #### `-h, --help`


### PR DESCRIPTION
This change adds support to remember user's --mode choices, so that they do not need to be used every time. In addition, it adds a basic support for diff.rs to inspect (by loading a diff from a version to itself) such that this mode memory can be shared between diff and inspect.

If xfbs/diff.rs#24 is merged, we should change the diff.rs inspect behaviour to use the new browse endpoints instead.

Finally, this patch changes the default mode from sourcegraph to diff.rs. As noted in #611, sourcegraph has been quite unreliable lately, and diff.rs is likely to provide a better experience until that is resolved.