### PR TITLE
Update some dependencies to more recent versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.70.0
+          toolchain: 1.82.0
           override: true
       - name: Run cargo check
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,14 +36,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstream"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -100,6 +139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,9 +161,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -129,16 +183,32 @@ dependencies = [
  "home",
  "serde",
  "serde_derive",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml",
+ "unicode-xid",
+ "url",
 ]
 
 [[package]]
@@ -172,29 +242,30 @@ dependencies = [
  "similar",
  "tar",
  "tempfile",
- "textwrap",
- "thiserror",
+ "textwrap 0.16.2",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "url",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
 dependencies = [
  "camino",
  "cargo-platform",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -202,15 +273,18 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -225,62 +299,59 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.6"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "indexmap 1.8.2",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap-cargo"
-version = "0.9.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841b17c26cdae63b80cd9014f4fb779b761c388908bdf58e15223a08d65e9b08"
+checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
 dependencies = [
+ "anstyle",
  "clap",
- "doc-comment",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.6"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "combine"
-version = "4.6.4"
+name = "colorchoice"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
-dependencies = [
- "bytes",
- "memchr",
-]
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
@@ -299,21 +370,22 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.18.8"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2519c91ad7a6e3250a64fb71162d2db1afe7bcf826a465f84d2052fd69639b7a"
+checksum = "fc5380d50f922b49fc83564b9e83c4986718d49185b7a16555b1e1a20ae21c43"
 dependencies = [
- "git2",
  "hex",
  "home",
  "memchr",
- "num_cpus",
  "rustc-hash",
+ "rustc-stable-hash",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
- "smartstring",
+ "smol_str",
+ "thiserror 2.0.12",
+ "toml",
 ]
 
 [[package]]
@@ -327,29 +399,35 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
+name = "displaydoc"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "educe"
@@ -362,12 +440,6 @@ dependencies = [
  "quote",
  "syn 1.0.96",
 ]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -405,34 +477,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.1"
+name = "erased-serde"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
+ "serde",
+ "typeid",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "errno"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
- "cc",
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
-dependencies = [
- "instant",
-]
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -465,11 +533,10 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -531,7 +598,19 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -539,19 +618,6 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
-name = "git2"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "h2"
@@ -586,18 +652,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -616,11 +673,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.3"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -674,7 +731,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -695,14 +752,110 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "icu_collections"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -751,21 +904,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -777,15 +921,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -795,28 +958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
-name = "itertools"
-version = "0.10.3"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
-dependencies = [
- "either",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
-
-[[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -835,20 +986,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+name = "libredox"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "cc",
+ "bitflags 2.9.1",
  "libc",
- "libz-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -858,7 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -876,6 +1024,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,12 +1043,6 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -912,8 +1066,8 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap",
- "thiserror",
+ "textwrap 0.15.0",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -925,7 +1079,7 @@ checksum = "4901771e1d44ddb37964565c654a3223ba41a594d02b8da471cc4464912b5cfa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -951,14 +1105,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "log",
- "wasi",
- "windows-sys 0.36.1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1002,16 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,25 +1171,41 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "open"
-version = "3.0.2"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a407004a1033f53e93f9b45580d14de23928faad187384f891507c9b0c045"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
 dependencies = [
+ "is-wsl",
+ "libc",
  "pathdiff",
- "windows-sys 0.36.1",
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.1.0"
+name = "option-ext"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "owo-colors"
@@ -1062,15 +1221,15 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1085,46 +1244,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.96",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "zerovec",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_syscall"
@@ -1132,18 +1282,18 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
+ "getrandom 0.2.7",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1162,15 +1312,6 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -1234,9 +1375,15 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-stable-hash"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 
 [[package]]
 name = "rustc_version"
@@ -1253,12 +1400,25 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1300,49 +1460,71 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.193"
+name = "serde-untagged"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -1391,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -1403,27 +1585,25 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "serde",
- "static_assertions",
- "version_check",
-]
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1436,22 +1616,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "supports-color"
@@ -1494,13 +1684,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1515,25 +1716,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1558,23 +1749,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
+name = "textwrap"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1587,49 +1804,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "tinystr"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1659,46 +1868,44 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.14.4"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
-dependencies = [
- "combine",
- "indexmap 1.8.2",
- "itertools",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower-service"
@@ -1727,7 +1934,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1772,16 +1979,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
@@ -1799,19 +2006,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1821,15 +2025,26 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -1864,6 +2079,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1977,15 +2201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,24 +2208,29 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2019,13 +2239,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
  "windows_i686_gnu 0.48.0",
  "windows_i686_msvc 0.48.0",
  "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.48.0",
  "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2035,10 +2271,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2047,10 +2283,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
+name = "windows_aarch64_msvc"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2059,10 +2295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
+name = "windows_i686_gnu"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2071,10 +2313,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
+name = "windows_i686_msvc"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2083,16 +2325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2101,10 +2349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "winnow"
-version = "0.6.18"
+name = "windows_x86_64_msvc"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -2119,10 +2373,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/mozilla/cargo-vet"
 homepage = "https://mozilla.github.io/cargo-vet/"
 description = "Supply-chain security for Rust"
-rust-version = "1.70"
+rust-version = "1.82"
 exclude = [
   "book/*",
   "src/snapshots/*",
@@ -20,13 +20,13 @@ exclude = [
 [dependencies]
 base64-stream = "1.2.7"
 bytes = "1.1.0"
-cargo_metadata = "0.15.2"
+cargo_metadata = "0.20.0"
 chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std", "serde"] }
-clap = { version = "3.2.6", features = ["derive"] }
-clap-cargo = "0.9.1"
+clap = { version = "4.5.39", features = ["derive"] }
+clap-cargo = "0.15.2"
 console = "0.15.0"
-crates-index = { version = "0.18.8", default-features = false }
-dirs = "4.0.0"
+crates-index = { version = "3.10.0", default-features = false }
+dirs = "6.0.0"
 filetime = "0.2.16"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 futures-util = { version = "0.3.21", default-features = false, features = ["std"] }
@@ -38,28 +38,26 @@ nom = "7.1.1"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.136"
 serde_json = "1.0.82"
-similar = "2.2.0"
+similar = "2.7.0"
 tar = { version = "0.4.26", default-features = false }
-tempfile = "3.3.0"
-textwrap = { version = "0.15", default-features = false }
-toml_edit = { version = "0.14.4", features = ["serde"] }
-tokio = { version = "1.20.1", features = ["fs", "macros", "process", "rt-multi-thread"] }
+tempfile = "3.20.0"
+textwrap = { version = "0.16.2", default-features = false }
+toml_edit = { version = "0.22.26", features = ["serde"] }
+tokio = { version = "1.45.1", features = ["fs", "macros", "process", "rt-multi-thread"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-subscriber = "0.3.11"
 miette = { version = "5.9.0", features = ["fancy"] }
-thiserror = "1.0.31"
+thiserror = "2.0.12"
 url = "2.2.2"
-toml = "0.5.9"
-open = "3.0.2"
+toml = "0.8.22"
+open = "5.3.2"
 cargo-config2 = "0.1.27"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.59"
 features = [
-  "minwindef",
-  "winerror",
-  "fileapi",
-  "minwinbase",
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
 ]
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use cargo_metadata::semver;
-use miette::{Diagnostic, MietteSpanContents, SourceCode, SourceOffset, SourceSpan};
+use miette::{Diagnostic, MietteSpanContents, SourceCode, SourceSpan};
 use thiserror::Error;
 
 use crate::{
@@ -966,13 +966,12 @@ impl Display for AggregateCriteriaImplies {
 //////////////////////////////////////////////////////////
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Failed to parse toml file")]
+#[error("Failed to parse toml file: {}", error.message())]
 pub struct TomlParseError {
     #[source_code]
     pub source_code: SourceFile,
     #[label("here")]
-    pub span: SourceOffset,
-    #[source]
+    pub span: SourceSpan,
     pub error: toml::de::Error,
 }
 

--- a/src/flock.rs
+++ b/src/flock.rs
@@ -376,10 +376,11 @@ mod sys {
     use std::mem;
     use std::os::windows::io::AsRawHandle;
 
-    use winapi::shared::minwindef::DWORD;
-    use winapi::shared::winerror::{ERROR_INVALID_FUNCTION, ERROR_LOCK_VIOLATION};
-    use winapi::um::fileapi::{LockFileEx, UnlockFile};
-    use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY};
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Foundation::{ERROR_INVALID_FUNCTION, ERROR_LOCK_VIOLATION};
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, UnlockFile, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
 
     pub(super) fn lock_shared(file: &File) -> Result<()> {
         lock_file(file, 0)
@@ -409,7 +410,7 @@ mod sys {
 
     pub(super) fn unlock(file: &File) -> Result<()> {
         unsafe {
-            let ret = UnlockFile(file.as_raw_handle(), 0, 0, !0, !0);
+            let ret = UnlockFile(file.as_raw_handle() as HANDLE, 0, 0, !0, !0);
             if ret == 0 {
                 Err(Error::last_os_error())
             } else {
@@ -418,10 +419,17 @@ mod sys {
         }
     }
 
-    fn lock_file(file: &File, flags: DWORD) -> Result<()> {
+    fn lock_file(file: &File, flags: u32) -> Result<()> {
         unsafe {
             let mut overlapped = mem::zeroed();
-            let ret = LockFileEx(file.as_raw_handle(), flags, 0, !0, !0, &mut overlapped);
+            let ret = LockFileEx(
+                file.as_raw_handle() as HANDLE,
+                flags,
+                0,
+                !0,
+                !0,
+                &mut overlapped,
+            );
             if ret == 0 {
                 Err(Error::last_os_error())
             } else {

--- a/src/format.rs
+++ b/src/format.rs
@@ -260,14 +260,14 @@ impl Tidyable for AuditsFile {
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct ForeignAuditsFile {
     #[serde(default)]
-    pub criteria: SortedMap<CriteriaName, toml::Value>,
+    pub criteria: SortedMap<CriteriaName, toml::Table>,
     #[serde(default)]
     #[serde(rename = "wildcard-audits")]
-    pub wildcard_audits: SortedMap<PackageName, Vec<toml::Value>>,
+    pub wildcard_audits: SortedMap<PackageName, Vec<toml::Table>>,
     #[serde(default)]
-    pub audits: SortedMap<PackageName, Vec<toml::Value>>,
+    pub audits: SortedMap<PackageName, Vec<toml::Table>>,
     #[serde(default)]
-    pub trusted: SortedMap<PackageName, Vec<toml::Value>>,
+    pub trusted: SortedMap<PackageName, Vec<toml::Table>>,
 }
 
 /// Information on a Criteria

--- a/src/git_tool.rs
+++ b/src/git_tool.rs
@@ -237,7 +237,7 @@ impl Editor<'_> {
             let line = line.trim_end();
             // Don't record 2 consecutive empty lines or empty lines at the
             // start of the file.
-            if line.is_empty() && lines.last().map_or(true, |l| l.is_empty()) {
+            if line.is_empty() && lines.last().is_none_or(|l| l.is_empty()) {
                 continue;
             }
             lines.push(line.to_owned());

--- a/src/network.rs
+++ b/src/network.rs
@@ -269,10 +269,9 @@ impl Network {
                     tracing::warn!("Attempt to fetch unsupported URL from mock network: {url}");
                     DownloadError::FailedToWriteDownload {
                         target: url.to_string().into(),
-                        error: std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("mock network does not support URL: {url}"),
-                        ),
+                        error: std::io::Error::other(format!(
+                            "mock network does not support URL: {url}"
+                        )),
                     }
                 })?;
             return Ok(Response::Mock(Some(chunk)));

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2589,7 +2589,7 @@ async fn suggest_delta(
                 // have sources if the index is unavailable.
                 known_versions
                     .as_ref()
-                    .map_or(true, |versions| versions.contains_key(&ver.semver))
+                    .is_none_or(|versions| versions.contains_key(&ver.semver))
             };
             reachable = Some(Reachable {
                 from_root: reachable_from_root

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -937,7 +937,7 @@ fn init_files(
             for package in &metadata.packages {
                 if package.id == *pkgid {
                     config.policy.insert(
-                        package.name.clone(),
+                        package.name.to_string(),
                         PackagePolicyEntry::Unversioned(PolicyEntry {
                             audit_as_crates_io: None,
                             criteria: Some(vec![default_criteria.to_string().into()]),
@@ -1012,7 +1012,7 @@ fn files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, ImportsFi
     for package in &metadata.packages {
         if package.is_third_party(&config.policy) {
             audited
-                .entry(package.name.clone())
+                .entry(package.name.to_string())
                 .or_default()
                 .push(full_audit(package.vet_version(), DEFAULT_CRIT));
         }
@@ -1041,7 +1041,7 @@ fn builtin_files_full_audited(metadata: &Metadata) -> (ConfigFile, AuditsFile, I
     for package in &metadata.packages {
         if package.is_third_party(&config.policy) {
             audited
-                .entry(package.name.clone())
+                .entry(package.name.to_string())
                 .or_default()
                 .push(full_audit(package.vet_version(), SAFE_TO_DEPLOY));
         }

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__all_empty.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__all_empty.snap
@@ -2,8 +2,7 @@
 source: src/tests/store_parsing.rs
 expression: acquire_errors
 ---
-  × Failed to parse toml file
-  ╰─▶ missing field `audits`
+  × Failed to parse toml file: missing field `audits`
    ╭─[audits.toml:1:1]
  1 │ 
    · ▲

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_audit.snap
@@ -2,15 +2,13 @@
 source: src/tests/store_parsing.rs
 expression: acquire_errors
 ---
-  × Failed to parse toml file
-  ╰─▶ unknown field `unknown-field`, expected one of `who`, `criteria`,
-      `version`, `delta`, `violation`, `importable`, `notes`, `aggregated-
-      from` for key `audits.zzz` at line 4 column 1
-   ╭─[audits.toml:3:1]
- 3 │ 
- 4 │ [[audits.zzz]]
-   · ▲
-   · ╰── here
- 5 │ criteria = "safe-to-deploy"
+  × Failed to parse toml file: unknown field `unknown-field`, expected one of
+  │ `who`, `criteria`, `version`, `delta`, `violation`, `importable`, `notes`,
+  │ `aggregated-from`
+   ╭─[audits.toml:6:1]
+ 6 │ version = "2.0.0"
+ 7 │ unknown-field = "invalid"
+   · ──────┬──────
+   ·       ╰── here
    ╰────
 

--- a/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_criteria.snap
+++ b/src/tests/snapshots/cargo_vet__tests__store_parsing__unknown_field_criteria.snap
@@ -2,14 +2,13 @@
 source: src/tests/store_parsing.rs
 expression: acquire_errors
 ---
-  × Failed to parse toml file
-  ╰─▶ unknown field `unknown-field`, expected one of `description`,
-      `description-url`, `implies`, `aggregated-from` for key `criteria.good`
-      at line 9 column 1
-   ╭─[audits.toml:8:1]
+  × Failed to parse toml file: unknown field `unknown-field`, expected one of
+  │ `description`, `description-url`, `implies`, `aggregated-from`
+   ╭─[audits.toml:6:1]
+ 6 │ implies = "safe-to-deploy"
+ 7 │ unknown-field = "invalid"
+   · ──────┬──────
+   ·       ╰── here
  8 │ 
- 9 │ [audits]
-   · ▲
-   · ╰── here
    ╰────
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -19,6 +19,17 @@ pointers. Some `debug_assert!`s document and check these invariants as well
 (though there could be more).
 """
 
+[[audits.bitflags]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "2.9.0 -> 2.9.1"
+
+[[audits.borsh]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "1.5.7"
+notes = "Uses of unsafe are limited to safe use-cases."
+
 [[audits.cargo-config2]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -32,6 +43,21 @@ such as filesystem access.
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
 delta = "0.14.2 -> 0.15.2"
+
+[[audits.cargo_metadata]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.19.2 -> 0.20.0"
+
+[[audits.dirs]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "4.0.0 -> 6.0.0"
+
+[[audits.dirs-sys]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.7 -> 0.5.0"
 
 [[audits.doc-comment]]
 who = "Nika Layzell <nika@thelayzells.com>"
@@ -61,6 +87,28 @@ unsafe code is used to invoke the Windows SHGetFolderPathW API to get the
 profile directory when the USERPROFILE environment variable is unavailable.
 """
 
+[[audits.home]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.3 -> 0.5.11"
+
+[[audits.idna_adapter]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+
+[[audits.is-docker]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "Fairly straightforward checking of /.dockerenv and /proc/self/cgroup"
+
+[[audits.is-wsl]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = 'Straightforward checking of procfs for the string "microsoft"'
+
 [[audits.is_ci]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -73,6 +121,35 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 
+[[audits.option-ext]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+
+[[audits.pin-project-lite]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.14 -> 0.2.16"
+notes = """
+Only functional change is to work around a bug in the negative_impls feature
+(https://github.com/taiki-e/pin-project/issues/340#issuecomment-2432146009)
+"""
+
+[[audits.rustc_version]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+Use of powerful capabilities is limited to invoking `rustc -vV` to get version
+information for parsing version information.
+"""
+
+[[audits.serde-value]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "Basic implementation of a serde value type. No use of unsafe code."
+
 [[audits.similar]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -82,11 +159,200 @@ Algorithm crate implemented entirely in safe rust. Does no platform-specific
 logic, only implementing diffing and string manipulation algorithms.
 """
 
+[[audits.similar]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.1 -> 2.7.0"
+
+[[audits.smol_str]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+Unsafe is used to implement the small string size optimizations (and is always
+checked ahead of time), as well as to avoid redundant utf-8 validation.
+"""
+
+[[audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.13.2"
+
+[[audits.tempfile]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "3.19.1 -> 3.20.0"
+
+[[audits.textwrap]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.16.2"
+
+[[audits.tinystr]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.6 -> 0.8.1"
+
+[[audits.utf8parse]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+
+[[trusted.anstream]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-16"
+end = "2026-06-03"
+
+[[trusted.anstyle]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-05-18"
+end = "2026-06-03"
+
+[[trusted.anstyle-parse]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2026-06-03"
+
+[[trusted.anstyle-query]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-04-13"
+end = "2026-06-03"
+
+[[trusted.anstyle-wincon]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2026-06-03"
+
+[[trusted.bytes]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2021-01-11"
+end = "2026-06-02"
+
+[[trusted.cargo-platform]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2023-07-13"
+end = "2026-06-02"
+
+[[trusted.cargo-util-schemas]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2024-03-21"
+end = "2026-06-02"
+
+[[trusted.clap]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2026-06-03"
+
+[[trusted.clap-cargo]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2019-04-08"
+end = "2026-06-03"
+
+[[trusted.clap_builder]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-28"
+end = "2026-06-03"
+
+[[trusted.clap_derive]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2026-06-03"
+
+[[trusted.clap_lex]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-04-15"
+end = "2026-06-03"
+
+[[trusted.colorchoice]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-04-13"
+end = "2026-06-03"
+
+[[trusted.crates-index]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-07-29"
+end = "2026-06-02"
+
+[[trusted.erased-serde]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2020-01-06"
+end = "2026-06-02"
+
+[[trusted.errno]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2023-08-29"
+end = "2026-06-02"
+
+[[trusted.flate2]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2022-11-24"
+end = "2026-06-02"
+
 [[trusted.hashbrown]]
 criteria = "safe-to-deploy"
 user-id = 2915 # Amanieu d'Antras (Amanieu)
 start = "2019-04-02"
 end = "2025-09-12"
+
+[[trusted.icu_collections]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.icu_locale_core]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2025-05-07"
+end = "2026-06-02"
+
+[[trusted.icu_normalizer]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.icu_normalizer_data]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-11-16"
+end = "2026-06-02"
+
+[[trusted.icu_properties]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.icu_properties_data]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-11-16"
+end = "2026-06-02"
+
+[[trusted.icu_provider]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2022-10-08"
+end = "2026-06-02"
 
 [[trusted.indexmap]]
 criteria = "safe-to-deploy"
@@ -94,11 +360,113 @@ user-id = 539 # Josh Stone (cuviper)
 start = "2020-01-15"
 end = "2025-09-12"
 
+[[trusted.io-lifetimes]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2026-06-02"
+
+[[trusted.is_terminal_polyfill]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2024-05-02"
+end = "2026-06-03"
+
+[[trusted.itoa]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2026-06-02"
+
+[[trusted.libc]]
+criteria = "safe-to-deploy"
+user-id = 55123 # rust-lang-owner
+start = "2024-08-15"
+end = "2026-06-02"
+
+[[trusted.linux-raw-sys]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2026-06-02"
+
+[[trusted.litemap]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.mio]]
+criteria = "safe-to-deploy"
+user-id = 10
+start = "2019-05-15"
+end = "2026-06-02"
+
+[[trusted.mio]]
+criteria = "safe-to-deploy"
+user-id = 6025 # Thomas de Zeeuw (Thomasdezeeuw)
+start = "2019-12-17"
+end = "2026-06-02"
+
+[[trusted.once_cell_polyfill]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2025-05-22"
+end = "2026-06-03"
+
+[[trusted.open]]
+criteria = "safe-to-deploy"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2019-07-03"
+end = "2026-06-02"
+
+[[trusted.ordered-float]]
+criteria = "safe-to-deploy"
+user-id = 2017 # Matt Brubeck (mbrubeck)
+start = "2019-03-13"
+end = "2026-06-02"
+
+[[trusted.proc-macro2]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-23"
+end = "2026-06-02"
+
+[[trusted.rustc-stable-hash]]
+criteria = "safe-to-deploy"
+user-id = 304535 # Urgau
+start = "2024-12-10"
+end = "2026-06-02"
+
+[[trusted.rustix]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-10-29"
+end = "2026-06-02"
+
+[[trusted.ryu]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2026-06-02"
+
+[[trusted.semver]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2021-05-25"
+end = "2026-06-02"
+
 [[trusted.serde]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-01"
 end = "2025-09-12"
+
+[[trusted.serde-untagged]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2023-08-27"
+end = "2026-06-02"
 
 [[trusted.serde_derive]]
 criteria = "safe-to-deploy"
@@ -106,17 +474,77 @@ user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-01"
 end = "2025-09-12"
 
+[[trusted.serde_json]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-02-28"
+end = "2026-06-02"
+
 [[trusted.serde_spanned]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2023-01-20"
 end = "2025-09-12"
 
+[[trusted.serde_yaml]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2026-06-02"
+
+[[trusted.smallvec]]
+criteria = "safe-to-deploy"
+user-id = 2017 # Matt Brubeck (mbrubeck)
+start = "2019-10-28"
+end = "2026-06-02"
+
+[[trusted.socket2]]
+criteria = "safe-to-deploy"
+user-id = 6025 # Thomas de Zeeuw (Thomasdezeeuw)
+start = "2020-09-09"
+end = "2026-06-02"
+
 [[trusted.syn]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-01"
 end = "2025-09-12"
+
+[[trusted.thiserror]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2026-06-02"
+
+[[trusted.thiserror-impl]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2026-06-02"
+
+[[trusted.tinystr]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.tokio]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2020-12-25"
+end = "2026-06-02"
+
+[[trusted.tokio-macros]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2020-10-26"
+end = "2026-06-02"
+
+[[trusted.toml]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-12-14"
+end = "2026-06-02"
 
 [[trusted.toml_datetime]]
 criteria = "safe-to-deploy"
@@ -130,8 +558,116 @@ user-id = 6743 # Ed Page (epage)
 start = "2021-09-13"
 end = "2025-09-12"
 
+[[trusted.toml_write]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2025-04-25"
+end = "2026-06-02"
+
+[[trusted.typeid]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2024-05-13"
+end = "2026-06-02"
+
+[[trusted.unicode-ident]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2021-10-02"
+end = "2026-06-02"
+
+[[trusted.wasi]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2020-06-03"
+end = "2026-06-02"
+
+[[trusted.windows-sys]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-11-15"
+end = "2026-06-02"
+
+[[trusted.windows-targets]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-09"
+end = "2026-06-02"
+
+[[trusted.windows_aarch64_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2026-06-02"
+
+[[trusted.windows_aarch64_msvc]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-11-05"
+end = "2026-06-02"
+
+[[trusted.windows_i686_gnu]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-28"
+end = "2026-06-02"
+
+[[trusted.windows_i686_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2024-04-02"
+end = "2026-06-02"
+
+[[trusted.windows_i686_msvc]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-27"
+end = "2026-06-02"
+
+[[trusted.windows_x86_64_gnu]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-28"
+end = "2026-06-02"
+
+[[trusted.windows_x86_64_gnullvm]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-09-01"
+end = "2026-06-02"
+
+[[trusted.windows_x86_64_msvc]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-10-27"
+end = "2026-06-02"
+
 [[trusted.winnow]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2023-02-22"
 end = "2025-09-12"
+
+[[trusted.zerotrie]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-11-16"
+end = "2026-06-02"
+
+[[trusted.zerovec]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"
+
+[[trusted.zerovec-derive]]
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2021-12-11"
+end = "2026-06-02"
+
+[[trusted.zerovec-derive]]
+criteria = "safe-to-deploy"
+user-id = 166196 # Robert Bastian (robertbastian)
+start = "2023-01-26"
+end = "2026-06-02"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -42,10 +42,6 @@ criteria = "safe-to-deploy"
 version = "0.13.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.bytes]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.camino]]
 version = "1.0.9"
 criteria = "safe-to-deploy"
@@ -54,32 +50,8 @@ criteria = "safe-to-deploy"
 version = "0.4.23"
 criteria = "safe-to-deploy"
 
-[[exemptions.clap]]
-version = "3.2.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap-cargo]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_derive]]
-version = "3.2.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_lex]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.combine]]
-version = "4.6.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.console]]
 version = "0.15.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.crates-index]]
-version = "0.18.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc32fast]]
@@ -106,20 +78,12 @@ criteria = "safe-to-deploy"
 version = "3.1.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.fastrand]]
-version = "1.7.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.filetime]]
 version = "0.2.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.flate2]]
 version = "1.0.24"
-criteria = "safe-to-deploy"
-
-[[exemptions.form_urlencoded]]
-version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-channel]]
@@ -152,10 +116,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.gimli]]
 version = "0.26.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.git2]]
-version = "0.14.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.h2]]
@@ -198,48 +158,21 @@ criteria = "safe-to-deploy"
 version = "1.16.0"
 criteria = "safe-to-run"
 
-[[exemptions.instant]]
-version = "0.1.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.io-lifetimes]]
-version = "1.0.11"
-criteria = "safe-to-deploy"
-
 [[exemptions.ipnet]]
 version = "2.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.itertools]]
-version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.itoa]]
-version = "1.0.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.jobserver]]
-version = "0.1.24"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
 version = "0.3.57"
 criteria = "safe-to-deploy"
 
-[[exemptions.libc]]
-version = "0.2.146"
+[[exemptions.libredox]]
+version = "0.1.3"
 criteria = "safe-to-deploy"
-
-[[exemptions.libgit2-sys]]
-version = "0.13.4+1.4.2"
-criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.libz-sys]]
 version = "1.1.15"
-criteria = "safe-to-deploy"
-
-[[exemptions.linux-raw-sys]]
-version = "0.3.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.memchr]]
@@ -266,16 +199,8 @@ criteria = "safe-to-deploy"
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.mio]]
-version = "0.8.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.nom]]
 version = "7.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.num_cpus]]
-version = "1.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.object]]
@@ -284,10 +209,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
 version = "1.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.open]]
-version = "3.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.os_str_bytes]]
@@ -302,21 +223,24 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.percent-encoding]]
-version = "2.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.proc-macro-error]]
 version = "1.0.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.r-efi]]
+version = "5.2.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.redox_syscall]]
 version = "0.2.13"
 criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.redox_users]]
-version = "0.4.3"
+version = "0.5.0"
 criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.regex]]
 version = "1.5.6"
@@ -324,10 +248,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
 version = "0.6.26"
-criteria = "safe-to-deploy"
-
-[[exemptions.remove_dir_all]]
-version = "0.5.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.reqwest]]
@@ -338,14 +258,6 @@ criteria = "safe-to-deploy"
 version = "0.16.20"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustc_version]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustix]]
-version = "0.37.20"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustls]]
 version = "0.20.6"
 criteria = "safe-to-deploy"
@@ -354,44 +266,16 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ryu]]
-version = "1.0.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.semver]]
-version = "1.0.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_json]]
-version = "1.0.82"
-criteria = "safe-to-deploy"
-
 [[exemptions.serde_urlencoded]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
-
-[[exemptions.serde_yaml]]
-version = "0.8.24"
-criteria = "safe-to-run"
 
 [[exemptions.signal-hook-registry]]
 version = "1.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.smallvec]]
-version = "1.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.smartstring]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.smawk]]
 version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.socket2]]
-version = "0.4.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
@@ -426,24 +310,12 @@ criteria = "safe-to-deploy"
 version = "0.1.17"
 criteria = "safe-to-deploy"
 
-[[exemptions.tokio]]
-version = "1.20.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-macros]]
-version = "1.8.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.tokio-rustls]]
 version = "0.23.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-util]]
 version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml]]
-version = "0.5.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower-service]]
@@ -474,20 +346,8 @@ criteria = "safe-to-deploy"
 version = "1.15.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.unicode-ident]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicode-linebreak]]
 version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.url]]
-version = "2.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasi]]
-version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
@@ -536,66 +396,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-targets]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_gnullvm]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_msvc]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_msvc]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnu]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnu]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_msvc]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_msvc]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnu]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnu]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnullvm]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.36.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.winreg]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,12 +1,129 @@
 
 # cargo-vet imports lock
 
+[[publisher.anstream]]
+version = "0.6.18"
+when = "2024-11-04"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle]]
+version = "1.0.10"
+when = "2024-11-01"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-parse]]
+version = "0.2.6"
+when = "2024-10-24"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-query]]
+version = "1.1.2"
+when = "2024-10-24"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-wincon]]
+version = "3.0.8"
+when = "2025-05-22"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.bumpalo]]
 version = "3.10.0"
 when = "2022-06-01"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
+
+[[publisher.bytes]]
+version = "1.10.1"
+when = "2025-03-05"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.cargo-platform]]
+version = "0.2.0"
+when = "2025-02-20"
+user-id = 55123
+user-login = "rust-lang-owner"
+
+[[publisher.cargo-util-schemas]]
+version = "0.2.0"
+when = "2024-03-21"
+user-id = 55123
+user-login = "rust-lang-owner"
+
+[[publisher.clap]]
+version = "4.5.39"
+when = "2025-05-27"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap-cargo]]
+version = "0.15.2"
+when = "2025-01-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_builder]]
+version = "4.5.39"
+when = "2025-05-27"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_derive]]
+version = "4.5.32"
+when = "2025-03-10"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_lex]]
+version = "0.7.4"
+when = "2024-12-05"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.colorchoice]]
+version = "1.0.3"
+when = "2024-10-24"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.crates-index]]
+version = "3.10.0"
+when = "2025-04-27"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.erased-serde]]
+version = "0.4.6"
+when = "2025-03-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.errno]]
+version = "0.3.12"
+when = "2025-05-15"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
 
 [[publisher.hashbrown]]
 version = "0.11.2"
@@ -22,6 +139,55 @@ user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
+[[publisher.icu_collections]]
+version = "2.0.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_locale_core]]
+version = "2.0.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_normalizer]]
+version = "2.0.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_normalizer_data]]
+version = "2.0.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_properties]]
+version = "2.0.1"
+when = "2025-05-19"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_properties_data]]
+version = "2.0.1"
+when = "2025-05-19"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.icu_provider]]
+version = "2.0.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
 [[publisher.indexmap]]
 version = "1.8.2"
 when = "2022-05-28"
@@ -36,26 +202,185 @@ user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
 
+[[publisher.io-lifetimes]]
+version = "1.0.11"
+when = "2023-05-24"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.is_terminal_polyfill]]
+version = "1.70.1"
+when = "2024-07-25"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.itoa]]
+version = "1.0.2"
+when = "2022-05-15"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.libc]]
+version = "0.2.172"
+when = "2025-04-15"
+user-id = 55123
+user-login = "rust-lang-owner"
+
+[[publisher.linux-raw-sys]]
+version = "0.3.8"
+when = "2023-05-19"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.linux-raw-sys]]
+version = "0.9.4"
+when = "2025-04-09"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.litemap]]
+version = "0.8.0"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.mio]]
+version = "1.0.4"
+when = "2025-05-24"
+user-id = 6025
+user-login = "Thomasdezeeuw"
+user-name = "Thomas de Zeeuw"
+
+[[publisher.once_cell_polyfill]]
+version = "1.70.1"
+when = "2025-05-22"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.open]]
+version = "5.3.2"
+when = "2025-01-05"
+user-id = 980
+user-login = "Byron"
+user-name = "Sebastian Thiel"
+
+[[publisher.ordered-float]]
+version = "2.10.1"
+when = "2023-10-10"
+user-id = 2017
+user-login = "mbrubeck"
+user-name = "Matt Brubeck"
+
+[[publisher.proc-macro2]]
+version = "1.0.95"
+when = "2025-04-16"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.rustc-stable-hash]]
+version = "0.1.2"
+when = "2025-03-05"
+user-id = 304535
+user-login = "Urgau"
+
+[[publisher.rustix]]
+version = "0.37.20"
+when = "2023-06-11"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.rustix]]
+version = "1.0.7"
+when = "2025-04-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.ryu]]
+version = "1.0.10"
+when = "2022-05-15"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.semver]]
+version = "1.0.26"
+when = "2025-03-04"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.serde]]
-version = "1.0.193"
-when = "2023-11-21"
+version = "1.0.219"
+when = "2025-03-09"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde-untagged]]
+version = "0.1.7"
+when = "2025-03-03"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_derive]]
-version = "1.0.193"
-when = "2023-11-21"
+version = "1.0.219"
+when = "2025-03-09"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_json]]
+version = "1.0.140"
+when = "2025-03-03"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_spanned]]
-version = "0.6.7"
-when = "2024-07-25"
+version = "0.6.8"
+when = "2024-09-25"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.serde_yaml]]
+version = "0.8.24"
+when = "2022-05-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.smallvec]]
+version = "1.15.0"
+when = "2025-04-05"
+user-id = 2017
+user-login = "mbrubeck"
+user-name = "Matt Brubeck"
+
+[[publisher.socket2]]
+version = "0.4.4"
+when = "2022-01-27"
+user-id = 6025
+user-login = "Thomasdezeeuw"
+user-name = "Thomas de Zeeuw"
+
+[[publisher.socket2]]
+version = "0.5.10"
+when = "2025-05-26"
+user-id = 6025
+user-login = "Thomasdezeeuw"
+user-name = "Thomas de Zeeuw"
 
 [[publisher.syn]]
 version = "1.0.96"
@@ -65,32 +390,102 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.syn]]
-version = "2.0.43"
-when = "2023-12-25"
+version = "2.0.101"
+when = "2025-04-26"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.thiserror]]
+version = "1.0.69"
+when = "2024-11-10"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror]]
+version = "2.0.12"
+when = "2025-03-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror-impl]]
+version = "1.0.69"
+when = "2024-11-10"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror-impl]]
+version = "2.0.12"
+when = "2025-03-03"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.tinystr]]
+version = "0.7.6"
+when = "2024-05-28"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.tokio]]
+version = "1.45.1"
+when = "2025-05-24"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.tokio-macros]]
+version = "2.5.0"
+when = "2025-01-08"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.toml]]
+version = "0.8.22"
+when = "2025-04-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.toml_datetime]]
-version = "0.6.8"
-when = "2024-07-30"
+version = "0.6.9"
+when = "2025-04-25"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.toml_edit]]
-version = "0.14.4"
-when = "2022-05-09"
+version = "0.22.26"
+when = "2025-04-28"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
-[[publisher.toml_edit]]
-version = "0.22.20"
-when = "2024-07-31"
+[[publisher.toml_write]]
+version = "0.1.1"
+when = "2025-04-28"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.typeid]]
+version = "1.0.3"
+when = "2025-03-04"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.unicode-ident]]
+version = "1.0.1"
+when = "2022-06-13"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
 
 [[publisher.unicode-width]]
 version = "0.1.9"
@@ -99,12 +494,207 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
+[[publisher.unicode-xid]]
+version = "0.2.6"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.utf8_iter]]
+version = "1.0.4"
+when = "2023-12-01"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.wasi]]
+version = "0.11.0+wasi-snapshot-preview1"
+when = "2022-01-19"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasi]]
+version = "0.14.2+wasi-0.2.4"
+when = "2025-02-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.windows-sys]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-sys]]
+version = "0.52.0"
+when = "2023-11-15"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-sys]]
+version = "0.59.0"
+when = "2024-07-30"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-targets]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-targets]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_gnullvm]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_msvc]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_aarch64_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnu]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnu]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_msvc]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_i686_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnu]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnu]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnullvm]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_gnullvm]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_msvc]]
+version = "0.48.0"
+when = "2023-03-31"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows_x86_64_msvc]]
+version = "0.52.6"
+when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
 [[publisher.winnow]]
-version = "0.6.18"
-when = "2024-07-31"
+version = "0.7.10"
+when = "2025-05-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.wit-bindgen-rt]]
+version = "0.39.0"
+when = "2025-02-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.zerotrie]]
+version = "0.2.2"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.zerovec]]
+version = "0.11.2"
+when = "2025-05-07"
+user-id = 166196
+user-login = "robertbastian"
+user-name = "Robert Bastian"
+
+[[publisher.zerovec-derive]]
+version = "0.11.1"
+when = "2025-02-26"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
 
 [[audits.bytecodealliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -112,6 +702,18 @@ criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2025-07-30"
+
+[[audits.bytecodealliance.wildcard-audits.wit-bindgen-rt]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-01"
+end = "2025-05-08"
+notes = """
+The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
+publication of this crate from CI. This repository requires all PRs are reviewed
+by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
+"""
 
 [[audits.bytecodealliance.audits.adler]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -135,11 +737,51 @@ criteria = "safe-to-deploy"
 version = "0.3.66"
 notes = "I am the author of this crate."
 
-[[audits.bytecodealliance.audits.cargo-platform]]
+[[audits.bytecodealliance.audits.bitflags]]
+who = "Jamey Sharp <jsharp@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.1"
+notes = """
+This version adds unsafe impls of traits from the bytemuck crate when built
+with that library enabled, but I believe the impls satisfy the documented
+safety requirements for bytemuck. The other changes are minor.
+"""
+
+[[audits.bytecodealliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.2 -> 2.3.3"
+notes = """
+Nothing outside the realm of what one would expect from a bitflags generator,
+all as expected.
+"""
+
+[[audits.bytecodealliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.6.0"
+notes = """
+Changes in how macros are invoked and various bits and pieces of macro-fu.
+Otherwise no major changes and nothing dealing with `unsafe`.
+"""
+
+[[audits.bytecodealliance.audits.cargo_metadata]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
-version = "0.1.2"
-notes = "no build, no ambient capabilities, no unsafe"
+version = "0.15.3"
+notes = "no build, no unsafe, inputs to cargo command are reasonably sanitized"
+
+[[audits.bytecodealliance.audits.cargo_metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.18.1"
+notes = "No major changes, no unsafe code here."
+
+[[audits.bytecodealliance.audits.cargo_metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.1 -> 0.19.2"
+notes = "Dependency updates and minor changes, nothing suspicious."
 
 [[audits.bytecodealliance.audits.cc]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -153,29 +795,26 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 notes = "I am the author of this crate."
 
-[[audits.bytecodealliance.audits.errno]]
-who = "Dan Gohman <dev@sunfishcode.online>"
+[[audits.bytecodealliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.3.0"
-notes = "This crate uses libc and windows-sys APIs to get and set the raw OS error value."
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
 
-[[audits.bytecodealliance.audits.errno]]
-who = "Dan Gohman <dev@sunfishcode.online>"
+[[audits.bytecodealliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-delta = "0.3.0 -> 0.3.1"
-notes = "Just a dependency version bump and a bug fix for redox"
-
-[[audits.bytecodealliance.audits.errno-dragonfly]]
-who = "Jamey Sharp <jsharp@fastly.com>"
-criteria = "safe-to-deploy"
-version = "0.1.2"
-notes = "This should be portable to any POSIX system and seems like it should be part of the libc crate, but at any rate it's safe as is."
+delta = "2.1.1 -> 2.3.0"
+notes = "Minor refactoring, nothing new."
 
 [[audits.bytecodealliance.audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.4.0"
-notes = "Contains `forbid_unsafe` and only uses `std::fmt` from the standard library. Otherwise only contains string manipulation."
+delta = "0.4.1 -> 0.5.0"
+notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
 
 [[audits.bytecodealliance.audits.httpdate]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -203,6 +842,22 @@ The is-terminal implementation code is now sync'd up with the prototype
 implementation in the Rust standard library.
 """
 
+[[audits.bytecodealliance.audits.percent-encoding]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+notes = """
+This crate is a single-file crate that does what it says on the tin. There are
+a few `unsafe` blocks related to utf-8 validation which are locally verifiable
+as correct and otherwise this crate is good to go.
+"""
+
+[[audits.bytecodealliance.audits.pin-project-lite]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.13 -> 0.2.14"
+notes = "No substantive changes in this update"
+
 [[audits.bytecodealliance.audits.pin-utils]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -213,11 +868,6 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.25"
 notes = "This crate shells out to the pkg-config executable, but it appears to sanitize inputs reasonably."
-
-[[audits.bytecodealliance.audits.quote]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.23 -> 1.0.27"
 
 [[audits.bytecodealliance.audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -243,27 +893,28 @@ criteria = "safe-to-deploy"
 version = "0.4.6"
 notes = "provides a datastructure implemented using std's Vec. all uses of unsafe are just delegating to the underlying unsafe Vec methods."
 
-[[audits.bytecodealliance.audits.static_assertions]]
-who = "Andrew Brown <andrew.brown@intel.com>"
+[[audits.bytecodealliance.audits.tempfile]]
+who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
-version = "1.1.0"
-notes = "No dependencies and completely a compile-time crate as advertised. Uses `unsafe` in one module as a compile-time check only: `mem::transmute` and `ptr::write` are wrapped in an impossible-to-run closure."
+delta = "3.3.0 -> 3.5.0"
+
+[[audits.bytecodealliance.audits.tempfile]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "3.5.0 -> 3.6.0"
+notes = "Dependency updates and new optimized trait implementations, but otherwise everything looks normal."
+
+[[audits.bytecodealliance.audits.tempfile]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "3.16.0 -> 3.19.1"
+notes = "Idiom and platform updates, but nothing major and nothing out of line."
 
 [[audits.bytecodealliance.audits.thread_local]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "1.1.4"
 notes = "uses unsafe to implement thread local storage of objects"
-
-[[audits.bytecodealliance.audits.tinyvec]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "1.6.0"
-notes = """
-This crate, while it implements collections, does so without `std::*` APIs and
-without `unsafe`. Skimming the crate everything looks reasonable and what one
-would expect from idiomatic safe collections in Rust.
-"""
 
 [[audits.bytecodealliance.audits.tracing-attributes]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -278,27 +929,6 @@ version = "0.1.3"
 notes = """
 This is a standard adapter between the `log` ecosystem and the `tracing`
 ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
-"""
-
-[[audits.bytecodealliance.audits.unicode-bidi]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "0.3.8"
-notes = """
-This crate has no unsafe code and does not use `std::*`. Skimming the crate it
-does not attempt to out of the bounds of what it's already supposed to be doing.
-"""
-
-[[audits.bytecodealliance.audits.unicode-normalization]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-version = "0.1.19"
-notes = """
-This crate contains one usage of `unsafe` which I have manually checked to see
-it as correct. This crate's size comes in large part due to the generated
-unicode tables that it contains. This crate is additionally widely used
-throughout the ecosystem and skimming the crate shows no usage of `std::*` APIs
-and nothing suspicious.
 """
 
 [[audits.bytecodealliance.audits.vcpkg]]
@@ -317,23 +947,41 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.83 -> 0.2.80"
 
-[[audits.embark.audits.thiserror]]
+[[audits.embark.audits.cargo_metadata]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
-version = "1.0.40"
-notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
+delta = "0.15.3 -> 0.15.4"
+notes = "No notable changes"
 
-[[audits.embark.audits.thiserror-impl]]
+[[audits.embark.audits.cargo_metadata]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
-version = "1.0.40"
-notes = "Found no unsafe or ambient capabilities used"
+delta = "0.15.4 -> 0.17.0"
+notes = "No notable changes"
 
-[[audits.embark.audits.tinyvec_macros]]
+[[audits.embark.audits.cfg_aliases]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = "Inspected it and is a tiny crate with single safe macro"
+version = "0.1.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark.audits.idna]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark.audits.similar]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "2.2.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark.audits.utf8parse]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Single unsafe usage that looks sound, no ambient capabilities"
 
 [[audits.embark.audits.valuable]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -363,11 +1011,55 @@ Additional review comments can be found at https://crrev.com/c/4723145/31
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.6.0 -> 2.8.0"
+notes = "No changes related to `unsafe impl ... bytemuck` pieces from `src/external.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.9.0"
+notes = "Adds a straightforward clear() function, but no new unsafe code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.displaydoc]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.5"
+notes = "No unsafe code"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.equivalent]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "1.0.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits.
+
+`heck` (version `0.3.3`) has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.number_prefix]]
 who = "George Burgess IV <gbiv@google.com>"
@@ -382,80 +1074,88 @@ version = "0.2.9"
 notes = "Reviewed on https://fxrev.dev/824504"
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.13"
+notes = "Audited at https://fxrev.dev/946396"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.potential_utf]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Contains a handful of lines of from-UTF8 unsafety and some `repr(transparent)` casting unsafety. Reasonably well commented, could do with listing invariants explicitly."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.potential_utf]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.2"
+notes = "Addition of safe comparison APIs since last audit"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.proc-macro-error-attr]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.proc-macro2]]
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "1.0.78"
+version = "1.0.35"
 notes = """
-Grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
-(except for a benign \"fs\" hit in a doc comment)
-
-Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.proc-macro2]]
+[[audits.google.audits.quote]]
 who = "Adrian Taylor <adetaylor@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.78 -> 1.0.79"
+delta = "1.0.35 -> 1.0.36"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.proc-macro2]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.79 -> 1.0.80"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.80 -> 1.0.81"
-notes = "Comment changes only"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.81 -> 1.0.82"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.82 -> 1.0.83"
-notes = "Substantive change is replacing String with Box<str>, saving memory."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.83 -> 1.0.84"
-notes = "Only doc comment changes in `src/lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-delta = "1.0.84 -> 1.0.85"
-notes = "Test-only changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.85 -> 1.0.86"
+delta = "1.0.36 -> 1.0.37"
 notes = """
-Comment-only changes in `build.rs`.
-Reordering of `Cargo.toml` entries.
-Just bumping up the version number in `lib.rs`.
-Config-related changes in `test_size.rs`.
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
 """
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.37 -> 1.0.38"
+notes = "Still no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+notes = "Only minor changes for clippy lints and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.39 -> 1.0.40"
+notes = """
+The delta is just a simplification of how `tokens.extend(...)` call is made.
+Still no `unsafe` anywhere.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.stable_deref_trait]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "Purely a trait, crates using this should be carefully vetted since self-referential stuff can be super tricky around various unsafe rust edges."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.strsim]]
@@ -469,11 +1169,146 @@ Previously reviewed during security review and the audit is grandparented in.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.synstructure]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = "Exposes unsafe codegen APIs but does not itself contain unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.version_check]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.writeable]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.6.0"
+notes = "Contains three lines of unsafe, thoroughly commented: one is for from-UTF8 on ASCII, the other two are for from-UTF8 on a datastructure that keeps track of a buffer with partial UTF8 validation. Relatively straigtforward."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.writeable]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.6.1"
+notes = "Minor comment/documentation updates and switch to a non-panicking alternative to split_at()."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.0"
+notes = """
+Cleaning up a previous hack for adding trait bounds to yoke objects. Unsafe changes:
+- deleting the hack itself removes a lot of unsafe use required in the hack's implementation
+- changes another unsafe use to remove the use of the hack, now that it's no longer needed
+
+
+See https://crrev.com/c/6323349 for more audit notes.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke-derive]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+notes = "Custom derive implementing the `Yokeable` trait. Generally generates simple code that asserts covariance."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke-derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.0"
+notes = "No code changes: only incrementing the version."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.1.6"
+notes = "Only minor cfg tweaks."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom-derive]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom-derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.1.6"
+notes = "Only a minor clippy adjustment."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.getrandom]]
+who = "Tim Geoghegan <timg@letsencrypt.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.10"
+notes = "These changes include some new `unsafe` code for the `emscripten` and `psvita` targets, but all it does is call `libc::getentropy`."
+
+[[audits.isrg.audits.getrandom]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.10 -> 0.2.11"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.11 -> 0.2.12"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.12 -> 0.2.14"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.14 -> 0.2.15"
+
+[[audits.isrg.audits.once_cell]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.17.1 -> 1.17.2"
+
+[[audits.isrg.audits.once_cell]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.17.2 -> 1.18.0"
+
+[[audits.isrg.audits.once_cell]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.18.0 -> 1.19.0"
+
+[[audits.isrg.audits.once_cell]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.19.0 -> 1.20.1"
+
+[[audits.isrg.audits.once_cell]]
+who = "J.C. Jones <jc@insufficient.coffee>"
+criteria = "safe-to-deploy"
+delta = "1.21.1 -> 1.21.3"
+notes = "The unsafe code has moved from `compare_exchange` to a new `init` function, which makes it easier to reason about."
 
 [[audits.isrg.audits.untrusted]]
 who = "David Cook <dcook@divviup.org>"
@@ -490,8 +1325,26 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-12-05"
-end = "2024-05-03"
+end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-xid]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-07-25"
+end = "2026-02-01"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.utf8_iter]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2022-04-19"
+end = "2024-06-16"
+notes = "Maintained by Henri Sivonen who works at Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.autocfg]]
@@ -501,11 +1354,43 @@ version = "1.1.0"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.cargo_metadata]]
+[[audits.mozilla.audits.bitflags]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.2 -> 2.0.2"
+notes = "Removal of some unsafe code/methods. No changes to externals, just some refactoring (mostly internal)."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.2 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.3.3 -> 2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-version = "0.15.2"
-notes = "I reviewed the whole code base. Parser for the output of cargo-metadata, relying mostly on serde. No unsafe code used."
+delta = "2.4.0 -> 2.4.1"
+notes = "Only allowing new clippy lints"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.2.1"
+notes = "Very minor changes."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.encoding_rs]]
@@ -515,11 +1400,79 @@ version = "0.8.31"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.0.1 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.1.1"
+notes = "Fairly trivial changes, no chance of security regression."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.fnv]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.0.7"
 notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.7 -> 0.2.8"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Yannis Juglaret <yjuglaret@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.8 -> 0.2.9"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.15 -> 0.3.1"
+notes = """
+I've looked over all unsafe code, and it appears to be safe, fully initializing the rng buffers.
+In addition, I've checked Linux, Windows, Mac, and Android more thoroughly against API
+documentation.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+notes = """
+Biggest non-trivial change is a new UEFI back-end, which looks reasonable to
+the best of my ability: There's some trickiness on initialization but doesn't
+look unsafe, at worse it leaks, and it might not if the relevant pointers are
+static/non-owning. Other changes also look reasonable too: some tweaks to
+inlining and a syscall-based linux back-end, whose relevant unsafe code looks
+reasonable.
+"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.hex]]
@@ -529,10 +1482,28 @@ version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.idna]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.3.0 -> 0.2.3"
-notes = "Backwards diff with some algorithm changes, no unsafe code."
+delta = "0.4.0 -> 0.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 1.0.2"
+notes = "In the 0.5.0 to 1.0.2 delta, I, Henri Sivonen, rewrote the non-Punycode internals of the crate and made the changes to the Punycode code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.2 -> 1.0.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna_adapter]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.linked-hash-map]]
@@ -546,13 +1517,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 version = "0.4.17"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.matches]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.1.9"
-notes = "This is a trivial crate."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-bigint]]
@@ -576,40 +1540,54 @@ version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.quote]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "1.0.18"
-notes = """
-`quote` is a utility crate used by proc-macros to generate TokenStreams
-conveniently from source code. The bulk of the logic is some complex
-interlocking `macro_rules!` macros which are used to parse and build the
-`TokenStream` within the proc-macro.
-
-This crate contains no unsafe code, and the internal logic, while difficult to
-read, is generally straightforward. I have audited the the quote macros, ident
-formatter, and runtime logic.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
+[[audits.mozilla.audits.once_cell]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
+delta = "1.12.0 -> 1.13.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.quote]]
+[[audits.mozilla.audits.once_cell]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.21 -> 1.0.23"
+delta = "1.13.1 -> 1.16.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.quote]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+[[audits.mozilla.audits.once_cell]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.27 -> 1.0.28"
-notes = "Enabled on wasm targets"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+delta = "1.16.0 -> 1.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.1 -> 1.20.2"
+notes = "This update works around a Cargo bug that forces the addition of `portable-atomic` into a lockfile, which we have never needed to use."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.2 -> 1.20.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.once_cell]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.20.3 -> 1.21.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 2.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.0 -> 2.3.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -618,14 +1596,100 @@ version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.rustc-hash]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.0 -> 2.1.1"
+notes = "Simple hashing crate, no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strsim]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tempfile]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "3.6.0 -> 3.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tempfile]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "3.8.0 -> 3.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tempfile]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "3.9.0 -> 3.10.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tempfile]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "3.10.1 -> 3.16.0"
+notes = "Big change, but nothing unsafe and lots of it is documentation and convenience APIs"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.textwrap]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.15.0"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.textwrap]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.15.0 -> 0.15.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.textwrap]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.15.2 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.textwrap]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.16.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.typenum]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.15.0 -> 1.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+delta = "2.5.0 -> 2.5.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.5.1 -> 2.5.4"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"

--- a/tests/snapshots/test_cli__long-help.snap
+++ b/tests/snapshots/test_cli__long-help.snap
@@ -3,173 +3,147 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-cargo-vet 0.10.1
 Supply-chain security for Rust
 
-When run without a subcommand, `cargo vet` will invoke the `check` subcommand. See `cargo vet help
-check` for more details.
+When run without a subcommand, `cargo vet` will invoke the `check` subcommand. See `cargo vet help check` for more details.
 
-USAGE:
-    cargo vet [OPTIONS]
-    cargo vet <SUBCOMMAND>
+Usage: cargo vet [OPTIONS]
+       cargo vet <COMMAND>
 
-OPTIONS:
-    -h, --help
-            Print help information
+Commands:
+  check             \[default\] Check that the current project has been vetted
+  suggest           Suggest some low-hanging fruit to review
+  init              Initialize cargo-vet for your project
+  inspect           Fetch the source of a package
+  diff              Yield a diff against the last reviewed version
+  certify           Mark a package as audited
+  import            Import a new peer's imports
+  trust             Trust a given crate and publisher
+  regenerate        Explicitly regenerate various pieces of information
+  add-exemption     Mark a package as exempted from review
+  record-violation  Declare that some versions of a package violate certain audit criteria
+  fmt               Reformat all of vet's files (in case you hand-edited them)
+  prune             Prune unnecessary imports and exemptions
+  aggregate         Fetch and merge audits from multiple sources into a single `audits.toml` file
+  dump-graph        Print the cargo build graph as understood by `cargo vet`
+  gc                Clean up old packages from the vet cache
+  renew             Renew wildcard audit expirations
+  help              Print this message or the help of the given subcommand(s)
 
-    -V, --version
-            Print version information
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
-GLOBAL OPTIONS:
-        --manifest-path <PATH>
-            Path to Cargo.toml
+  -V, --version
+          Print version
 
-        --store-path <STORE_PATH>
-            Path to the supply-chain directory
+Global Options:
+      --manifest-path <PATH>
+          Path to Cargo.toml
 
-        --no-all-features
-            Don't use --all-features
-            
-            We default to passing --all-features to `cargo metadata` because we want to analyze your
-            full dependency tree
+      --store-path <STORE_PATH>
+          Path to the supply-chain directory
 
-        --no-default-features
-            Do not activate the `default` feature
+      --no-all-features
+          Don't use --all-features
+          
+          We default to passing --all-features to `cargo metadata` because we want to analyze your full dependency tree
 
-        --features <FEATURES>
-            Space-separated list of features to activate
+      --no-default-features
+          Do not activate the `default` feature
 
-        --locked
-            Do not fetch new imported audits
+      --features <FEATURES>
+          Space-separated list of features to activate
 
-        --frozen
-            Avoid the network entirely, requiring either that the cargo cache is populated or the
-            dependencies are vendored. Requires --locked
+      --locked
+          Do not fetch new imported audits
 
-        --no-minimize-exemptions
-            Prevent commands such as `check` and `certify` from automatically cleaning up unused
-            exemptions
+      --frozen
+          Avoid the network entirely, requiring either that the cargo cache is populated or the dependencies are vendored. Requires --locked
 
-        --no-registry-suggestions
-            Prevent commands such as `check` and `suggest` from suggesting registry imports
+      --no-minimize-exemptions
+          Prevent commands such as `check` and `certify` from automatically cleaning up unused exemptions
 
-        --verbose <VERBOSE>
-            How verbose logging should be (log level)
-            
-            [default: warn]
-            [possible values: off, error, warn, info, debug, trace]
+      --no-registry-suggestions
+          Prevent commands such as `check` and `suggest` from suggesting registry imports
 
-        --output-file <OUTPUT_FILE>
-            Instead of stdout, write output to this file
+      --verbose <VERBOSE>
+          How verbose logging should be (log level)
+          
+          [default: warn]
+          [possible values: off, error, warn, info, debug, trace]
 
-        --log-file <LOG_FILE>
-            Instead of stderr, write logs to this file (only used after successful CLI parsing)
+      --output-file <OUTPUT_FILE>
+          Instead of stdout, write output to this file
 
-        --output-format <OUTPUT_FORMAT>
-            The format of the output
-            
-            [default: human]
-            [possible values: human, json]
+      --log-file <LOG_FILE>
+          Instead of stderr, write logs to this file (only used after successful CLI parsing)
 
-        --cache-dir <CACHE_DIR>
-            Use the following path instead of the global cache directory
-            
-            The cache stores information such as the summary results used by vet's suggestion
-            machinery, cached results from crates.io APIs, and checkouts of crates from crates.io in
-            some cases. This is generally automatically managed in the system cache directory.
-            
-            This mostly exists for testing vet itself.
+      --output-format <OUTPUT_FORMAT>
+          The format of the output
+          
+          [default: human]
 
-        --filter-graph <FILTER_GRAPH>
-            Filter out different parts of the build graph and pretend that's the true graph
-            
-            Example: `--filter-graph="exclude(any(eq(is_dev_only(true)),eq(name(serde_derive))))"`
-            
-            This mostly exists to debug or reduce projects that cargo-vet is mishandling.
-            Combining this with `cargo vet --output-format=json dump-graph` can produce an
-            input that can be added to vet's test suite.
-            
-            
-            The resulting graph is computed as follows:
-            
-            1. First compute the original graph
-            2. Then apply the filters to find the new set of nodes
-            3. Create a new empty graph
-            4. For each workspace member that still exists, recursively add it and its dependencies
-            
-            This means that any non-workspace package that becomes "orphaned" by the filters will
-            be implicitly discarded even if it passes the filters.
-            
-            Possible filters:
-            
-            * `include($query)`: only include packages that match this filter
-            * `exclude($query)`: exclude packages that match this filter
-            
-            
-            Possible queries:
-            
-            * `any($query1, $query2, ...)`: true if any of the listed queries are true
-            * `all($query1, $query2, ...)`: true if all of the listed queries are true
-            * `not($query)`: true if the query is false
-            * `$property`: true if the package has this property
-            
-            
-            Possible properties:
-            
-            * `name($string)`: the package's name (i.e. `serde`)
-            * `version($version)`: the package's version (i.e. `1.2.0`)
-            * `is_root($bool)`: whether it's a root in the original graph (ignoring dev-deps)
-            * `is_workspace_member($bool)`: whether the package is a workspace-member (can be
-            tested)
-            * `is_third_party($bool)`: whether the package is considered third-party by vet
-            * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
-            graph
+          Possible values:
+          - human: Print output in a human-readable form
+          - json:  Print output in a machine-readable form with minimal extra context
 
-        --cargo-arg <CARGO_ARG>
-            Arguments to pass through to cargo. It can be specified multiple times for multiple
-            arguments.
-            
-            Example: `--cargo-arg=-Zbindeps`
-            
-            This allows using unstable options in Cargo if a project's Cargo.toml requires them.
+      --cache-dir <CACHE_DIR>
+          Use the following path instead of the global cache directory
+          
+          The cache stores information such as the summary results used by vet's suggestion machinery, cached results from crates.io APIs, and checkouts of crates from crates.io in some cases. This is generally automatically managed in the system cache directory.
+          
+          This mostly exists for testing vet itself.
 
-SUBCOMMANDS:
-    check
-            \[default\] Check that the current project has been vetted
-    suggest
-            Suggest some low-hanging fruit to review
-    init
-            Initialize cargo-vet for your project
-    inspect
-            Fetch the source of a package
-    diff
-            Yield a diff against the last reviewed version
-    certify
-            Mark a package as audited
-    import
-            Import a new peer's imports
-    trust
-            Trust a given crate and publisher
-    regenerate
-            Explicitly regenerate various pieces of information
-    add-exemption
-            Mark a package as exempted from review
-    record-violation
-            Declare that some versions of a package violate certain audit criteria
-    fmt
-            Reformat all of vet's files (in case you hand-edited them)
-    prune
-            Prune unnecessary imports and exemptions
-    aggregate
-            Fetch and merge audits from multiple sources into a single `audits.toml` file
-    dump-graph
-            Print the cargo build graph as understood by `cargo vet`
-    gc
-            Clean up old packages from the vet cache
-    renew
-            Renew wildcard audit expirations
-    help
-            Print this message or the help of the given subcommand(s)
+      --filter-graph <FILTER_GRAPH>
+          Filter out different parts of the build graph and pretend that's the true graph
+          
+          Example: `--filter-graph="exclude(any(eq(is_dev_only(true)),eq(name(serde_derive))))"`
+          
+          This mostly exists to debug or reduce projects that cargo-vet is mishandling.
+          Combining this with `cargo vet --output-format=json dump-graph` can produce an
+          input that can be added to vet's test suite.
+          
+          
+          The resulting graph is computed as follows:
+          
+          1. First compute the original graph
+          2. Then apply the filters to find the new set of nodes
+          3. Create a new empty graph
+          4. For each workspace member that still exists, recursively add it and its dependencies
+          
+          This means that any non-workspace package that becomes "orphaned" by the filters will
+          be implicitly discarded even if it passes the filters.
+          
+          Possible filters:
+          
+          * `include($query)`: only include packages that match this filter
+          * `exclude($query)`: exclude packages that match this filter
+          
+          
+          Possible queries:
+          
+          * `any($query1, $query2, ...)`: true if any of the listed queries are true
+          * `all($query1, $query2, ...)`: true if all of the listed queries are true
+          * `not($query)`: true if the query is false
+          * `$property`: true if the package has this property
+          
+          
+          Possible properties:
+          
+          * `name($string)`: the package's name (i.e. `serde`)
+          * `version($version)`: the package's version (i.e. `1.2.0`)
+          * `is_root($bool)`: whether it's a root in the original graph (ignoring dev-deps)
+          * `is_workspace_member($bool)`: whether the package is a workspace-member (can be tested)
+          * `is_third_party($bool)`: whether the package is considered third-party by vet
+          * `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original graph
+
+      --cargo-arg <CARGO_ARG>
+          Arguments to pass through to cargo. It can be specified multiple times for multiple arguments.
+          
+          Example: `--cargo-arg=-Zbindeps`
+          
+          This allows using unstable options in Cargo if a project's Cargo.toml requires them.
 
 stderr:
 

--- a/tests/snapshots/test_cli__markdown-help.snap
+++ b/tests/snapshots/test_cli__markdown-help.snap
@@ -7,29 +7,49 @@ stdout:
 
 > This manual can be regenerated with `cargo vet help-markdown`
 
-Version: `cargo-vet 0.10.1`
-
+## cargo vet
 Supply-chain security for Rust
 
-When run without a subcommand, `cargo vet` will invoke the `check` subcommand. See `cargo vet help
-check` for more details.
+When run without a subcommand, `cargo vet` will invoke the `check` subcommand. See `cargo vet help check` for more details.
 
-### USAGE
+### Usage
 ```
 cargo vet [OPTIONS]
 ```
 ```
-cargo vet <SUBCOMMAND>
+cargo vet <COMMAND>
 ```
 
-### OPTIONS
+### Commands
+
+* [check](#cargo-vet-check): \[default\] Check that the current project has been vetted
+* [suggest](#cargo-vet-suggest): Suggest some low-hanging fruit to review
+* [init](#cargo-vet-init): Initialize cargo-vet for your project
+* [inspect](#cargo-vet-inspect): Fetch the source of a package
+* [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
+* [certify](#cargo-vet-certify): Mark a package as audited
+* [import](#cargo-vet-import): Import a new peer's imports
+* [trust](#cargo-vet-trust): Trust a given crate and publisher
+* [regenerate](#cargo-vet-regenerate): Explicitly regenerate various pieces of information
+* [add-exemption](#cargo-vet-add-exemption): Mark a package as exempted from review
+* [record-violation](#cargo-vet-record-violation): Declare that some versions of a package violate certain audit criteria
+* [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
+* [prune](#cargo-vet-prune): Prune unnecessary imports and exemptions
+* [aggregate](#cargo-vet-aggregate): Fetch and merge audits from multiple sources into a single `audits.toml` file
+* [dump-graph](#cargo-vet-dump-graph): Print the cargo build graph as understood by `cargo vet`
+* [gc](#cargo-vet-gc): Clean up old packages from the vet cache
+* [renew](#cargo-vet-renew): Renew wildcard audit expirations
+
+### Options
+
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
 #### `-V, --version`
-Print version information
+Print version
 
-### GLOBAL OPTIONS
+### Global Options
+
 #### `--manifest-path <PATH>`
 Path to Cargo.toml
 
@@ -39,8 +59,7 @@ Path to the supply-chain directory
 #### `--no-all-features`
 Don't use --all-features
 
-We default to passing --all-features to `cargo metadata` because we want to analyze your
-full dependency tree
+We default to passing --all-features to `cargo metadata` because we want to analyze your full dependency tree
 
 #### `--no-default-features`
 Do not activate the `default` feature
@@ -52,12 +71,10 @@ Space-separated list of features to activate
 Do not fetch new imported audits
 
 #### `--frozen`
-Avoid the network entirely, requiring either that the cargo cache is populated or the
-dependencies are vendored. Requires --locked
+Avoid the network entirely, requiring either that the cargo cache is populated or the dependencies are vendored. Requires --locked
 
 #### `--no-minimize-exemptions`
-Prevent commands such as `check` and `certify` from automatically cleaning up unused
-exemptions
+Prevent commands such as `check` and `certify` from automatically cleaning up unused exemptions
 
 #### `--no-registry-suggestions`
 Prevent commands such as `check` and `suggest` from suggesting registry imports
@@ -78,14 +95,15 @@ Instead of stderr, write logs to this file (only used after successful CLI parsi
 The format of the output
 
 \[default: human]  
-\[possible values: human, json]  
+
+Possible values:
+- human: Print output in a human-readable form
+- json:  Print output in a machine-readable form with minimal extra context
 
 #### `--cache-dir <CACHE_DIR>`
 Use the following path instead of the global cache directory
 
-The cache stores information such as the summary results used by vet's suggestion
-machinery, cached results from crates.io APIs, and checkouts of crates from crates.io in
-some cases. This is generally automatically managed in the system cache directory.
+The cache stores information such as the summary results used by vet's suggestion machinery, cached results from crates.io APIs, and checkouts of crates from crates.io in some cases. This is generally automatically managed in the system cache directory.
 
 This mostly exists for testing vet itself.
 
@@ -128,39 +146,16 @@ Possible properties:
 * `name($string)`: the package's name (i.e. `serde`)
 * `version($version)`: the package's version (i.e. `1.2.0`)
 * `is_root($bool)`: whether it's a root in the original graph (ignoring dev-deps)
-* `is_workspace_member($bool)`: whether the package is a workspace-member (can be
-tested)
+* `is_workspace_member($bool)`: whether the package is a workspace-member (can be tested)
 * `is_third_party($bool)`: whether the package is considered third-party by vet
-* `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original
-graph
+* `is_dev_only($bool)`: whether it's only used by dev (test) builds in the original graph
 
 #### `--cargo-arg <CARGO_ARG>`
-Arguments to pass through to cargo. It can be specified multiple times for multiple
-arguments.
+Arguments to pass through to cargo. It can be specified multiple times for multiple arguments.
 
 Example: `--cargo-arg=-Zbindeps`
 
 This allows using unstable options in Cargo if a project's Cargo.toml requires them.
-
-### SUBCOMMANDS
-* [check](#cargo-vet-check): \[default\] Check that the current project has been vetted
-* [suggest](#cargo-vet-suggest): Suggest some low-hanging fruit to review
-* [init](#cargo-vet-init): Initialize cargo-vet for your project
-* [inspect](#cargo-vet-inspect): Fetch the source of a package
-* [diff](#cargo-vet-diff): Yield a diff against the last reviewed version
-* [certify](#cargo-vet-certify): Mark a package as audited
-* [import](#cargo-vet-import): Import a new peer's imports
-* [trust](#cargo-vet-trust): Trust a given crate and publisher
-* [regenerate](#cargo-vet-regenerate): Explicitly regenerate various pieces of information
-* [add-exemption](#cargo-vet-add-exemption): Mark a package as exempted from review
-* [record-violation](#cargo-vet-record-violation): Declare that some versions of a package violate certain audit criteria
-* [fmt](#cargo-vet-fmt): Reformat all of vet's files (in case you hand-edited them)
-* [prune](#cargo-vet-prune): Prune unnecessary imports and exemptions
-* [aggregate](#cargo-vet-aggregate): Fetch and merge audits from multiple sources into a single `audits.toml` file
-* [dump-graph](#cargo-vet-dump-graph): Print the cargo build graph as understood by `cargo vet`
-* [gc](#cargo-vet-gc): Clean up old packages from the vet cache
-* [renew](#cargo-vet-renew): Renew wildcard audit expirations
-* [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 
 <br><br><br>
 ## cargo vet check
@@ -168,141 +163,122 @@ This allows using unstable options in Cargo if a project's Cargo.toml requires t
 
 This is the default behaviour if no subcommand is specified.
 
-If the check fails due to lack of audits, we will do our best to explain why vetting failed, and
-what should be done to fix it. This can involve a certain amount of guesswork, as there are many
-possible solutions and we only want to recommend the "best" one to keep things simple.
+If the check fails due to lack of audits, we will do our best to explain why vetting failed, and what should be done to fix it. This can involve a certain amount of guesswork, as there are many possible solutions and we only want to recommend the "best" one to keep things simple.
 
-Failures and suggestions can either be "Certain" or "Speculative". Speculative items are greyed
-out and sorted lower to indicate that the Certain entries should be looked at first. Speculative
-items are for packages that probably need audits too, but only appear as transitive dependencies of
-Certain items.
+Failures and suggestions can either be "Certain" or "Speculative". Speculative items are greyed out and sorted lower to indicate that the Certain entries should be looked at first. Speculative items are for packages that probably need audits too, but only appear as transitive dependencies of Certain items.
 
-During review of Certain issues you may take various actions that change what's needed for the
-Speculative ones. For instance you may discover you're enabling a feature you don't need, and
-that's the only reason the Speculative package is in your tree. Or you may determine that the
-Certain package only needs to be safe-to-run, which may make the Speculative requirements weaker or
-completely resolved. For these reasons we recommend fixing problems "top down", and Certain items
-are The Top.
+During review of Certain issues you may take various actions that change what's needed for the Speculative ones. For instance you may discover you're enabling a feature you don't need, and that's the only reason the Speculative package is in your tree. Or you may determine that the Certain package only needs to be safe-to-run, which may make the Speculative requirements weaker or completely resolved. For these reasons we recommend fixing problems "top down", and Certain items are The Top.
 
-Suggested fixes are grouped by the criteria they should be reviewed for and sorted by how easy the
-review should be (in terms of lines of code). We only ever suggest audits (and provide the command
-you need to run to do it), but there are other possible fixes like an `exemption` or `policy`
-change.
+Suggested fixes are grouped by the criteria they should be reviewed for and sorted by how easy the review should be (in terms of lines of code). We only ever suggest audits (and provide the command you need to run to do it), but there are other possible fixes like an `exemption` or `policy` change.
 
-The most aggressive solution is to run `cargo vet regenerate exemptions` which will add whatever
-exemptions necessary to make `check` pass (and remove uneeded ones). Ideally you should avoid doing
-this and prefer adding audits, but if you've done all the audits you plan on doing, that's the way
-to finish the job.
+The most aggressive solution is to run `cargo vet regenerate exemptions` which will add whatever exemptions necessary to make `check` pass (and remove uneeded ones). Ideally you should avoid doing this and prefer adding audits, but if you've done all the audits you plan on doing, that's the way to finish the job.
 
-### USAGE
+### Usage
 ```
 cargo vet check [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet suggest
 Suggest some low-hanging fruit to review
 
-This is essentially the same as `check` but with all your `exemptions` temporarily removed as a way
-to inspect your "review backlog". As such, we recommend against running this command while `check`
-is failing, because this will just give you worse information.
+This is essentially the same as `check` but with all your `exemptions` temporarily removed as a way to inspect your "review backlog". As such, we recommend against running this command while `check` is failing, because this will just give you worse information.
 
-If you don't consider an exemption to be "backlog", add `suggest = false` to its entry and we won't
-remove it while suggesting.
+If you don't consider an exemption to be "backlog", add `suggest = false` to its entry and we won't remove it while suggesting.
 
-See also `regenerate exemptions`, which can be used to "garbage collect" your backlog (if you run it
-while `check` is passing).
+See also `regenerate exemptions`, which can be used to "garbage collect" your backlog (if you run it while `check` is passing).
 
-### USAGE
+### Usage
 ```
 cargo vet suggest [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet init
 Initialize cargo-vet for your project
 
-This will add `exemptions` and `audit-as-crates-io = false` for all packages that need it to make
-`check` pass immediately and make it easy to start using vet with your project.
+This will add `exemptions` and `audit-as-crates-io = false` for all packages that need it to make `check` pass immediately and make it easy to start using vet with your project.
 
-At this point you can either configure your project further or start working on your review backlog
-with `suggest`.
+At this point you can either configure your project further or start working on your review backlog with `suggest`.
 
-### USAGE
+### Usage
 ```
 cargo vet init [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet inspect
 Fetch the source of a package
 
-We will attempt to guess what criteria you want to audit the package for based on the current check/
-suggest status, and show you the meaning of those criteria ahead of time.
+We will attempt to guess what criteria you want to audit the package for based on the current check/suggest status, and show you the meaning of those criteria ahead of time.
 
-### USAGE
+### Usage
 ```
 cargo vet inspect [OPTIONS] <PACKAGE> <VERSION>
 ```
 
-### ARGS
+### Arguments
+
 #### `<PACKAGE>`
 The package to inspect
 
 #### `<VERSION>`
 The version to inspect
 
-### OPTIONS
+### Options
+
 #### `--mode <MODE>`
 How to inspect the source
 
-Defaults to the most recently used --mode argument, or diff.rs if no mode argument has
-been used.
+Defaults to the most recently used --mode argument, or diff.rs if no mode argument has been used.
 
 This option is ignored if a git version is passed.
 
 \[possible values: local, sourcegraph, diff.rs]  
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet diff
 Yield a diff against the last reviewed version
 
-We will attempt to guess what criteria you want to audit the package for based on the current check/
-suggest status, and show you the meaning of those criteria ahead of time.
+We will attempt to guess what criteria you want to audit the package for based on the current check/suggest status, and show you the meaning of those criteria ahead of time.
 
-### USAGE
+### Usage
 ```
 cargo vet diff [OPTIONS] <PACKAGE> <VERSION1> <VERSION2>
 ```
 
-### ARGS
+### Arguments
+
 #### `<PACKAGE>`
 The package to diff
 
@@ -312,21 +288,21 @@ The base version to diff
 #### `<VERSION2>`
 The target version to diff
 
-### OPTIONS
+### Options
+
 #### `--mode <MODE>`
 How to inspect the diff
 
-Defaults to the most recently used --mode argument, or diff.rs if no mode argument has
-been used.
+Defaults to the most recently used --mode argument, or diff.rs if no mode argument has been used.
 
 This option is ignored if a git version is passed.
 
 \[possible values: local, sourcegraph, diff.rs]  
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
@@ -335,33 +311,30 @@ Mark a package as audited
 
 This command will do its best to guess what you want to be certifying.
 
-If invoked with no args, it will try to certify the last thing you looked at with `inspect` or
-`diff`. Otherwise you must either supply the package name and one version (for a full audit) or two
-versions (for a delta audit).
+If invoked with no args, it will try to certify the last thing you looked at with `inspect` or `diff`. Otherwise you must either supply the package name and one version (for a full audit) or two versions (for a delta audit).
 
-Once the package+version(s) have been selected, we will try to guess what criteria to certify it
-for. First we will `check`, and if the check fails and your audit would seemingly fix this package,
-we will use the criteria recommended for that fix. If `check` passes, we will assume you are working
-on your backlog and instead use the recommendations of `suggest`.
+Once the package+version(s) have been selected, we will try to guess what criteria to certify it for. First we will `check`, and if the check fails and your audit would seemingly fix this package, we will use the criteria recommended for that fix. If `check` passes, we will assume you are working on your backlog and instead use the recommendations of `suggest`.
 
 If this removes the need for an `exemption` will we automatically remove it.
 
-### USAGE
+### Usage
 ```
-cargo vet certify [OPTIONS] [ARGS]
+cargo vet certify [OPTIONS] [PACKAGE] [VERSION1] [VERSION2]
 ```
 
-### ARGS
-#### `<PACKAGE>`
+### Arguments
+
+#### `[PACKAGE]`
 The package to certify as audited
 
-#### `<VERSION1>`
+#### `[VERSION1]`
 The version to certify as audited
 
-#### `<VERSION2>`
+#### `[VERSION2]`
 If present, instead certify a diff from version1->version2
 
-### OPTIONS
+### Options
+
 #### `--wildcard <WILDCARD>`
 If present, certify a wildcard audit for the user with the given username.
 
@@ -387,8 +360,7 @@ Start date to create a wildcard audit from.
 
 Only valid with `--wildcard`.
 
-If not provided, will be the publication date of the first version published by the
-given user.
+If not provided, will be the publication date of the first version published by the given user.
 
 #### `--end-date <END_DATE>`
 End date to create a wildcard audit from. May be at most 1 year in the future.
@@ -403,76 +375,73 @@ Accept all criteria without an interactive prompt
 #### `--force`
 Force the command to ignore whether the package/version makes sense
 
-To catch typos/mistakes, we check if the thing you're trying to talk about is part of
-your current build, but this flag disables that.
+To catch typos/mistakes, we check if the thing you're trying to talk about is part of your current build, but this flag disables that.
 
 #### `--no-collapse`
 Prevent combination of the audit with a prior adjacent non-importable git audit, if any.
 
 This will only have an effect if the supplied `from` version is a git version.
 
-For example, normally an existing audit from `1.0.0->1.0.0@git:1111111` and a new
-certified audit from `1.0.0@git:1111111->1.0.0@git:2222222` would result in a single
-audit from `1.0.0->1.0.0@git:2222222`. Passing this flag would prevent this.
+For example, normally an existing audit from `1.0.0->1.0.0@git:1111111` and a new certified audit from `1.0.0@git:1111111->1.0.0@git:2222222` would result in a single audit from `1.0.0->1.0.0@git:2222222`. Passing this flag would prevent this.
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet import
 Import a new peer's imports
 
-If invoked without a URL parameter, it will look up the named peer in the cargo-vet registry, and
-import that peer.
+If invoked without a URL parameter, it will look up the named peer in the cargo-vet registry, and import that peer.
 
-### USAGE
+### Usage
 ```
 cargo vet import [OPTIONS] <NAME> [URL]...
 ```
 
-### ARGS
+### Arguments
+
 #### `<NAME>`
 The name of the peer to import
 
-#### `<URL>...`
+#### `[URL]...`
 The URL(s) of the peer's audits.toml file(s).
 
-If a URL is not provided, a peer with the given name will be looked up in the cargo-vet
-registry to determine the import URL(s).
+If a URL is not provided, a peer with the given name will be looked up in the cargo-vet registry to determine the import URL(s).
 
-### OPTIONS
+### Options
+
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet trust
 Trust a given crate and publisher
 
-### USAGE
+### Usage
 ```
-cargo vet trust [OPTIONS] [ARGS]
+cargo vet trust [OPTIONS] [PACKAGE] [PUBLISHER_LOGIN]
 ```
 
-### ARGS
-#### `<PACKAGE>`
+### Arguments
+
+#### `[PACKAGE]`
 The package to trust
 
 Must be specified unless --all has been specified.
 
-#### `<PUBLISHER_LOGIN>`
+#### `[PUBLISHER_LOGIN]`
 The username of the publisher to trust
 
-If not provided, will be inferred to be the sole known publisher of the given crate.
-If there is more than one publisher for the given crate, the login must be provided
-explicitly.
+If not provided, will be inferred to be the sole known publisher of the given crate. If there is more than one publisher for the given crate, the login must be provided explicitly.
 
-### OPTIONS
+### Options
+
 #### `--criteria <CRITERIA>`
 The criteria to certify for this trust entry
 
@@ -481,8 +450,7 @@ If not provided, we will prompt you for this information.
 #### `--start-date <START_DATE>`
 Start date to create the trust entry from.
 
-If not provided, will be the publication date of the first version published by the
-given user.
+If not provided, will be the publication date of the first version published by the given user.
 
 #### `--end-date <END_DATE>`
 End date to create the trust entry from. May be at most 1 year in the future.
@@ -495,171 +463,146 @@ A free-form string to include with the new audit entry
 If not provided, there will be no notes.
 
 #### `--all <ALL>`
-If specified, trusts all packages with exemptions or failures which are solely published
-by the given user
+If specified, trusts all packages with exemptions or failures which are solely published by the given user
 
 #### `--allow-multiple-publishers`
-If specified along with --all, also trusts packages with multiple publishers, so long as
-at least one version was published by the given user
+If specified along with --all, also trusts packages with multiple publishers, so long as at least one version was published by the given user
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet regenerate
 Explicitly regenerate various pieces of information
 
-There are several things that `cargo vet` *can* do for you automatically but we choose to make
-manual just to keep a human in the loop of those decisions. Some of these might one day become
-automatic if we agree they're boring/reliable enough.
+There are several things that `cargo vet` *can* do for you automatically but we choose to make manual just to keep a human in the loop of those decisions. Some of these might one day become automatic if we agree they're boring/reliable enough.
 
 See the subcommands for specifics.
 
-### USAGE
+### Usage
 ```
-cargo vet regenerate [OPTIONS] <SUBCOMMAND>
+cargo vet regenerate [OPTIONS] <COMMAND>
 ```
 
-### OPTIONS
+### Commands
+
+* [exemptions](#cargo-vet-regenerate-exemptions): Regenerate your exemptions to make `check` pass minimally
+* [imports](#cargo-vet-regenerate-imports): Regenerate your imports and accept changes to criteria
+* [audit-as-crates-io](#cargo-vet-regenerate-audit-as-crates-io): Add `audit-as-crates-io` to the policy entry for all crates which require one
+* [unpublished](#cargo-vet-regenerate-unpublished): Remove all outdated `unpublished` entries for crates which have since been published, or should now be audited as a more-recent version
+
+### Options
+
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
-### SUBCOMMANDS
-* [exemptions](#cargo-vet-exemptions): Regenerate your exemptions to make `check` pass minimally
-* [imports](#cargo-vet-imports): Regenerate your imports and accept changes to criteria
-* [audit-as-crates-io](#cargo-vet-audit-as-crates-io): Add `audit-as-crates-io` to the policy entry for all crates which require one
-* [unpublished](#cargo-vet-unpublished): Remove all outdated `unpublished` entries for crates which have since been published, or
-should now be audited as a more-recent version
-* [help](#cargo-vet-help): Print this message or the help of the given subcommand(s)
 
 <br><br><br>
-## cargo vet exemptions
+## cargo vet regenerate exemptions
 Regenerate your exemptions to make `check` pass minimally
 
-This command can be used for two purposes: to force your supply-chain to pass `check` when it's
-currently failing, or to minimize/garbage-collect your exemptions when it's already passing. These
-are ultimately the same operation.
+This command can be used for two purposes: to force your supply-chain to pass `check` when it's currently failing, or to minimize/garbage-collect your exemptions when it's already passing. These are ultimately the same operation.
 
-We will try our best to preserve existing exemptions, removing only those that aren't needed,
-and adding only those that are needed. Exemptions that are overbroad may also be weakened (i.e.
-safe-to-deploy may be reduced to safe-to-run).
+We will try our best to preserve existing exemptions, removing only those that aren't needed, and adding only those that are needed. Exemptions that are overbroad may also be weakened (i.e. safe-to-deploy may be reduced to safe-to-run).
 
-### USAGE
+### Usage
 ```
 cargo vet regenerate exemptions [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet imports
+## cargo vet regenerate imports
 Regenerate your imports and accept changes to criteria
 
-This is equivalent to `cargo vet fetch-imports` but it won't produce an error if the descriptions of
-foreign criteria change.
+This is equivalent to `cargo vet fetch-imports` but it won't produce an error if the descriptions of foreign criteria change.
 
-### USAGE
+### Usage
 ```
 cargo vet regenerate imports [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet audit-as-crates-io
+## cargo vet regenerate audit-as-crates-io
 Add `audit-as-crates-io` to the policy entry for all crates which require one.
 
-Crates which have a matching `description` and `repository` entry to a published crate on crates.io
-will be marked as `audit-as-crates-io = true`.
+Crates which have a matching `description` and `repository` entry to a published crate on crates.io will be marked as `audit-as-crates-io = true`.
 
-### USAGE
+### Usage
 ```
 cargo vet regenerate audit-as-crates-io [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
-## cargo vet unpublished
-Remove all outdated `unpublished` entries for crates which have since been published, or should now
-be audited as a more-recent version.
+## cargo vet regenerate unpublished
+Remove all outdated `unpublished` entries for crates which have since been published, or should now be audited as a more-recent version.
 
-Unlike `cargo vet prune`, this will remove outdated `unpublished` entries even if it will cause
-`check` to start failing.
+Unlike `cargo vet prune`, this will remove outdated `unpublished` entries even if it will cause `check` to start failing.
 
-### USAGE
+### Usage
 ```
 cargo vet regenerate unpublished [OPTIONS]
 ```
 
-### OPTIONS
+### Options
+
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
-This subcommand accepts all the [global options](#global-options)
-
-<br><br><br>
-## cargo vet help
-Print this message or the help of the given subcommand(s)
-
-### USAGE
-```
-cargo vet regenerate help [OPTIONS] [SUBCOMMAND]...
-```
-
-### ARGS
-#### `<SUBCOMMAND>...`
-The subcommand whose help message to display
-
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet add-exemption
 Mark a package as exempted from review
 
-Exemptions are *usually* just "backlog" and the expectation is that you will review them
-"eventually". You should usually only be trying to remove them, but sometimes additions are
-necessary to make progress.
+Exemptions are *usually* just "backlog" and the expectation is that you will review them "eventually". You should usually only be trying to remove them, but sometimes additions are necessary to make progress.
 
-`regenerate exemptions` will do this for your automatically to make `check` pass (and remove any
-unnecessary ones), so we recommend using that over `add-exemption`. This command mostly exists as
-"plumbing" for building tools on top of `cargo vet`.
+`regenerate exemptions` will do this for your automatically to make `check` pass (and remove any unnecessary ones), so we recommend using that over `add-exemption`. This command mostly exists as "plumbing" for building tools on top of `cargo vet`.
 
-### USAGE
+### Usage
 ```
 cargo vet add-exemption [OPTIONS] <PACKAGE> <VERSION>
 ```
 
-### ARGS
+### Arguments
+
 #### `<PACKAGE>`
 The package to mark as exempted
 
 #### `<VERSION>`
 The version to mark as exempted
 
-### OPTIONS
+### Options
+
 #### `--criteria <CRITERIA>`
 The criteria to assume (trust)
 
@@ -676,53 +619,41 @@ Suppress suggesting this exemption for review
 #### `--force`
 Force the command to ignore whether the package/version makes sense
 
-To catch typos/mistakes, we check if the thing you're trying to talk about is part of
-your current build, but this flag disables that.
+To catch typos/mistakes, we check if the thing you're trying to talk about is part of your current build, but this flag disables that.
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet record-violation
 Declare that some versions of a package violate certain audit criteria
 
-**IMPORTANT**: violations take *VersionReqs* not *Versions*. This is the same syntax used by
-Cargo.toml when specifying dependencies. A bare `1.0.0` actually means `^1.0.0`. If you want to
-forbid a *specific* version, use `=1.0.0`. This command can be a bit awkward because syntax like `*`
-has special meaning in scripts and terminals. It's probably easier to just manually add the entry to
-your audits.toml, but the command's here in case you want it.
+**IMPORTANT**: violations take *VersionReqs* not *Versions*. This is the same syntax used by Cargo.toml when specifying dependencies. A bare `1.0.0` actually means `^1.0.0`. If you want to forbid a *specific* version, use `=1.0.0`. This command can be a bit awkward because syntax like `*` has special meaning in scripts and terminals. It's probably easier to just manually add the entry to your audits.toml, but the command's here in case you want it.
 
-Violations are essentially treated as integrity constraints on your supply-chain, and will only
-result in errors if you have `exemptions` or `audits` (including imported ones) that claim criteria
-that are contradicted by the `violation`. It is not inherently an error to depend on a package with
-a `violation`.
+Violations are essentially treated as integrity constraints on your supply-chain, and will only result in errors if you have `exemptions` or `audits` (including imported ones) that claim criteria that are contradicted by the `violation`. It is not inherently an error to depend on a package with a `violation`.
 
-For instance, someone may review a package and determine that it's horribly unsound in the face of
-untrusted inputs, and therefore *un*safe-to-deploy. They would then add a "safe-to-deploy" violation
-for whatever versions of that package seem to have that problem. But if the package basically works
-fine on trusted inputs, it might still be safe-to-run. So if you use it in your tests and have an
-audit that only claims safe-to-run, we won't mention it.
+For instance, someone may review a package and determine that it's horribly unsound in the face of untrusted inputs, and therefore *un*safe-to-deploy. They would then add a "safe-to-deploy" violation for whatever versions of that package seem to have that problem. But if the package basically works fine on trusted inputs, it might still be safe-to-run. So if you use it in your tests and have an audit that only claims safe-to-run, we won't mention it.
 
-When a violation *does* cause an integrity error, it's up to you and your peers to figure out what
-to do about it. There isn't yet a mechanism for dealing with disagreements with a peer's published
-violations.
+When a violation *does* cause an integrity error, it's up to you and your peers to figure out what to do about it. There isn't yet a mechanism for dealing with disagreements with a peer's published violations.
 
-### USAGE
+### Usage
 ```
 cargo vet record-violation [OPTIONS] <PACKAGE> <VERSIONS>
 ```
 
-### ARGS
+### Arguments
+
 #### `<PACKAGE>`
 The package to forbid
 
 #### `<VERSIONS>`
 The versions to forbid
 
-### OPTIONS
+### Options
+
 #### `--criteria <CRITERIA>`
 The criteria that have failed to be satisfied.
 
@@ -741,47 +672,46 @@ If not provided, there will be no notes.
 #### `--force`
 Force the command to ignore whether the package/version makes sense
 
-To catch typos/mistakes, we check if the thing you're trying to talk about is part of
-your current build, but this flag disables that.
+To catch typos/mistakes, we check if the thing you're trying to talk about is part of your current build, but this flag disables that.
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet fmt
 Reformat all of vet's files (in case you hand-edited them)
 
-Most commands will implicitly do this, so this mostly exists as "plumbing" for building tools on top
-of vet, or in case you don't want to run another command.
+Most commands will implicitly do this, so this mostly exists as "plumbing" for building tools on top of vet, or in case you don't want to run another command.
 
-### USAGE
+### Usage
 ```
 cargo vet fmt [OPTIONS]
 ```
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet prune
 Prune unnecessary imports and exemptions
 
-This will fetch the updated state of imports, and attempt to remove any now-unnecessary imports or
-exemptions from the supply-chain.
+This will fetch the updated state of imports, and attempt to remove any now-unnecessary imports or exemptions from the supply-chain.
 
-### USAGE
+### Usage
 ```
 cargo vet prune [OPTIONS]
 ```
 
-### OPTIONS
+### Options
+
 #### `--no-imports`
 Don't prune unused imports
 
@@ -792,58 +722,54 @@ Don't prune unused exemptions
 Don't prune unused non-importable audits
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet aggregate
 Fetch and merge audits from multiple sources into a single `audits.toml` file.
 
-Will fetch the audits from each URL in the provided file, combining them into a single file. Custom
-criteria will be merged by-name, and must have identical descriptions in each source audit file.
+Will fetch the audits from each URL in the provided file, combining them into a single file. Custom criteria will be merged by-name, and must have identical descriptions in each source audit file.
 
-### USAGE
+### Usage
 ```
 cargo vet aggregate [OPTIONS] <SOURCES>
 ```
 
-### ARGS
+### Arguments
+
 #### `<SOURCES>`
 Path to a file containing a list of URLs to aggregate the audits from
 
-### OPTIONS
-#### `-h, --help`
-Print help information
+### Options
 
-### GLOBAL OPTIONS
+#### `-h, --help`
+Print help (see a summary with '-h')
+
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet dump-graph
 Print the cargo build graph as understood by `cargo vet`
 
-This is a debugging command, the output's format is not guaranteed. Use `cargo metadata` to get a
-stable version of what *cargo* thinks the build graph is. Our graph is based on that result.
+This is a debugging command, the output's format is not guaranteed. Use `cargo metadata` to get a stable version of what *cargo* thinks the build graph is. Our graph is based on that result.
 
-With `--output-format=human` (the default) this will print out mermaid-js diagrams, which things
-like github natively support rendering of.
+With `--output-format=human` (the default) this will print out mermaid-js diagrams, which things like github natively support rendering of.
 
 With `--output-format=json` we will print out more raw statistics for you to search/analyze.
 
-Most projects will have unreadably complex build graphs, so you may want to use the global
-`--filter-graph` argument to narrow your focus on an interesting subgraph. `--filter-graph` is
-applied *before* doing any semantic analysis, so if you filter out a package and it was the problem,
-the problem will disappear. This can be used to bisect a problem if you get ambitious enough with
-your filters.
+Most projects will have unreadably complex build graphs, so you may want to use the global `--filter-graph` argument to narrow your focus on an interesting subgraph. `--filter-graph` is applied *before* doing any semantic analysis, so if you filter out a package and it was the problem, the problem will disappear. This can be used to bisect a problem if you get ambitious enough with your filters.
 
-### USAGE
+### Usage
 ```
 cargo vet dump-graph [OPTIONS]
 ```
 
-### OPTIONS
+### Options
+
 #### `--depth <DEPTH>`
 The depth of the graph to print (for a large project, the full graph is a HUGE MESS)
 
@@ -851,58 +777,58 @@ The depth of the graph to print (for a large project, the full graph is a HUGE M
 \[possible values: roots, workspace, first-party, first-party-and-directs, full]  
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet gc
 Clean up old packages from the vet cache
 
-Removes packages which haven't been accessed in a while, and deletes any extra files which aren't
-recognized by cargo-vet.
+Removes packages which haven't been accessed in a while, and deletes any extra files which aren't recognized by cargo-vet.
 
 In the future, many cargo-vet subcommands will implicitly do this.
 
-### USAGE
+### Usage
 ```
 cargo vet gc [OPTIONS]
 ```
 
-### OPTIONS
+### Options
+
 #### `--max-package-age-days <MAX_PACKAGE_AGE_DAYS>`
 Packages in the vet cache which haven't been used for this many days will be removed
 
 \[default: 30]  
 
 #### `--clean`
-Remove the entire cache directory, forcing it to be regenerated next time you use cargo
-vet
+Remove the entire cache directory, forcing it to be regenerated next time you use cargo vet
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 <br><br><br>
 ## cargo vet renew
 Renew wildcard audit expirations
 
-This will set a wildcard audit expiration to be one year in the future from when it is run. It can
-optionally do this for all audits which are expiring soon.
+This will set a wildcard audit expiration to be one year in the future from when it is run. It can optionally do this for all audits which are expiring soon.
 
-### USAGE
+### Usage
 ```
 cargo vet renew [OPTIONS] [CRATE]
 ```
 
-### ARGS
-#### `<CRATE>`
+### Arguments
+
+#### `[CRATE]`
 The name of a crate to renew
 
-### OPTIONS
+### Options
+
 #### `--expiring`
 Renew all wildcard audits which will have expired six weeks from now
 
@@ -910,25 +836,9 @@ Renew all wildcard audits which will have expired six weeks from now
 Renew wildcard audits for inactive crates which have not been updated in 4 months
 
 #### `-h, --help`
-Print help information
+Print help (see a summary with '-h')
 
-### GLOBAL OPTIONS
-This subcommand accepts all the [global options](#global-options)
-
-<br><br><br>
-## cargo vet help
-Print this message or the help of the given subcommand(s)
-
-### USAGE
-```
-cargo vet help [OPTIONS] [SUBCOMMAND]...
-```
-
-### ARGS
-#### `<SUBCOMMAND>...`
-The subcommand whose help message to display
-
-### GLOBAL OPTIONS
+### Global Options
 This subcommand accepts all the [global options](#global-options)
 
 

--- a/tests/snapshots/test_cli__short-help.snap
+++ b/tests/snapshots/test_cli__short-help.snap
@@ -3,90 +3,52 @@ source: tests/test-cli.rs
 expression: format_outputs(&output)
 ---
 stdout:
-cargo-vet 0.10.1
 Supply-chain security for Rust
 
-USAGE:
-    cargo vet [OPTIONS]
-    cargo vet <SUBCOMMAND>
+Usage: cargo vet [OPTIONS]
+       cargo vet <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+Commands:
+  check             \[default\] Check that the current project has been vetted
+  suggest           Suggest some low-hanging fruit to review
+  init              Initialize cargo-vet for your project
+  inspect           Fetch the source of a package
+  diff              Yield a diff against the last reviewed version
+  certify           Mark a package as audited
+  import            Import a new peer's imports
+  trust             Trust a given crate and publisher
+  regenerate        Explicitly regenerate various pieces of information
+  add-exemption     Mark a package as exempted from review
+  record-violation  Declare that some versions of a package violate certain audit criteria
+  fmt               Reformat all of vet's files (in case you hand-edited them)
+  prune             Prune unnecessary imports and exemptions
+  aggregate         Fetch and merge audits from multiple sources into a single `audits.toml` file
+  dump-graph        Print the cargo build graph as understood by `cargo vet`
+  gc                Clean up old packages from the vet cache
+  renew             Renew wildcard audit expirations
+  help              Print this message or the help of the given subcommand(s)
 
-GLOBAL OPTIONS:
-        --manifest-path <PATH>
-            Path to Cargo.toml
+Options:
+  -h, --help     Print help (see more with '--help')
+  -V, --version  Print version
 
-        --store-path <STORE_PATH>
-            Path to the supply-chain directory
-
-        --no-all-features
-            Don't use --all-features
-
-        --no-default-features
-            Do not activate the `default` feature
-
-        --features <FEATURES>
-            Space-separated list of features to activate
-
-        --locked
-            Do not fetch new imported audits
-
-        --frozen
-            Avoid the network entirely, requiring either that the cargo cache is populated or the
-            dependencies are vendored. Requires --locked
-
-        --no-minimize-exemptions
-            Prevent commands such as `check` and `certify` from automatically cleaning up unused
-            exemptions
-
-        --no-registry-suggestions
-            Prevent commands such as `check` and `suggest` from suggesting registry imports
-
-        --verbose <VERBOSE>
-            How verbose logging should be (log level) [default: warn] [possible values: off, error,
-            warn, info, debug, trace]
-
-        --output-file <OUTPUT_FILE>
-            Instead of stdout, write output to this file
-
-        --log-file <LOG_FILE>
-            Instead of stderr, write logs to this file (only used after successful CLI parsing)
-
-        --output-format <OUTPUT_FORMAT>
-            The format of the output [default: human] [possible values: human, json]
-
-        --cache-dir <CACHE_DIR>
-            Use the following path instead of the global cache directory
-
-        --filter-graph <FILTER_GRAPH>
-            Filter out different parts of the build graph and pretend that's the true graph
-
-        --cargo-arg <CARGO_ARG>
-            Arguments to pass through to cargo. It can be specified multiple times for multiple
-            arguments
-
-SUBCOMMANDS:
-    check               \[default\] Check that the current project has been vetted
-    suggest             Suggest some low-hanging fruit to review
-    init                Initialize cargo-vet for your project
-    inspect             Fetch the source of a package
-    diff                Yield a diff against the last reviewed version
-    certify             Mark a package as audited
-    import              Import a new peer's imports
-    trust               Trust a given crate and publisher
-    regenerate          Explicitly regenerate various pieces of information
-    add-exemption       Mark a package as exempted from review
-    record-violation    Declare that some versions of a package violate certain audit criteria
-    fmt                 Reformat all of vet's files (in case you hand-edited them)
-    prune               Prune unnecessary imports and exemptions
-    aggregate           Fetch and merge audits from multiple sources into a single `audits.toml`
-                            file
-    dump-graph          Print the cargo build graph as understood by `cargo vet`
-    gc                  Clean up old packages from the vet cache
-    renew               Renew wildcard audit expirations
-    help                Print this message or the help of the given subcommand(s)
+Global Options:
+      --manifest-path <PATH>           Path to Cargo.toml
+      --store-path <STORE_PATH>        Path to the supply-chain directory
+      --no-all-features                Don't use --all-features
+      --no-default-features            Do not activate the `default` feature
+      --features <FEATURES>            Space-separated list of features to activate
+      --locked                         Do not fetch new imported audits
+      --frozen                         Avoid the network entirely, requiring either that the cargo cache is populated or the dependencies are vendored. Requires --locked
+      --no-minimize-exemptions         Prevent commands such as `check` and `certify` from automatically cleaning up unused exemptions
+      --no-registry-suggestions        Prevent commands such as `check` and `suggest` from suggesting registry imports
+      --verbose <VERBOSE>              How verbose logging should be (log level) [default: warn] [possible values: off, error, warn, info, debug, trace]
+      --output-file <OUTPUT_FILE>      Instead of stdout, write output to this file
+      --log-file <LOG_FILE>            Instead of stderr, write logs to this file (only used after successful CLI parsing)
+      --output-format <OUTPUT_FORMAT>  The format of the output [default: human] [possible values: human, json]
+      --cache-dir <CACHE_DIR>          Use the following path instead of the global cache directory
+      --filter-graph <FILTER_GRAPH>    Filter out different parts of the build graph and pretend that's the true graph
+      --cargo-arg <CARGO_ARG>          Arguments to pass through to cargo. It can be specified multiple times for multiple arguments
 
 stderr:
 


### PR DESCRIPTION
This patch updates some of the more significant dependencies of cargo-vet to more recent versions of the corresponding crate.

The following are the notable updates:

* `toml` and `toml_edit` have adjusted their API and formatting of TOML outputs (which needed to be accounted for to avoid disruptive formatting changes). In addition, the error format changed to include more details, which lead to toml parse error changes.
* `crates-index` was updated to the latest version.
* The dependency on `winapi` was replaced with a dependency on `windows-sys` for file locking.
* Argument parsing was updated to `clap 4`. This was a substantial API and help formatting change, which necessitated a change to markdown-help generation.

In addition, a number of trusted entries and audits were added to allow cargo vet to pass once again. A few crates for unsupported targets (specifically redox) were explicitly exempted.