### PR TITLE
Don't automatically renew wildcard audits for inactive crates

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -750,6 +750,11 @@ pub struct RenewArgs {
     #[clap(long, action, conflicts_with("crate-name"))]
     pub expiring: bool,
 
+    /// Renew wildcard audits for inactive crates which have not been updated
+    /// in 4 months.
+    #[clap(long, action, requires("expiring"))]
+    pub include_inactive: bool,
+
     /// The name of a crate to renew.
     #[clap(value_name("CRATE"), action, required_unless_present("expiring"))]
     pub crate_name: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1848,7 +1848,8 @@ fn cmd_regenerate_unpublished(
 
 fn cmd_renew(out: &Arc<dyn Out>, cfg: &Config, sub_args: &RenewArgs) -> Result<(), miette::Report> {
     trace!("renewing wildcard audits");
-    let mut store = Store::acquire_offline(cfg)?;
+    let network = Network::acquire(cfg);
+    let mut store = Store::acquire(cfg, network.as_ref(), false)?;
     do_cmd_renew(out, cfg, &mut store, sub_args);
     store.commit()?;
     Ok(())
@@ -1882,7 +1883,7 @@ fn do_cmd_renew(out: &Arc<dyn Out>, cfg: &Config, store: &mut Store, sub_args: &
     } else {
         // Find and update all expiring crates.
         assert!(sub_args.expiring);
-        renewing = WildcardAuditRenewal::expiring(cfg, store, false);
+        renewing = WildcardAuditRenewal::expiring(cfg, store, !sub_args.include_inactive);
 
         if renewing.is_empty() {
             info!("no wildcard audits that are eligible for renewal have expired or are expiring in the next {WILDCARD_AUDIT_EXPIRATION_STRING}");

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -906,6 +906,9 @@ The name of a crate to renew
 #### `--expiring`
 Renew all wildcard audits which will have expired six weeks from now
 
+#### `--include-inactive`
+Renew wildcard audits for inactive crates which have not been updated in 4 months
+
 #### `-h, --help`
 Print help information
 


### PR DESCRIPTION
This is a follow-up from #648. After that change the `cargo vet renew --expiring` command still would renew audits for inactive crates. This changes that behaviour to also require an `--include-inactive` flag to renew for inactive crates.
