### PR TITLE
Use audit versions to check audit-as-crates-io policies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 * Added support for declaring wildcard audits and trusted entries for crates published using ["Trusted Publishing"](https://crates.io/docs/trusted-publishing) (#671)
+* `cargo vet check --frozen` (a disabled network) will infer the existence of crates using versions
+  in audits when checking audit-as-crates-io policies (#661)
 
 # Version 0.10.1 (2025-02-10)
 

--- a/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__simple-audit-as-crates-io-no-network-existing-audit.snap
+++ b/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__simple-audit-as-crates-io-no-network-existing-audit.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/audit_as_crates_io.rs
+expression: output
+---
+  × There are some issues with your policy.audit-as-crates-io entries
+
+Error:   × Some non-crates.io-fetched packages match published crates.io versions
+  │   root-package:10.0.0
+  │   first-party:10.0.0
+  help: Add a `policy.*.audit-as-crates-io` entry for them
+

--- a/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__simple-audit-as-crates-io-no-network.snap
+++ b/src/tests/snapshots/cargo_vet__tests__audit_as_crates_io__simple-audit-as-crates-io-no-network.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/audit_as_crates_io.rs
+expression: output
+---
+


### PR DESCRIPTION
Closes #661.