### PR TITLE
Add protocubo audit set to the registry

### DIFF
--- a/registry.toml
+++ b/registry.toml
@@ -19,5 +19,8 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 [registry.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
+[registry.protocubo]
+url = "https://raw.githubusercontent.com/protocubo/supply-chain/main/audits.toml"
+
 [registry.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"


### PR DESCRIPTION
We've starting using cargo-vet at my company and would like to contribute our audit set to the registry.

https://github.com/protocubo/supply-chain

Currently aggregated from a single private/proprietary source.