### PR TITLE
Fix the rust 1.92 unused_assignment warning

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,8 @@
+// The `#[derive(Diagnostic)]` proc macro unfortunately currently generates
+// spurious `unused_assignemnts` diagnostics in rust 1.92+, which cannot be
+// easily annotated. (see https://github.com/zkat/miette/issues/458)
+#![allow(unused_assignments)]
+
 use std::{
     ffi::OsString,
     fmt::{Debug, Display},


### PR DESCRIPTION
This warning is being generated within the miette::Diagnostic derive, and has not yet been fixed upstream, so we cannot update for a fix yet.

This attempts to scope the `#[allow]` to a smaller scope when possible, to avoid allowing the diagnostic where it could catch actual issues.