### PR TITLE
Advertise Google's ub-risk-N audit criteria as an example of custom criteria

### DIFF
--- a/book/src/audit-criteria.md
+++ b/book/src/audit-criteria.md
@@ -51,3 +51,20 @@ criteria:
   for A, B, and C allows the two projects to partially share work.
 
 You can define and use as many separate sets of criteria as you like.
+
+### Example criteria set: Google's `ub-risk-N`
+
+Google's rust crate audits define a set of 7 audit criteria that form an
+implication chain: `ub-risk-0` through `ub-risk-4`, along with
+`ub-risk-1-thorough` and `ub-risk-2-thorough` indicating that two unsafe Rust
+experts performed the audit. Most projects that want to use this critera set
+should specify `ub-risk-2` as the policy criteria and specify per-crate
+policy exceptions for `ub-risk-3` crates.
+
+A notable feature of this criteria set is that it allows you to record an audit
+for a crate that your organization has decided is unacceptable for use
+(`ub-risk-4`), which can assist in tracking whether the issues have been fixed
+when you revisit the crate in the future.
+
+The criteria can be viewed in the `[registry.google]` link in `registry.toml`
+and at <https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md>.

--- a/book/src/audit-criteria.md
+++ b/book/src/audit-criteria.md
@@ -23,6 +23,10 @@ member of a designated set of cryptography experts within the project.
 
 The full feature set is documented [here](config.md#the-criteria-table).
 
+If you are using [aggregated audits](multiple-repositories.md), the
+`description` of each criteria must be **exactly identical** in every
+repository, or the aggregation will fail.
+
 ## Multiple Sets of Criteria
 
 There are a number of reasons you might wish to operate with multiple sets of
@@ -30,10 +34,18 @@ criteria:
 * **Applying extra checks to some crates:** For example, you might define
   `crypto-reviewed` criteria and require them for audits of crates which
   implement cryptographic algorithms that your application depends on.
+
 * **Relaxing your audit requirements for some crates:** For example, you might
   decide that crates not exposed in production can just be `safe-to-run`
   rather than `safe-to-deploy`, since they don't need to be audited for handling
   adversarial input.
+
+    ```
+    [policy.mycrate]
+    criteria = ["safe-to-deploy"]
+    dependency-criteria = { non-exposed-crate = ["safe-to-run"] }
+    ```
+
 * **Improving Sharing:** If one project wants to audit for issues A and B, and
   another project wants to audit for B and C, defining separate sets of criteria
   for A, B, and C allows the two projects to partially share work.


### PR DESCRIPTION
The [ub-risk-N criteria set](https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-0) seems to be a well-designed set of audit criteria that seems to have worked well for over a year, and aside from zcash's `crypto-reviewed` and `license-reviewed` is the only set of non-default criteria currently available in the ecosystem registry.toml.

I didn't include the `does-not-implement-crypto` + `crypto-safe` criteria set because it seems fairly obvious, and I didn't include the `rule-of-two-safe-to-deploy` criteria because the audit registry doesn't actually include any audits under that criteria, so it's not actually in use in any visible manner.

I have *not* consulted anyone from Google about adding this, but it does seem like a very high quality document that should get additional attention.

In particular, this scheme adds an obvious way to record "qualified" and "adverse" audits with ub-risk-3 and "ub-risk-4 without safe-to-run" that is more clear than `criteria = []` which may look like an auditor mistake.