### PR TITLE
Add a `first-party` config value to policy entries

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -198,6 +198,11 @@ Specifies whether first-party packages with this crate name should receive audit
 enforcement as if they were fetched from crates.io. See [First-Party
 Code](first-party-code.md) for more details.
 
+#### `first-party`
+
+Overrides the detection of if a package is first-party or not. See
+[First-Party Code](first-party-code.md) for more details.
+
 #### `notes`
 
 Free-form string for recording rationale or other relevant information.

--- a/book/src/first-party-code.md
+++ b/book/src/first-party-code.md
@@ -6,7 +6,9 @@ crates.io dependencies.
 
 Generally speaking, all other nodes in the graph are considered trusted and
 therefore non-auditable. This includes root crates, path dependencies, git
-dependencies, and custom (non-crates.io) registry dependencies.
+dependencies, and custom (non-crates.io) registry dependencies. This behavior
+can be overridden with a policy entry for that crate with `first-party` as
+either true or false.
 
 However, there are some situations which blur the line between first- and
 third-party code. This can occur, for example, when the `[patch]` table is used

--- a/src/format.rs
+++ b/src/format.rs
@@ -872,6 +872,13 @@ pub struct PolicyEntry {
     #[serde(default)]
     pub dependency_criteria: CriteriaMap,
 
+    /// Whether or not this crate should be explicitly considered as first or third party,
+    /// regardless of the default heuristic for if this is from `crates.io` or not.
+    ///
+    /// This field is always optional.
+    #[serde(rename = "first-party")]
+    pub first_party: Option<bool>,
+
     /// Freeform notes
     pub notes: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,9 @@ impl PackageExt for Package {
     fn is_third_party(&self, policy: &Policy) -> bool {
         let forced_third_party = self
             .policy_entry(policy)
-            .and_then(|policy| policy.audit_as_crates_io)
+            .map(|policy| {
+                (policy.first_party == Some(false)) || (policy.audit_as_crates_io == Some(true))
+            })
             .unwrap_or(false);
 
         forced_third_party || self.is_crates_io()
@@ -2617,7 +2619,12 @@ fn cmd_dump_graph(
     // Dump a mermaid-js graph
     trace!("dumping...");
 
-    let graph = resolver::DepGraph::new(&cfg.metadata, cfg.cli.filter_graph.as_ref(), None);
+    let store = Store::acquire_offline(cfg)?;
+    let graph = resolver::DepGraph::new(
+        &cfg.metadata,
+        cfg.cli.filter_graph.as_ref(),
+        &store.config.policy,
+    );
     match cfg.cli.output_format {
         OutputFormat::Human => graph.print_mermaid(out, sub_args).into_diagnostic()?,
         OutputFormat::Json => {
@@ -3100,24 +3107,28 @@ fn foreign_packages<'a>(
 /// (because it's used for validating that field's value).
 fn first_party_packages_strict<'a>(
     metadata: &'a Metadata,
-    _config: &'a ConfigFile,
+    config: &'a ConfigFile,
 ) -> impl Iterator<Item = &'a Package> + 'a {
-    metadata
-        .packages
-        .iter()
-        .filter(move |package| !package.is_crates_io())
+    metadata.packages.iter().filter(move |package| {
+        package
+            .policy_entry(&config.policy)
+            .and_then(|policy_entry| policy_entry.first_party)
+            .unwrap_or(!package.is_crates_io())
+    })
 }
 
 /// All third-party packages, **without** the audit-as-crates-io policy applied (used in crate
 /// policy verification).
-fn foreign_packages_strict<'a>(
+fn foreign_packages_strict<'a: 'b, 'b>(
     metadata: &'a Metadata,
-    _config: &ConfigFile,
-) -> impl Iterator<Item = &'a Package> + 'a {
-    metadata
-        .packages
-        .iter()
-        .filter(move |package| package.is_crates_io())
+    config: &'b ConfigFile,
+) -> impl Iterator<Item = &'a Package> + 'b {
+    metadata.packages.iter().filter(move |package| {
+        package
+            .policy_entry(&config.policy)
+            .and_then(|policy_entry| policy_entry.first_party.map(<bool as core::ops::Not>::not))
+            .unwrap_or(package.is_crates_io())
+    })
 }
 
 async fn check_audit_as_crates_io(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -400,10 +400,8 @@ impl<'a> DepGraph<'a> {
     pub fn new(
         metadata: &'a Metadata,
         filter_graph: Option<&Vec<GraphFilter>>,
-        policy: Option<&Policy>,
+        policy: &Policy,
     ) -> Self {
-        let default_policy = Policy::default();
-        let policy = policy.unwrap_or(&default_policy);
         let package_list = &*metadata.packages;
         let resolve_list = &*metadata
             .resolve
@@ -868,7 +866,7 @@ pub fn resolve<'a>(
 ) -> ResolveReport<'a> {
     // A large part of our algorithm is unioning and intersecting criteria, so we map all
     // the criteria into indexed boolean sets (*whispers* an integer with lots of bits).
-    let graph = DepGraph::new(metadata, filter_graph, Some(&store.config.policy));
+    let graph = DepGraph::new(metadata, filter_graph, &store.config.policy);
     // trace!("built DepGraph: {:#?}", graph);
     trace!("built DepGraph!");
 
@@ -2903,7 +2901,7 @@ pub(crate) fn get_store_updates(
     let graph = DepGraph::new(
         &cfg.metadata,
         cfg.cli.filter_graph.as_ref(),
-        Some(&store.config.policy),
+        &store.config.policy,
     );
     let criteria_mapper = CriteriaMapper::new(&store.audits.criteria);
     let requirements = resolve_requirements(&graph, &store.config.policy, &criteria_mapper);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -869,6 +869,7 @@ mod test {
                 criteria: Some(vec!["long-criteria".to_owned().into()]),
                 dev_criteria: None,
                 dependency_criteria: dc_long,
+                first_party: None,
                 notes: Some("notes go here!".to_owned()),
             }),
         );
@@ -879,6 +880,7 @@ mod test {
                 criteria: Some(vec!["short-criteria".to_owned().into()]),
                 dev_criteria: None,
                 dependency_criteria: dc_short,
+                first_party: None,
                 notes: Some("notes go here!".to_owned()),
             }),
         );

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -366,6 +366,7 @@ fn default_policy() -> PolicyEntry {
         criteria: None,
         dev_criteria: None,
         dependency_criteria: SortedMap::new(),
+        first_party: None,
         notes: None,
     }
 }
@@ -976,6 +977,7 @@ fn init_files(
                             criteria: Some(vec![default_criteria.to_string().into()]),
                             dev_criteria: Some(vec![default_criteria.to_string().into()]),
                             dependency_criteria: CriteriaMap::new(),
+                            first_party: None,
                             notes: None,
                         }),
                     );


### PR DESCRIPTION
This is a minimal PR which simply adds such a flag. It gives no consideration to if any other code paths assume the old behavior, nor about any potential complex interactions between `first-party` and `audit-as-crates-io`. This also doesn't add tests to explore this behavior.

The point of this is to allow non-`crates.io` dependencies, prior assumed to be trusted, to now be declared as not trusted and instead tracked via `cargo vet`. This is necessary for any project which manages dependencies without using `crates.io` (and instead any alternative).

This concern was raised with https://github.com/mozilla/cargo-vet/issues/683. I just proceeded to poke at what an implementation could be.

I have locally tested this against my own project, which has just under 1000 dependencies and multiple Git repositories, and can confirm it appears to work as I wanted however. It lets me explicitly declare entries as non-first-party, confirm that against the output of `dump-graph`, and missing vet statements (and exemptions) for Git dependencies do in fact cause failures.