### PR TITLE
 Don't prompt to renew expiring wildcard audits for inactive crates

### DIFF
--- a/src/git_tool.rs
+++ b/src/git_tool.rs
@@ -136,7 +136,7 @@ pub struct Editor<'a> {
     run_editor: Box<dyn FnOnce(&Path) -> io::Result<bool> + 'a>,
 }
 
-impl<'a> Editor<'a> {
+impl Editor<'_> {
     /// Create a new editor for a temporary file.
     pub fn new(name: &str) -> io::Result<Self> {
         let tempfile = tempfile::Builder::new()
@@ -172,12 +172,6 @@ impl<'a> Editor<'a> {
                 .find(|cc| *cc != '\0')
                 .expect("couldn't find a viable comment character"),
         );
-    }
-
-    #[cfg(test)]
-    /// Test-only method to mock out the actual invocation of the editor.
-    pub fn set_run_editor(&mut self, run_editor: impl FnOnce(&Path) -> io::Result<bool> + 'a) {
-        self.run_editor = Box::new(run_editor);
     }
 
     /// Add comment lines to the editor. Any newlines in the input will be
@@ -257,6 +251,14 @@ impl<'a> Editor<'a> {
         }
 
         Ok(lines.join("\n"))
+    }
+}
+
+#[cfg(test)]
+impl<'a> Editor<'a> {
+    /// Test-only method to mock out the actual invocation of the editor.
+    pub fn set_run_editor(&mut self, run_editor: impl FnOnce(&Path) -> io::Result<bool> + 'a) {
+        self.run_editor = Box::new(run_editor);
     }
 }
 

--- a/src/tests/audit_as_crates_io.rs
+++ b/src/tests/audit_as_crates_io.rs
@@ -25,7 +25,11 @@ fn build_registry(network: &mut Network, extra_packages: &[&str]) {
                 }),
                 repository: None,
             },
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-01-01")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_months_ago(12),
+            )],
         );
     }
     registry.serve(network);

--- a/src/tests/certify.rs
+++ b/src/tests/certify.rs
@@ -619,7 +619,7 @@ fn mock_wildcard_certify_flow() {
         |_| Ok("\n".to_owned()),
         |_| {
             Ok("\
-            I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.\n\
+            I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-18 and 2024-01-01 will satisfy the above criteria.\n\
             \n\
             These are testing notes. They contain some\n\
             newlines. Trailing whitespace        \n    \
@@ -655,8 +655,8 @@ fn mock_wildcard_certify_flow() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(9), Some(5), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(9), Some(5), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);
@@ -709,9 +709,9 @@ fn mock_trust_flow_simple() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(2), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(2), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);
@@ -764,9 +764,9 @@ fn mock_trust_flow_ambiguous() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(5), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(5), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);
@@ -808,9 +808,9 @@ fn mock_trust_flow_explicit() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(5), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(5), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);
@@ -863,22 +863,26 @@ fn mock_trust_flow_all() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(5), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(5), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .package(
             "transitive-third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(2), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(2), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .package(
             "third-party2",
-            &[reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(2),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 
@@ -940,22 +944,26 @@ fn mock_trust_flow_all_allow_multiple() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(5), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(5), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .package(
             "transitive-third-party1",
             &[
-                reg_published_by(ver(1), None, "2022-10-12"),
-                reg_published_by(ver(9), Some(2), "2022-10-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
+                reg_published_by(ver(1), None, mock_weeks_ago(10)),
+                reg_published_by(ver(9), Some(2), mock_weeks_ago(10)),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
             ],
         )
         .package(
             "third-party2",
-            &[reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(2),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 

--- a/src/tests/import.rs
+++ b/src/tests/import.rs
@@ -193,7 +193,11 @@ fn existing_peer_skip_import() {
         .user(1, "user1", "User One")
         .package(
             "third-party2",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 
@@ -1650,15 +1654,15 @@ fn import_wildcard_audit_publisher() {
         .package(
             "third-party1",
             &[
-                reg_published_by(ver(DEFAULT_VER), Some(2), "2022-12-12"),
-                reg_published_by(ver(5), Some(2), "2022-12-12"),
+                reg_published_by(ver(DEFAULT_VER), Some(2), mock_weeks_ago(2)),
+                reg_published_by(ver(5), Some(2), mock_weeks_ago(2)),
             ],
         )
         .package(
             "third-party2",
             &[
-                reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12"),
-                reg_published_by(ver(5), Some(2), "2022-12-12"),
+                reg_published_by(ver(DEFAULT_VER), Some(1), mock_weeks_ago(2)),
+                reg_published_by(ver(5), Some(2), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);
@@ -1983,7 +1987,11 @@ fn existing_import_kept_despite_local_wildcard_audit() {
         .user(1, "user1", "User One")
         .package(
             "third-party2",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-15")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
     network.mock_serve_toml(FOREIGN_URL, &foreign_audits);
@@ -2044,7 +2052,11 @@ fn local_wildcard_audit_preferred_to_fresh_import() {
         .user(1, "user1", "User One")
         .package(
             "third-party2",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-15")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
     network.mock_serve_toml(FOREIGN_URL, &foreign_audits);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -264,8 +264,8 @@ fn wildcard_audit(user_id: u64, criteria: CriteriaStr) -> WildcardEntry {
         notes: None,
         criteria: vec![criteria.to_string().into()],
         user_id,
-        start: chrono::NaiveDate::from_ymd_opt(2022, 12, 1).unwrap().into(),
-        end: chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().into(),
+        start: mock_months_ago(1).date_naive().into(),
+        end: mock_today().into(),
         renew: None,
         aggregated_from: vec![],
         is_fresh_import: false,
@@ -281,8 +281,8 @@ fn wildcard_audit_m(
         notes: None,
         criteria: criteria.into_iter().map(|s| s.into().into()).collect(),
         user_id,
-        start: chrono::NaiveDate::from_ymd_opt(2022, 12, 1).unwrap().into(),
-        end: chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().into(),
+        start: mock_months_ago(1).date_naive().into(),
+        end: mock_today().into(),
         renew: None,
         aggregated_from: vec![],
         is_fresh_import: false,
@@ -294,8 +294,8 @@ fn trusted_entry(user_id: u64, criteria: CriteriaStr) -> TrustEntry {
         notes: None,
         criteria: vec![criteria.to_string().into()],
         user_id,
-        start: chrono::NaiveDate::from_ymd_opt(2022, 12, 1).unwrap().into(),
-        end: chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().into(),
+        start: mock_months_ago(1).date_naive().into(),
+        end: mock_today().into(),
         aggregated_from: vec![],
     }
 }
@@ -303,7 +303,7 @@ fn trusted_entry(user_id: u64, criteria: CriteriaStr) -> TrustEntry {
 fn publisher_entry(version: VetVersion, user_id: u64) -> CratesPublisher {
     CratesPublisher {
         version,
-        when: chrono::NaiveDate::from_ymd_opt(2022, 12, 15).unwrap(),
+        when: mock_weeks_ago(2).date_naive(),
         user_id,
         user_login: format!("user{user_id}"),
         user_name: None,
@@ -319,7 +319,7 @@ fn publisher_entry_named(
 ) -> CratesPublisher {
     CratesPublisher {
         version,
-        when: chrono::NaiveDate::from_ymd_opt(2022, 12, 15).unwrap(),
+        when: mock_weeks_ago(2).date_naive(),
         user_id,
         user_login: login.to_owned(),
         user_name: Some(name.to_owned()),
@@ -1078,7 +1078,17 @@ fn mock_now() -> chrono::DateTime<chrono::Utc> {
     )
 }
 
-/// Returns a fixed datetime that should be considered `today`: 2023-01-01.
+/// Returns a fixed datetime that is `months` months ago relative to `mock_now()`
+fn mock_months_ago(months: u32) -> chrono::DateTime<chrono::Utc> {
+    mock_now() - chrono::Months::new(months)
+}
+
+/// Returns a fixed datetime that is `weeks` weeks ago relative to `mock_now()`
+fn mock_weeks_ago(weeks: i64) -> chrono::DateTime<chrono::Utc> {
+    mock_now() - chrono::Duration::weeks(weeks)
+}
+
+/// Returns a fixed date that should be considered `today`: 2023-01-01.
 ///
 /// This is derived from `mock_now()`.
 fn mock_today() -> chrono::NaiveDate {
@@ -1256,7 +1266,7 @@ struct MockRegistryVersion {
 fn reg_published_by(
     version: VetVersion,
     published_by: Option<CratesUserId>,
-    when: &str,
+    when: chrono::DateTime<chrono::Utc>,
 ) -> MockRegistryVersion {
     assert!(
         version.git_rev.is_none(),
@@ -1265,13 +1275,7 @@ fn reg_published_by(
     MockRegistryVersion {
         version: version.semver,
         published_by,
-        created_at: chrono::DateTime::from_utc(
-            chrono::NaiveDateTime::new(
-                when.parse::<chrono::NaiveDate>().unwrap(),
-                chrono::NaiveTime::from_hms_opt(12, 0, 0).unwrap(),
-            ),
-            chrono::Utc,
-        ),
+        created_at: when,
     }
 }
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all.snap
@@ -38,12 +38,12 @@ description = "weakly reviewed"
 [[trusted.third-party2]]
 criteria = "reviewed"
 user-id = 2 # Test user (testuser)
-start = "2022-12-12"
+start = "2022-12-18"
 end = "2024-01-01"
 
 [[trusted.transitive-third-party1]]
 criteria = "reviewed"
 user-id = 2 # Test user (testuser)
-start = "2022-10-12"
+start = "2022-10-23"
 end = "2024-01-01"
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all_allow_multiple.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_all_allow_multiple.snap
@@ -38,18 +38,18 @@ description = "weakly reviewed"
 [[trusted.third-party1]]
 criteria = "reviewed"
 user-id = 2 # Test user (testuser)
-start = "2022-12-12"
+start = "2022-12-18"
 end = "2024-01-01"
 
 [[trusted.third-party2]]
 criteria = "reviewed"
 user-id = 2 # Test user (testuser)
-start = "2022-12-12"
+start = "2022-12-18"
 end = "2024-01-01"
 
 [[trusted.transitive-third-party1]]
 criteria = "reviewed"
 user-id = 2 # Test user (testuser)
-start = "2022-10-12"
+start = "2022-10-23"
 end = "2024-01-01"
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_explicit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_explicit.snap
@@ -38,6 +38,6 @@ description = "weakly reviewed"
 [[trusted.third-party1]]
 criteria = "safe-to-deploy"
 user-id = 2
-start = "2022-12-12"
+start = "2022-12-18"
 end = "2024-01-01"
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_simple.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_trust_flow_simple.snap
@@ -38,6 +38,6 @@ description = "weakly reviewed"
 [[trusted.third-party1]]
 criteria = "safe-to-deploy"
 user-id = 2
-start = "2022-10-12"
+start = "2022-10-23"
 end = "2024-01-01"
 

--- a/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
+++ b/src/tests/snapshots/cargo_vet__tests__certify__mock_wildcard_certify_flow.snap
@@ -44,13 +44,13 @@ current selection: ["safe-to-deploy"]
 #
 # Uncomment the following statement:
 
-# I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.
+# I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-18 and 2024-01-01 will satisfy the above criteria.
 
 # Add any notes about your audit below this line:
 
 
 <<<EDIT OK>>>
-I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-12 and 2024-01-01 will satisfy the above criteria.
+I, testing, certify that any version of third-party1 published by 'testuser' between 2022-12-18 and 2024-01-01 will satisfy the above criteria.
 
 These are testing notes. They contain some
 newlines. Trailing whitespace        
@@ -79,7 +79,7 @@ description = "weakly reviewed"
 who = "testing"
 criteria = "safe-to-deploy"
 user-id = 2
-start = "2022-12-12"
+start = "2022-12-18"
 end = "2024-01-01"
 notes = """
 These are testing notes. They contain some

--- a/src/tests/snapshots/cargo_vet__tests__import__import_wildcard_audit_publisher.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__import_wildcard_audit_publisher.snap
@@ -5,14 +5,14 @@ expression: output
  
 +[[publisher.third-party1]]
 +version = "10.0.0"
-+when = "2022-12-12"
++when = "2022-12-18"
 +user-id = 2
 +user-login = "user2"
 +user-name = "User Two"
 +
 +[[publisher.third-party2]]
 +version = "10.0.0"
-+when = "2022-12-12"
++when = "2022-12-18"
 +user-id = 1
 +user-login = "user1"
 +user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__import__local_wildcard_audit_preferred_to_fresh_import.snap
+++ b/src/tests/snapshots/cargo_vet__tests__import__local_wildcard_audit_preferred_to_fresh_import.snap
@@ -5,7 +5,7 @@ expression: output
 +
 +[[publisher.third-party2]]
 +version = "10.0.0"
-+when = "2022-12-15"
++when = "2022-12-18"
 +user-id = 1
 +user-login = "user1"
 +user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prefer_exemptions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prefer_exemptions.snap
@@ -15,7 +15,7 @@ imports.lock:
  [[publisher.descriptive]]
 -version = "8.0.0"
 +version = "9.0.0"
- when = "2022-12-15"
+ when = "2022-12-18"
  user-id = 1
  user-login = "user1"
  user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_prune.snap
@@ -15,7 +15,7 @@ imports.lock:
  [[publisher.descriptive]]
 -version = "8.0.0"
 +version = "9.0.0"
- when = "2022-12-15"
+ when = "2022-12-18"
  user-id = 1
  user-login = "user1"
  user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_regenerate_exemptions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_nounpublished_regenerate_exemptions.snap
@@ -15,7 +15,7 @@ imports.lock:
  [[publisher.descriptive]]
 -version = "8.0.0"
 +version = "9.0.0"
- when = "2022-12-15"
+ when = "2022-12-18"
  user-id = 1
  user-login = "user1"
  user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_prune.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_prune.snap
@@ -16,7 +16,7 @@ imports.lock:
  [[publisher.descriptive]]
 -version = "8.0.0"
 +version = "9.0.0"
- when = "2022-12-15"
+ when = "2022-12-18"
  user-id = 1
  user-login = "user1"
  user-name = "User One"

--- a/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_regenerate_exemptions.snap
+++ b/src/tests/snapshots/cargo_vet__tests__unpublished__audit_as_crates_io_unpublished_wildcard_regenerate_exemptions.snap
@@ -16,7 +16,7 @@ imports.lock:
  [[publisher.descriptive]]
 -version = "8.0.0"
 +version = "9.0.0"
- when = "2022-12-15"
+ when = "2022-12-18"
  user-id = 1
  user-login = "user1"
  user-name = "User One"

--- a/src/tests/trusted.rs
+++ b/src/tests/trusted.rs
@@ -124,7 +124,11 @@ fn trusted_suggest_local() {
         .user(1, "testuser", "Test user")
         .package(
             "transitive-third-party1",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 
@@ -170,7 +174,11 @@ fn trusted_suggest_import() {
         .user(1, "testuser", "Test user")
         .package(
             "transitive-third-party1",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 
@@ -225,7 +233,11 @@ fn trusted_suggest_import_multiple() {
         .user(1, "testuser", "Test user")
         .package(
             "transitive-third-party1",
-            &[reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12")],
+            &[reg_published_by(
+                ver(DEFAULT_VER),
+                Some(1),
+                mock_weeks_ago(2),
+            )],
         )
         .serve(&mut network);
 
@@ -261,8 +273,8 @@ fn trusted_suggest_local_ambiguous() {
         .package(
             "transitive-third-party1",
             &[
-                reg_published_by(ver(9), Some(2), "2022-12-12"),
-                reg_published_by(ver(DEFAULT_VER), Some(1), "2022-12-12"),
+                reg_published_by(ver(9), Some(2), mock_weeks_ago(2)),
+                reg_published_by(ver(DEFAULT_VER), Some(1), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);

--- a/src/tests/unpublished.rs
+++ b/src/tests/unpublished.rs
@@ -70,8 +70,8 @@ fn unpublished_basic_regenerate(
         .package(
             "descriptive",
             &[
-                reg_published_by(ver(8), Some(1), "2022-12-15"),
-                reg_published_by(ver(9), Some(1), "2022-12-15"),
+                reg_published_by(ver(8), Some(1), mock_weeks_ago(2)),
+                reg_published_by(ver(9), Some(1), mock_weeks_ago(2)),
             ],
         )
         .serve(&mut network);


### PR DESCRIPTION
This silences the wildcard audit renewal warning for crates which have not been updated in at least 4 months, and haven't been updated since the wildcard audit has expired.

Fixes #647