### PR TITLE
Use the new browse endpoint for diff.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -580,7 +580,7 @@ fn cmd_inspect(
                     format!("https://sourcegraph.com/crates/{package}@v{version}")
                 }
                 FetchMode::DiffRs => {
-                    format!("https://diff.rs/{package}/{version}/{version}/")
+                    format!("https://diff.rs/browse/{package}/{version}/")
                 }
                 FetchMode::Local => unreachable!(),
             };


### PR DESCRIPTION
This was a new endpoint added in xfbs/diff.rs#24, which is used to browse a specific version of a crate.